### PR TITLE
Limitar edición a pendientes

### DIFF
--- a/src/controllers/reporte.controller.js
+++ b/src/controllers/reporte.controller.js
@@ -111,6 +111,15 @@ export const updateReporte = async (req, res, next) => {
       return errorResponse(res, 'No tienes permiso para editar este reporte.', 403);
     }
 
+    // Owners solo pueden editar reportes en estado 'pendiente'
+    if (isOwner && !isMod && reporte.estado !== 'pendiente') {
+      return errorResponse(
+        res,
+        'No puedes editar un reporte que ya está en revisión o procesado.',
+        403
+      );
+    }
+
     // Owners can edit content fields; mods/admins can also change estado
     const allowed = isOwner
       ? ['titulo', 'descripcion', 'direccion', 'municipio', 'departamento']
@@ -147,6 +156,15 @@ export const deleteReporte = async (req, res, next) => {
 
     if (!isOwner && !isMod) {
       return errorResponse(res, 'No tienes permiso para eliminar este reporte.', 403);
+    }
+
+    // Owners solo pueden eliminar reportes en estado 'pendiente'
+    if (isOwner && !isMod && reporte.estado !== 'pendiente') {
+      return errorResponse(
+        res,
+        'No puedes eliminar un reporte que ya está en revisión o procesado.',
+        403
+      );
     }
 
     await ReporteModel.remove(id);


### PR DESCRIPTION
#  Restringir edición/eliminación de reportes por estado

## Descripción
Los ciudadanos solo pueden editar o eliminar sus reportes mientras estén en estado "pendiente". Una vez que un moderador los toma (en_revision o posterior), quedan bloqueados. Moderadores/admins no tienen restricción.

## Cambios
- **updateReporte**: Valida que owners solo editen si `estado === 'pendiente'`
- **deleteReporte**: Valida que owners solo eliminen si `estado === 'pendiente'`
- Moderadores y admins pueden siempre editar/eliminar sin restricción

## Archivos
- `Backend/src/controllers/reporte.controller.js` [+validaciones en 2 handlers]

## Validación

**updateReporte**:
```javascript
if (isOwner && !isMod && reporte.estado !== 'pendiente') {
  return 403: 'No puedes editar un reporte que ya está en revisión o procesado.'
}