### PR TITLE
Accmcer

### DIFF
--- a/migrations/002_add_comentario_moderacion_reportes.sql
+++ b/migrations/002_add_comentario_moderacion_reportes.sql
@@ -1,0 +1,8 @@
+-- Migración: Agregar columna comentario_moderacion a tabla reportes
+-- Descripción: Permite a moderadores/admins adjuntar justificación al cambiar estado
+
+ALTER TABLE reportes
+ADD COLUMN comentario_moderacion TEXT NULL DEFAULT NULL COMMENT 'Comentario del moderador al cambiar estado (obligatorio para rechazo)' AFTER estado;
+
+-- Crear índice para búsquedas futuras
+CREATE INDEX idx_comentario_moderacion ON reportes(comentario_moderacion(100));

--- a/src/controllers/reporte.controller.js
+++ b/src/controllers/reporte.controller.js
@@ -111,6 +111,15 @@ export const updateReporte = async (req, res, next) => {
       return errorResponse(res, 'No tienes permiso para editar este reporte.', 403);
     }
 
+    // Owners solo pueden editar reportes en estado 'pendiente'
+    if (isOwner && !isMod && reporte.estado !== 'pendiente') {
+      return errorResponse(
+        res,
+        'No puedes editar un reporte que ya está en revisión o procesado.',
+        403
+      );
+    }
+
     // Owners can edit content fields; mods/admins can also change estado
     const allowed = isOwner
       ? ['titulo', 'descripcion', 'direccion', 'municipio', 'departamento']
@@ -147,6 +156,15 @@ export const deleteReporte = async (req, res, next) => {
 
     if (!isOwner && !isMod) {
       return errorResponse(res, 'No tienes permiso para eliminar este reporte.', 403);
+    }
+
+    // Owners solo pueden eliminar reportes en estado 'pendiente'
+    if (isOwner && !isMod && reporte.estado !== 'pendiente') {
+      return errorResponse(
+        res,
+        'No puedes eliminar un reporte que ya está en revisión o procesado.',
+        403
+      );
     }
 
     await ReporteModel.remove(id);

--- a/src/controllers/reporte.controller.js
+++ b/src/controllers/reporte.controller.js
@@ -120,10 +120,10 @@ export const updateReporte = async (req, res, next) => {
       );
     }
 
-    // Owners can edit content fields; mods/admins can also change estado
+    // Owners can edit content fields; mods/admins can also change estado y comentario_moderacion
     const allowed = isOwner
       ? ['titulo', 'descripcion', 'direccion', 'municipio', 'departamento']
-      : ['estado', 'nivel_severidad', 'titulo', 'descripcion', 'direccion', 'municipio', 'departamento'];
+      : ['estado', 'nivel_severidad', 'titulo', 'descripcion', 'direccion', 'municipio', 'departamento', 'comentario_moderacion'];
 
     const campos = {};
     for (const key of allowed) {
@@ -134,6 +134,14 @@ export const updateReporte = async (req, res, next) => {
 
     if (Object.keys(campos).length === 0) {
       return errorResponse(res, 'No se enviaron campos válidos para actualizar.', 400);
+    }
+
+    // Validar que comentario_moderacion es obligatorio si se rechaza
+    if (isMod && campos.estado === 'rechazado') {
+      const comentario = campos.comentario_moderacion?.trim();
+      if (!comentario) {
+        return errorResponse(res, 'El comentario es obligatorio al rechazar un reporte.', 400);
+      }
     }
 
     await ReporteModel.update(id, campos);

--- a/src/models/reporte.model.js
+++ b/src/models/reporte.model.js
@@ -65,6 +65,7 @@ export const ReporteModel = {
               r.latitud, r.longitud, r.direccion, r.municipio, r.departamento,
               r.ia_etiquetas, r.ia_confianza, r.ia_procesado,
               r.votos_relevancia, r.vistas,
+              r.comentario_moderacion,
               r.created_at, r.updated_at
        FROM reportes r
        WHERE r.id_reporte = ? AND r.deleted_at IS NULL
@@ -146,7 +147,7 @@ export const ReporteModel = {
   update: async (id_reporte, campos) => {
     const permitidos = [
       'estado', 'nivel_severidad', 'titulo', 'descripcion',
-      'direccion', 'municipio', 'departamento',
+      'direccion', 'municipio', 'departamento', 'comentario_moderacion',
     ];
 
     const sets = [];


### PR DESCRIPTION
#  Comentarios de moderación en reportes

## Descripción
Moderadores pueden adjuntar justificación al cambiar estado de reportes. Comentario obligatorio al rechazar.

## Cambios
- **BD**: Migración SQL agrega columna `comentario_moderacion TEXT` a tabla reportes
- **Modelo**: Incluye campo en `findById()` y lo acepta en `update()`
- **Controlador**: Permite `comentario_moderacion` en lista de campos mod/admin; valida obligatoriedad en rechazo

## Validación

```javascript
// Si estado === 'rechazado', comentario_moderacion es OBLIGATORIO
if (isMod && campos.estado === 'rechazado') {
  if (!comentario?.trim()) {
    return 400: 'El comentario es obligatorio al rechazar un reporte.'
  }
}

// Para otros estados, el comentario es OPCIONAL