### PR TITLE
Proteger Rutas de Perfil en Auth Router

### DIFF
--- a/routes/auth.routes.js
+++ b/routes/auth.routes.js
@@ -1,9 +1,19 @@
 import { Router } from 'express';
-import { register, login } from '../src/controllers/auth.controller.js';
+import { verifyToken } from '../middlewares/auth.middleware.js';
+import {
+	register,
+	login,
+	getPerfil,
+	updatePerfil,
+	changePassword,
+} from '../src/controllers/auth.controller.js';
 
 const authRouter = Router();
 
 authRouter.post('/register', register);
 authRouter.post('/login', login);
+authRouter.get('/perfil', verifyToken, getPerfil);
+authRouter.patch('/perfil', verifyToken, updatePerfil);
+authRouter.patch('/cambiar-contrasena', verifyToken, changePassword);
 
 export default authRouter;


### PR DESCRIPTION
## Descripción
Se conectaron los controladores de perfil al router de autenticación y se protegieron las rutas con middleware de token.

## Cambios realizados
- Se importaron `getPerfil`, `updatePerfil` y `changePassword` en el router de auth.
- Se importó y aplicó `verifyToken` en las rutas de perfil.
- Se registraron las rutas:
  - `GET /auth/perfil`
  - `PATCH /auth/perfil`
  - `PATCH /auth/cambiar-contrasena`
- Se mantuvieron intactas las rutas existentes:
  - `POST /auth/register`
  - `POST /auth/login`

## Seguridad
- Todas las rutas de perfil requieren autenticación con JWT.
- Sin token o con token inválido, la respuesta esperada es `401/403` según middleware.

## Criterios de aceptación
- [x] Las 3 rutas de perfil están registradas en auth router.
- [x] Las 3 rutas de perfil están protegidas con `verifyToken`.
- [x] No se rompieron rutas preexistentes del módulo auth.
- [x] El router sigue montado bajo prefijo `/auth`.
