### PR TITLE
Middleware requireRoles en auth.middleware.js

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,11 +6,11 @@ NODE_ENV=development
 DB_HOST=localhost
 DB_PORT=3306
 DB_USER=root
-DB_PASSWORD=your_password_here
-DB_NAME=green_alert
+DB_PASSWORD= 
+DB_NAME=green-alert
 
 # JWT Configuration
-JWT_SECRET=your_super_secret_jwt_key_change_this_in_production
+JWT_SECRET=jwt_toke.+n
 JWT_EXPIRES_IN=7d
 
 # File Upload Configuration
@@ -20,8 +20,8 @@ MAX_FILE_SIZE=10485760
 # Email Configuration (Optional - for future use)
 SMTP_HOST=smtp.gmail.com
 SMTP_PORT=587
-SMTP_USER=your_email@gmail.com
-SMTP_PASS=your_app_password
+SMTP_USER=jddelgado23@itp.edu.co
+SMTP_PASS=Juan_13975.
 
 # Logging
 LOG_LEVEL=info

--- a/middlewares/auth.middleware.js
+++ b/middlewares/auth.middleware.js
@@ -22,3 +22,22 @@ export const verifyToken = (req, res, next) => {
     });
   }
 };
+
+// Debe usarse despues de verifyToken para asegurar req.user.
+export const requireRoles = (...roles) => (req, res, next) => {
+  if (!req.user) {
+    return res.status(401).json({
+      status: 'error',
+      message: 'acceso denegado. usuario no autenticado.',
+    });
+  }
+
+  if (!roles.includes(req.user.rol)) {
+    return res.status(403).json({
+      status: 'error',
+      message: 'acceso denegado. rol no autorizado.',
+    });
+  }
+
+  return next();
+};


### PR DESCRIPTION
Se agrego el middleware requireRoles en auth.middleware.js:23-41 para restringir acceso por rol. Primero valida que exista req.user (401 si no hay usuario) y luego compara el rol del token con los roles permitidos (403 si no coincide). Se deja claro que debe usarse despues de verifyToken, y no se modifico el comportamiento de verifyToken.