### PR TITLE
Instalar dependencia Facebook OAuth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,5 +39,12 @@ GOOGLE_CLIENT_ID=your_client_id_here.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your_client_secret_here
 GOOGLE_CALLBACK_URL=http://localhost:3000/api/auth/google/callback
 
+# Facebook OAuth Configuration
+# Ver README.md para obtener estas credenciales
+FACEBOOK_APP_ID=your_facebook_app_id
+FACEBOOK_APP_SECRET=your_facebook_app_secret
+FACEBOOK_CALLBACK_URL=http://localhost:3000/api/auth/facebook/callback
+FACEBOOK_GRAPH_API_VERSION=v20.0
+
 # API Configuration
 API_PREFIX=/api

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ API REST para la plataforma de monitoreo ambiental ciudadano GreenAlert. Constru
 | **Base de Datos** | MySQL 8.0+ |
 | **Driver MySQL** | mysql2/promise |
 | **Autenticación JWT** | jsonwebtoken |
-| **Autenticación OAuth** | google-auth-library |
+| **Autenticación OAuth** | google-auth-library, passport-facebook |
 | **Hash de Contraseña** | crypto (scrypt) |
 | **Variables de Entorno** | dotenv |
 | **Desarrollo** | Nodemon |

--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ EMAIL_FROM=noreply@greenalert.com
 
 # Frontend
 FRONTEND_URL=http://localhost:5173
+
+# Facebook OAuth
+FACEBOOK_APP_ID=your_facebook_app_id
+FACEBOOK_APP_SECRET=your_facebook_app_secret
+FACEBOOK_CALLBACK_URL=http://localhost:3000/api/auth/facebook/callback
+FACEBOOK_GRAPH_API_VERSION=v20.0
 ```
 
 ### `.env.example`
@@ -311,6 +317,49 @@ Si faltan credenciales, mostrará advertencia con instrucciones:
 ```bash
 ⚠ Google OAuth not yet configured: Variables de entorno para Google OAuth no configuradas...
 ```
+
+### Configuracion Facebook OAuth
+
+Esta configuracion permite guardar en el backend las credenciales de una app creada en Meta for Developers. En esta tarea solo se prepara la configuracion y la validacion de credenciales; el flujo completo de login con Facebook se puede implementar despues.
+
+#### Crear app en Meta for Developers
+
+1. Entrar a [Meta for Developers](https://developers.facebook.com/).
+2. Crear una nueva app.
+3. Seleccionar un caso de uso relacionado con autenticacion o inicio de sesion.
+4. Agregar el producto `Facebook Login`.
+5. Configurar la URL de callback:
+
+```bash
+http://localhost:3000/api/auth/facebook/callback
+```
+
+6. Copiar el `App ID` y el `App Secret`.
+7. Guardar esos valores en el archivo `.env`.
+
+#### Variables de entorno
+
+```env
+FACEBOOK_APP_ID=your_facebook_app_id
+FACEBOOK_APP_SECRET=your_facebook_app_secret
+FACEBOOK_CALLBACK_URL=http://localhost:3000/api/auth/facebook/callback
+FACEBOOK_GRAPH_API_VERSION=v20.0
+```
+
+#### Archivos de configuracion
+
+- `src/config/facebook.config.js`: centraliza y valida las variables de Facebook OAuth.
+- `validate-facebook-credentials.js`: permite verificar que las credenciales existan y no sean valores de ejemplo.
+
+#### Validar credenciales
+
+Ejecuta este comando desde la carpeta `Backend`:
+
+```bash
+node validate-facebook-credentials.js
+```
+
+Si todo esta configurado correctamente, el script muestra que las credenciales fueron cargadas. Si falta una variable o se dejaron valores de ejemplo, el script muestra el error para corregir el `.env`.
 
 #### [CONFIG] Endpoints de Autenticación
 

--- a/README.md
+++ b/README.md
@@ -637,16 +637,38 @@ Todas las rutas usan `verifyToken` y `requireRoles('admin')` aplicados en el rou
 
 ---
 
-##  Autenticación
+## Autenticación
 
 ### JWT Token
 
-Se utiliza **JWT (JSON Web Tokens)** para autenticación:
+Se utiliza JWT para identificar al usuario despues de iniciar sesion. El token se genera en el backend cuando las credenciales son correctas.
 
-1. Usuario se autentica con `POST /auth/login`
-2. Backend retorna un token JWT válido por 7 días
-3. Cliente incluye token en header: `Authorization: Bearer <token>`
-4. Servidor verifica token en cada request protegido
+Flujo basico:
+
+1. El usuario envia `email` y `password` a `POST /auth/login`.
+2. El backend valida que el usuario exista, este activo y que la contrasena sea correcta.
+3. Si la autenticacion es exitosa, se genera un JWT con estos datos: `sub`, `uuid`, `rol` y `email`.
+4. El backend valida el token generado antes de enviarlo en la respuesta.
+5. El cliente debe enviar el token en las rutas protegidas usando el header `Authorization`.
+
+La duracion del token se configura con `JWT_EXPIRES_IN`. Si no se define, se usa `7d`.
+
+Respuesta esperada en login o registro exitoso:
+
+```json
+{
+  "status": "success",
+  "data": {
+    "token": "jwt_generado",
+    "user": {
+      "id_usuario": 1,
+      "email": "usuario@correo.com",
+      "rol": "ciudadano"
+    }
+  },
+  "message": "Inicio de sesion exitoso."
+}
+```
 
 ### Headers Requeridos
 
@@ -658,6 +680,9 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 
 El middleware `verifyToken` valida JWT en rutas protegidas.
 Para control de acceso por rol se usa `requireRoles(...)` y debe declararse despues de `verifyToken`.
+
+Si el token no se envia, el backend responde con estado `401`.
+Si el token es invalido o ya expiro, el backend responde con estado `403`.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
     "mysql2": "^3.9.8",
-    "nodemailer": "^8.0.5"
+    "nodemailer": "^8.0.5",
+    "passport-facebook": "^3.0.0"
   },
   "devDependencies": {
     "nodemon": "^3.1.3"

--- a/src/config/facebook.config.js
+++ b/src/config/facebook.config.js
@@ -1,0 +1,44 @@
+/**
+ * FACEBOOK OAUTH CONFIGURATION
+ * Centraliza y valida las variables de entorno para Facebook OAuth.
+ * No debe contener credenciales reales en el codigo.
+ */
+
+const validateFacebookConfig = () => {
+  const config = {
+    appId: process.env.FACEBOOK_APP_ID,
+    appSecret: process.env.FACEBOOK_APP_SECRET,
+    callbackUrl: process.env.FACEBOOK_CALLBACK_URL || 'http://localhost:3000/api/auth/facebook/callback',
+    graphApiVersion: process.env.FACEBOOK_GRAPH_API_VERSION || 'v20.0',
+  };
+
+  const missingVars = [];
+
+  if (!config.appId) missingVars.push('FACEBOOK_APP_ID');
+  if (!config.appSecret) missingVars.push('FACEBOOK_APP_SECRET');
+
+  if (missingVars.length > 0) {
+    throw new Error(
+      `Variables de entorno para Facebook OAuth no configuradas: ${missingVars.join(', ')}\n` +
+      'Completa estos valores en el archivo .env con las credenciales de Meta for Developers.'
+    );
+  }
+
+  return config;
+};
+
+let facebookConfig = null;
+
+export const getFacebookConfig = () => {
+  if (!facebookConfig) {
+    facebookConfig = validateFacebookConfig();
+  }
+
+  return facebookConfig;
+};
+
+export const isFacebookConfigured = () => (
+  Boolean(process.env.FACEBOOK_APP_ID && process.env.FACEBOOK_APP_SECRET)
+);
+
+export default getFacebookConfig;

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -18,23 +18,51 @@ const hashPassword = (password) => {
   return `${salt}:${derivedKey}`;
 };
 
-const buildToken = (user) => {
+const getJwtSecret = () => {
   if (!process.env.JWT_SECRET) {
-    const error = new Error('JWT_SECRET no configurado ');
+    const error = new Error('JWT_SECRET no configurado');
     error.statusCode = 500;
     throw error;
   }
 
-  return jwt.sign(
+  return process.env.JWT_SECRET;
+};
+
+const validateGeneratedToken = (token, secret, user) => {
+  const decoded = jwt.verify(token, secret);
+
+  if (
+    Number(decoded.sub) !== Number(user.id_usuario) ||
+    decoded.email !== user.email ||
+    decoded.rol !== user.rol ||
+    (user.uuid && decoded.uuid !== user.uuid)
+  ) {
+    const error = new Error('JWT generado no coincide con el usuario autenticado');
+    error.statusCode = 500;
+    throw error;
+  }
+
+  return decoded;
+};
+
+const buildToken = (user) => {
+  const secret = getJwtSecret();
+  const expiresIn = process.env.JWT_EXPIRES_IN || '7d';
+
+  const token = jwt.sign(
     {
       sub: user.id_usuario,
       uuid: user.uuid,
       rol: user.rol,
       email: user.email,
     },
-    process.env.JWT_SECRET,
-    { expiresIn: '7d' }
+    secret,
+    { expiresIn }
   );
+
+  validateGeneratedToken(token, secret, user);
+
+  return token;
 };
 
 const toPublicUser = (user) => ({

--- a/validate-facebook-credentials.js
+++ b/validate-facebook-credentials.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+import 'dotenv/config';
+import { getFacebookConfig } from './src/config/facebook.config.js';
+
+const isPlaceholder = (value) => {
+  if (!value) return true;
+
+  const normalizedValue = value.toLowerCase();
+  return (
+    normalizedValue.includes('your_') ||
+    normalizedValue.includes('tu_') ||
+    normalizedValue.includes('app_id') ||
+    normalizedValue.includes('app_secret')
+  );
+};
+
+try {
+  const config = getFacebookConfig();
+  const warnings = [];
+
+  if (isPlaceholder(config.appId)) {
+    warnings.push('FACEBOOK_APP_ID parece ser un valor de ejemplo.');
+  }
+
+  if (isPlaceholder(config.appSecret)) {
+    warnings.push('FACEBOOK_APP_SECRET parece ser un valor de ejemplo.');
+  }
+
+  console.log('[OK] FACEBOOK_APP_ID configurado.');
+  console.log('[OK] FACEBOOK_APP_SECRET configurado.');
+  console.log(`[OK] FACEBOOK_CALLBACK_URL: ${config.callbackUrl}`);
+  console.log(`[OK] FACEBOOK_GRAPH_API_VERSION: ${config.graphApiVersion}`);
+
+  if (warnings.length > 0) {
+    console.log('\n[AVISO] Revisa estas advertencias:');
+    warnings.forEach((warning) => console.log(`- ${warning}`));
+    process.exit(1);
+  }
+
+  console.log('\n[SUCCESS] Credenciales de Facebook OAuth cargadas correctamente.');
+} catch (error) {
+  console.error('[ERROR] No se pudo validar Facebook OAuth.');
+  console.error(error.message);
+  process.exit(1);
+}


### PR DESCRIPTION
Se instaló la librería necesaria para preparar la autenticación con Facebook en el backend.

Cambios realizados:

- Se instaló la dependencia `passport-facebook`.
- Se actualizó `package.json` con la nueva dependencia.
- Se actualizó `package-lock.json` con la información de instalación.
- Se actualizó el README en la sección de stack tecnológico.
- En autenticación OAuth ahora se indica el uso de:

    google-auth-library, passport-facebook

Validación realizada:

- Se verificó que la dependencia quedara instalada:

    npm ls passport-facebook

- Se verificó que la librería pueda importarse correctamente:

    node -e "import('passport-facebook').then(() => console.log('passport-facebook funcional'))"

Resultado:

- `passport-facebook` quedó instalado correctamente.
- La dependencia está disponible para usarla después en el flujo de autenticación con Facebook.
 