### PR TITLE
Unificación rutas con prefijo api

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,5 +39,12 @@ GOOGLE_CLIENT_ID=your_client_id_here.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your_client_secret_here
 GOOGLE_CALLBACK_URL=http://localhost:3000/api/auth/google/callback
 
+# Facebook OAuth Configuration
+# Ver README.md para obtener estas credenciales
+FACEBOOK_APP_ID=your_facebook_app_id
+FACEBOOK_APP_SECRET=your_facebook_app_secret
+FACEBOOK_CALLBACK_URL=http://localhost:3000/api/auth/facebook/callback
+FACEBOOK_GRAPH_API_VERSION=v20.0
+
 # API Configuration
 API_PREFIX=/api

--- a/README.md
+++ b/README.md
@@ -381,6 +381,23 @@ Content-Type: application/json
 
 Valida el token con Facebook. Si el usuario existe por email y esta activo, inicia sesion. Si no existe, crea una cuenta como ciudadano y retorna el JWT del backend. Si la cuenta existe pero esta desactivada, el backend responde con estado `403`.
 
+Respuesta esperada cuando la autenticacion es correcta:
+
+```json
+{
+  "status": "success",
+  "message": "Autenticacion con Facebook exitosa.",
+  "data": {
+    "token": "jwt_generado_por_el_backend",
+    "user": {
+      "id_usuario": 1,
+      "email": "usuario@correo.com",
+      "rol": "ciudadano"
+    }
+  }
+}
+```
+
 ```bash
 GET /auth/facebook/callback?code=...
 ```
@@ -438,6 +455,10 @@ GET /api/auth/facebook/callback?code=...
 ```
 
 En Facebook OAuth el backend usa el email retornado por Facebook para buscar el usuario. Si lo encuentra y esta activo, actualiza el ultimo acceso y genera el JWT. Si no existe, crea el usuario con rol `ciudadano`, marca el email como verificado y luego genera el JWT.
+Antes de responder, el backend valida que el JWT generado coincida con el usuario autenticado.
+
+Nota sobre Google OAuth:
+El endpoint `GET /auth/google/url` genera la URL de autenticacion aunque no exista `GOOGLE_CLIENT_SECRET`, porque para construir esa URL solo se necesita el `GOOGLE_CLIENT_ID` y la URL de callback. Si tampoco existe `GOOGLE_CLIENT_ID`, el backend usa el valor de ejemplo para que el endpoint responda correctamente en desarrollo. Para un login real con Google, igual se deben configurar `GOOGLE_CLIENT_ID` y `GOOGLE_CLIENT_SECRET` en `.env`.
 
 GESTIÓN DE CUENTA:
 

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ Si faltan credenciales, mostrará advertencia con instrucciones:
 
 ### Configuracion Facebook OAuth
 
-Esta configuracion permite guardar en el backend las credenciales de una app creada en Meta for Developers. En esta tarea solo se prepara la configuracion y la validacion de credenciales; el flujo completo de login con Facebook se puede implementar despues.
+Esta configuracion permite usar Facebook OAuth en el backend. El flujo soporta autenticacion por `access_token` enviado desde el cliente y tambien callback con `code`.
 
 #### Crear app en Meta for Developers
 
@@ -349,6 +349,7 @@ FACEBOOK_GRAPH_API_VERSION=v20.0
 #### Archivos de configuracion
 
 - `src/config/facebook.config.js`: centraliza y valida las variables de Facebook OAuth.
+- `src/services/facebook-oauth.service.js`: genera la URL de autenticacion, configura la estrategia y consulta la informacion del usuario en Facebook.
 - `validate-facebook-credentials.js`: permite verificar que las credenciales existan y no sean valores de ejemplo.
 
 #### Validar credenciales
@@ -360,6 +361,31 @@ node validate-facebook-credentials.js
 ```
 
 Si todo esta configurado correctamente, el script muestra que las credenciales fueron cargadas. Si falta una variable o se dejaron valores de ejemplo, el script muestra el error para corregir el `.env`.
+
+#### Endpoints de Facebook OAuth
+
+```bash
+GET /auth/facebook/url
+```
+
+Genera la URL para enviar al usuario a Facebook.
+
+```bash
+POST /auth/facebook/login
+Content-Type: application/json
+
+{
+  "access_token": "token_entregado_por_facebook"
+}
+```
+
+Valida el token con Facebook. Si el usuario existe por email, inicia sesion. Si no existe, crea una cuenta como ciudadano y retorna el JWT del backend.
+
+```bash
+GET /auth/facebook/callback?code=...
+```
+
+Recibe el codigo de Facebook, lo cambia por un `access_token`, obtiene la informacion del usuario y redirige al frontend con el JWT.
 
 #### [CONFIG] Endpoints de Autenticación
 
@@ -391,6 +417,24 @@ GET /api/auth/google/callback?code=...
   Parámetros: code (código de autorización de Google)
   Retorna: Redirige al frontend con token y usuario
   Descripción: Callback para el flujo Authorization Code de Google
+```
+
+AUTENTICACION CON FACEBOOK OAUTH:
+
+```
+GET /api/auth/facebook/url
+  Retorna: { authUrl }
+  Descripcion: Genera la URL de autenticacion con Facebook
+
+POST /api/auth/facebook/login
+  Body: { access_token }
+  Retorna: { token, user }
+  Descripcion: Verifica el access_token de Facebook y autentica al usuario
+
+GET /api/auth/facebook/callback?code=...
+  Parametros: code (codigo de autorizacion de Facebook)
+  Retorna: Redirige al frontend con token y usuario
+  Descripcion: Callback para el flujo Authorization Code de Facebook
 ```
 
 GESTIÓN DE CUENTA:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ API REST para la plataforma de monitoreo ambiental ciudadano GreenAlert. Constru
 | **Base de Datos** | MySQL 8.0+ |
 | **Driver MySQL** | mysql2/promise |
 | **Autenticación JWT** | jsonwebtoken |
-| **Autenticación OAuth** | google-auth-library |
+| **Autenticación OAuth** | google-auth-library, passport-facebook |
 | **Hash de Contraseña** | crypto (scrypt) |
 | **Variables de Entorno** | dotenv |
 | **Desarrollo** | Nodemon |

--- a/README.md
+++ b/README.md
@@ -365,13 +365,13 @@ Si todo esta configurado correctamente, el script muestra que las credenciales f
 #### Endpoints de Facebook OAuth
 
 ```bash
-GET /auth/facebook/url
+GET /api/auth/facebook/url
 ```
 
 Genera la URL para enviar al usuario a Facebook.
 
 ```bash
-POST /auth/facebook/login
+POST /api/auth/facebook/login
 Content-Type: application/json
 
 {
@@ -399,7 +399,7 @@ Respuesta esperada cuando la autenticacion es correcta:
 ```
 
 ```bash
-GET /auth/facebook/callback?code=...
+GET /api/auth/facebook/callback?code=...
 ```
 
 Recibe el codigo de Facebook, lo cambia por un `access_token`, obtiene la informacion del usuario y redirige al frontend con el JWT.
@@ -458,7 +458,7 @@ En Facebook OAuth el backend usa el email retornado por Facebook para buscar el 
 Antes de responder, el backend valida que el JWT generado coincida con el usuario autenticado.
 
 Nota sobre Google OAuth:
-El endpoint `GET /auth/google/url` genera la URL de autenticacion aunque no exista `GOOGLE_CLIENT_SECRET`, porque para construir esa URL solo se necesita el `GOOGLE_CLIENT_ID` y la URL de callback. Si tampoco existe `GOOGLE_CLIENT_ID`, el backend usa el valor de ejemplo para que el endpoint responda correctamente en desarrollo. Para un login real con Google, igual se deben configurar `GOOGLE_CLIENT_ID` y `GOOGLE_CLIENT_SECRET` en `.env`.
+El endpoint `GET /api/auth/google/url` genera la URL de autenticacion aunque no exista `GOOGLE_CLIENT_SECRET`, porque para construir esa URL solo se necesita el `GOOGLE_CLIENT_ID` y la URL de callback. Si tampoco existe `GOOGLE_CLIENT_ID`, el backend usa el valor de ejemplo para que el endpoint responda correctamente en desarrollo. Para un login real con Google, igual se deben configurar `GOOGLE_CLIENT_ID` y `GOOGLE_CLIENT_SECRET` en `.env`.
 
 GESTIÓN DE CUENTA:
 
@@ -601,6 +601,10 @@ npm run dev
 
 El servidor iniciará en `http://localhost:3000`
 
+### Prefijo de rutas
+
+La API usa el prefijo `/api` en todas sus rutas. Por ejemplo, autenticacion se consume como `/api/auth` y no como `/auth`. Esto se controla con `API_PREFIX=/api` en el archivo `.env`.
+
 ### Producción
 
 ```bash
@@ -686,70 +690,70 @@ backend/
 
 ##  Endpoints Disponibles
 
-### Autenticación (`/auth`)
+### Autenticación (`/api/auth`)
 
 | Método | Ruta | Protegida | Descripción |
 |--------|------|-----------|-------------|
-| `POST` | `/auth/register` | No | Registro de nuevo usuario |
-| `POST` | `/auth/login` | No | Login de usuario |
-| `POST` | `/auth/forgot-password` | No | Solicitar recuperacion de contrasena |
-| `POST` | `/auth/reset-password` | No | Restablecer contrasena con token |
-| `GET` | `/auth/perfil` | Si | Obtener perfil del usuario |
-| `PATCH` | `/auth/perfil` | Si | Actualizar perfil |
-| `PATCH` | `/auth/cambiar-contrasena` | Si | Cambiar contraseña |
+| `POST` | `/api/auth/register` | No | Registro de nuevo usuario |
+| `POST` | `/api/auth/login` | No | Login de usuario |
+| `POST` | `/api/auth/forgot-password` | No | Solicitar recuperacion de contrasena |
+| `POST` | `/api/auth/reset-password` | No | Restablecer contrasena con token |
+| `GET` | `/api/auth/perfil` | Si | Obtener perfil del usuario |
+| `PATCH` | `/api/auth/perfil` | Si | Actualizar perfil |
+| `PATCH` | `/api/auth/cambiar-contrasena` | Si | Cambiar contraseña |
 
-### Reportes (`/reportes`)
-
-| Método | Ruta | Protegida | Descripción |
-|--------|------|-----------|-------------|
-| `GET` | `/reportes` | No | Listar todos los reportes |
-| `GET` | `/reportes/stats` | No | Estadísticas generales |
-| `GET` | `/reportes/:id` | No | Obtener detalle de reporte |
-| `POST` | `/reportes` | Si | Crear nuevo reporte |
-| `PATCH` | `/reportes/:id` | Si | Actualizar reporte |
-| `DELETE` | `/reportes/:id` | Si | Eliminar reporte |
-
-### Categorías (`/categorias`)
+### Reportes (`/api/reportes`)
 
 | Método | Ruta | Protegida | Descripción |
 |--------|------|-----------|-------------|
-| `GET` | `/categorias` | No | Listar todas las categorías |
-| `GET` | `/categorias/:codigo` | No | Obtener detalle de categoría |
-| `GET` | `/categorias/:codigo/reportes` | No | Reportes por categoría |
-| `GET` | `/categorias/estadisticas/resumen` | No | Estadísticas por categoría |
-| `GET` | `/categorias/estadisticas/por-severidad` | No | Estadísticas por severidad |
+| `GET` | `/api/reportes` | No | Listar todos los reportes |
+| `GET` | `/api/reportes/stats` | No | Estadísticas generales |
+| `GET` | `/api/reportes/:id` | No | Obtener detalle de reporte |
+| `POST` | `/api/reportes` | Si | Crear nuevo reporte |
+| `PATCH` | `/api/reportes/:id` | Si | Actualizar reporte |
+| `DELETE` | `/api/reportes/:id` | Si | Eliminar reporte |
 
-### Administracion (`/admin`)
+### Categorías (`/api/categorias`)
+
+| Método | Ruta | Protegida | Descripción |
+|--------|------|-----------|-------------|
+| `GET` | `/api/categorias` | No | Listar todas las categorías |
+| `GET` | `/api/categorias/:codigo` | No | Obtener detalle de categoría |
+| `GET` | `/api/categorias/:codigo/reportes` | No | Reportes por categoría |
+| `GET` | `/api/categorias/estadisticas/resumen` | No | Estadísticas por categoría |
+| `GET` | `/api/categorias/estadisticas/por-severidad` | No | Estadísticas por severidad |
+
+### Administracion (`/api/admin`)
 
 Todas las rutas usan `verifyToken` y `requireRoles('admin')` aplicados en el router.
 
 | Metodo | Ruta | Protegida | Descripcion |
 |--------|------|-----------|-------------|
-| `GET` | `/admin/usuarios/stats` | Si | Estadisticas de usuarios y reportes |
-| `GET` | `/admin/usuarios` | Si | Listar usuarios con filtros y paginacion |
-| `GET` | `/admin/usuarios/:id` | Si | Obtener usuario por id |
-| `PATCH` | `/admin/usuarios/:id/rol` | Si | Cambiar rol del usuario |
-| `PATCH` | `/admin/usuarios/:id/estado` | Si | Activar o desactivar usuario |
-| `DELETE` | `/admin/usuarios/:id` | Si | Eliminar usuario (soft delete) |
+| `GET` | `/api/admin/usuarios/stats` | Si | Estadisticas de usuarios y reportes |
+| `GET` | `/api/admin/usuarios` | Si | Listar usuarios con filtros y paginacion |
+| `GET` | `/api/admin/usuarios/:id` | Si | Obtener usuario por id |
+| `PATCH` | `/api/admin/usuarios/:id/rol` | Si | Cambiar rol del usuario |
+| `PATCH` | `/api/admin/usuarios/:id/estado` | Si | Activar o desactivar usuario |
+| `DELETE` | `/api/admin/usuarios/:id` | Si | Eliminar usuario (soft delete) |
 
-### Administracion (`/admin`)
+### Administracion (`/api/admin`)
 
 Todas las rutas usan `verifyToken` y `requireRoles('admin')` aplicados en el router.
 
 | Metodo | Ruta | Protegida | Descripcion |
 |--------|------|-----------|-------------|
-| `GET` | `/admin/usuarios/stats` | [YES] | Estadisticas de usuarios y reportes |
-| `GET` | `/admin/usuarios` | [YES] | Listar usuarios con filtros y paginacion |
-| `GET` | `/admin/usuarios/:id` | [YES] | Obtener usuario por id |
-| `PATCH` | `/admin/usuarios/:id/rol` | [YES] | Cambiar rol del usuario |
-| `PATCH` | `/admin/usuarios/:id/estado` | [YES] | Activar o desactivar usuario |
-| `DELETE` | `/admin/usuarios/:id` | [YES] | Eliminar usuario (soft delete) |
+| `GET` | `/api/admin/usuarios/stats` | [YES] | Estadisticas de usuarios y reportes |
+| `GET` | `/api/admin/usuarios` | [YES] | Listar usuarios con filtros y paginacion |
+| `GET` | `/api/admin/usuarios/:id` | [YES] | Obtener usuario por id |
+| `PATCH` | `/api/admin/usuarios/:id/rol` | [YES] | Cambiar rol del usuario |
+| `PATCH` | `/api/admin/usuarios/:id/estado` | [YES] | Activar o desactivar usuario |
+| `DELETE` | `/api/admin/usuarios/:id` | [YES] | Eliminar usuario (soft delete) |
 
 ### Health
 
 | Método | Ruta | Protegida | Descripción |
 |--------|------|-----------|-------------|
-| `GET` | `/health` | No | Estado del servidor |
+| `GET` | `/api/health` | No | Estado del servidor |
 
 ---
 
@@ -761,7 +765,7 @@ Se utiliza JWT para identificar al usuario despues de iniciar sesion. El token s
 
 Flujo basico:
 
-1. El usuario envia `email` y `password` a `POST /auth/login`.
+1. El usuario envia `email` y `password` a `POST /api/auth/login`.
 2. El backend valida que el usuario exista, este activo y que la contrasena sea correcta.
 3. Si la autenticacion es exitosa, se genera un JWT con estos datos: `sub`, `uuid`, `rol` y `email`.
 4. El backend valida el token generado antes de enviarlo en la respuesta.
@@ -983,15 +987,15 @@ Ejecutar el script `DATABASE_COMPLETA.sql` en tu cliente MySQL/HeidiSQL:
 ## Endpoints principales
 
 ### Autenticación
-- `POST /auth/register`: registro de usuario
-- `POST /auth/login`: inicio de sesion
+- `POST /api/auth/register`: registro de usuario
+- `POST /api/auth/login`: inicio de sesion
 
 ### Reportes
-- `GET /reportes`: lista de reportes
-- `GET /reportes/:id`: detalle de reporte
-- `POST /reportes`: crear reporte (requiere token)
-- `PATCH /reportes/:id`: actualizar reporte (requiere token)
-- `DELETE /reportes/:id`: eliminar reporte logico (requiere token)
+- `GET /api/reportes`: lista de reportes
+- `GET /api/reportes/:id`: detalle de reporte
+- `POST /api/reportes`: crear reporte (requiere token)
+- `PATCH /api/reportes/:id`: actualizar reporte (requiere token)
+- `DELETE /api/reportes/:id`: eliminar reporte logico (requiere token)
 
 ### 🆕 Categorías de Riesgo
 - `GET /api/categorias`: obtener todas las categorías con estadísticas
@@ -1002,7 +1006,7 @@ Ejecutar el script `DATABASE_COMPLETA.sql` en tu cliente MySQL/HeidiSQL:
 - `GET /api/estadisticas/por-severidad`: estadísticas agrupadas por severidad
 
 ### Salud
-- `GET /health`: estado del servidor y conexion a base de datos
+- `GET /api/health`: estado del servidor y conexion a base de datos
 
 ##  Crear un Reporte
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ EMAIL_FROM=noreply@greenalert.com
 
 # Frontend
 FRONTEND_URL=http://localhost:5173
+
+# Facebook OAuth
+FACEBOOK_APP_ID=your_facebook_app_id
+FACEBOOK_APP_SECRET=your_facebook_app_secret
+FACEBOOK_CALLBACK_URL=http://localhost:3000/api/auth/facebook/callback
+FACEBOOK_GRAPH_API_VERSION=v20.0
 ```
 
 ### `.env.example`
@@ -311,6 +317,49 @@ Si faltan credenciales, mostrará advertencia con instrucciones:
 ```bash
 ⚠ Google OAuth not yet configured: Variables de entorno para Google OAuth no configuradas...
 ```
+
+### Configuracion Facebook OAuth
+
+Esta configuracion permite guardar en el backend las credenciales de una app creada en Meta for Developers. En esta tarea solo se prepara la configuracion y la validacion de credenciales; el flujo completo de login con Facebook se puede implementar despues.
+
+#### Crear app en Meta for Developers
+
+1. Entrar a [Meta for Developers](https://developers.facebook.com/).
+2. Crear una nueva app.
+3. Seleccionar un caso de uso relacionado con autenticacion o inicio de sesion.
+4. Agregar el producto `Facebook Login`.
+5. Configurar la URL de callback:
+
+```bash
+http://localhost:3000/api/auth/facebook/callback
+```
+
+6. Copiar el `App ID` y el `App Secret`.
+7. Guardar esos valores en el archivo `.env`.
+
+#### Variables de entorno
+
+```env
+FACEBOOK_APP_ID=your_facebook_app_id
+FACEBOOK_APP_SECRET=your_facebook_app_secret
+FACEBOOK_CALLBACK_URL=http://localhost:3000/api/auth/facebook/callback
+FACEBOOK_GRAPH_API_VERSION=v20.0
+```
+
+#### Archivos de configuracion
+
+- `src/config/facebook.config.js`: centraliza y valida las variables de Facebook OAuth.
+- `validate-facebook-credentials.js`: permite verificar que las credenciales existan y no sean valores de ejemplo.
+
+#### Validar credenciales
+
+Ejecuta este comando desde la carpeta `Backend`:
+
+```bash
+node validate-facebook-credentials.js
+```
+
+Si todo esta configurado correctamente, el script muestra que las credenciales fueron cargadas. Si falta una variable o se dejaron valores de ejemplo, el script muestra el error para corregir el `.env`.
 
 #### [CONFIG] Endpoints de Autenticación
 

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ Content-Type: application/json
 }
 ```
 
-Valida el token con Facebook. Si el usuario existe por email, inicia sesion. Si no existe, crea una cuenta como ciudadano y retorna el JWT del backend.
+Valida el token con Facebook. Si el usuario existe por email y esta activo, inicia sesion. Si no existe, crea una cuenta como ciudadano y retorna el JWT del backend. Si la cuenta existe pero esta desactivada, el backend responde con estado `403`.
 
 ```bash
 GET /auth/facebook/callback?code=...
@@ -436,6 +436,8 @@ GET /api/auth/facebook/callback?code=...
   Retorna: Redirige al frontend con token y usuario
   Descripcion: Callback para el flujo Authorization Code de Facebook
 ```
+
+En Facebook OAuth el backend usa el email retornado por Facebook para buscar el usuario. Si lo encuentra y esta activo, actualiza el ultimo acceso y genera el JWT. Si no existe, crea el usuario con rol `ciudadano`, marca el email como verificado y luego genera el JWT.
 
 GESTIÓN DE CUENTA:
 

--- a/README.md
+++ b/README.md
@@ -637,16 +637,38 @@ Todas las rutas usan `verifyToken` y `requireRoles('admin')` aplicados en el rou
 
 ---
 
-##  Autenticación
+## Autenticación
 
 ### JWT Token
 
-Se utiliza **JWT (JSON Web Tokens)** para autenticación:
+Se utiliza JWT para identificar al usuario despues de iniciar sesion. El token se genera en el backend cuando las credenciales son correctas.
 
-1. Usuario se autentica con `POST /auth/login`
-2. Backend retorna un token JWT válido por 7 días
-3. Cliente incluye token en header: `Authorization: Bearer <token>`
-4. Servidor verifica token en cada request protegido
+Flujo basico:
+
+1. El usuario envia `email` y `password` a `POST /auth/login`.
+2. El backend valida que el usuario exista, este activo y que la contrasena sea correcta.
+3. Si la autenticacion es exitosa, se genera un JWT con estos datos: `sub`, `uuid`, `rol` y `email`.
+4. El backend valida el token generado antes de enviarlo en la respuesta.
+5. El cliente debe enviar el token en las rutas protegidas usando el header `Authorization`.
+
+La duracion del token se configura con `JWT_EXPIRES_IN`. Si no se define, se usa `7d`.
+
+Respuesta esperada en login o registro exitoso:
+
+```json
+{
+  "status": "success",
+  "data": {
+    "token": "jwt_generado",
+    "user": {
+      "id_usuario": 1,
+      "email": "usuario@correo.com",
+      "rol": "ciudadano"
+    }
+  },
+  "message": "Inicio de sesion exitoso."
+}
+```
 
 ### Headers Requeridos
 
@@ -658,6 +680,9 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 
 El middleware `verifyToken` valida JWT en rutas protegidas.
 Para control de acceso por rol se usa `requireRoles(...)` y debe declararse despues de `verifyToken`.
+
+Si el token no se envia, el backend responde con estado `401`.
+Si el token es invalido o ya expiro, el backend responde con estado `403`.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
     "mysql2": "^3.9.8",
-    "nodemailer": "^8.0.5"
+    "nodemailer": "^8.0.5",
+    "passport-facebook": "^3.0.0"
   },
   "devDependencies": {
     "nodemon": "^3.1.3"

--- a/routes/auth.routes.js
+++ b/routes/auth.routes.js
@@ -14,6 +14,9 @@ import {
 	googleLogin,
 	googleCallback,
 	getGoogleAuthUrl,
+	facebookLogin,
+	facebookCallback,
+	getFacebookAuthUrl,
 } from '../src/controllers/auth.controller.js';
 
 const authRouter = Router();
@@ -35,5 +38,10 @@ authRouter.post('/verificar-email', verifyToken, verifyEmailOtp);
 authRouter.get('/google/url', getGoogleAuthUrl);
 authRouter.post('/google/login', googleLogin);
 authRouter.get('/google/callback', googleCallback);
+
+// Rutas para autenticacion con Facebook OAuth
+authRouter.get('/facebook/url', getFacebookAuthUrl);
+authRouter.post('/facebook/login', facebookLogin);
+authRouter.get('/facebook/callback', facebookCallback);
 
 export default authRouter;

--- a/src/app.js
+++ b/src/app.js
@@ -11,6 +11,13 @@ import adminRouter from '../routes/admin.routes.js';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const app = express();
+const normalizeApiPrefix = (prefix = '/api') => {
+  const trimmedPrefix = prefix.trim();
+  const withLeadingSlash = trimmedPrefix.startsWith('/') ? trimmedPrefix : `/${trimmedPrefix}`;
+  return withLeadingSlash.replace(/\/+$/, '') || '/api';
+};
+
+const apiPrefix = normalizeApiPrefix(process.env.API_PREFIX);
 
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
@@ -18,12 +25,12 @@ app.use(express.urlencoded({ extended: true }));
 // Archivos subidos por los usuarios
 app.use('/uploads', express.static(path.join(__dirname, '../uploads')));
 
-// rutas
-app.use('/health', healthRouter);
-app.use('/auth', authRouter);
-app.use('/reportes', reporteRouter);
-app.use('/categorias', categoriaRouter);
-app.use('/admin', adminRouter);
+// rutas de la API
+app.use(`${apiPrefix}/health`, healthRouter);
+app.use(`${apiPrefix}/auth`, authRouter);
+app.use(`${apiPrefix}/reportes`, reporteRouter);
+app.use(`${apiPrefix}/categorias`, categoriaRouter);
+app.use(`${apiPrefix}/admin`, adminRouter);
 
  
 app.use(notFoundHandler);

--- a/src/config/facebook.config.js
+++ b/src/config/facebook.config.js
@@ -1,0 +1,44 @@
+/**
+ * FACEBOOK OAUTH CONFIGURATION
+ * Centraliza y valida las variables de entorno para Facebook OAuth.
+ * No debe contener credenciales reales en el codigo.
+ */
+
+const validateFacebookConfig = () => {
+  const config = {
+    appId: process.env.FACEBOOK_APP_ID,
+    appSecret: process.env.FACEBOOK_APP_SECRET,
+    callbackUrl: process.env.FACEBOOK_CALLBACK_URL || 'http://localhost:3000/api/auth/facebook/callback',
+    graphApiVersion: process.env.FACEBOOK_GRAPH_API_VERSION || 'v20.0',
+  };
+
+  const missingVars = [];
+
+  if (!config.appId) missingVars.push('FACEBOOK_APP_ID');
+  if (!config.appSecret) missingVars.push('FACEBOOK_APP_SECRET');
+
+  if (missingVars.length > 0) {
+    throw new Error(
+      `Variables de entorno para Facebook OAuth no configuradas: ${missingVars.join(', ')}\n` +
+      'Completa estos valores en el archivo .env con las credenciales de Meta for Developers.'
+    );
+  }
+
+  return config;
+};
+
+let facebookConfig = null;
+
+export const getFacebookConfig = () => {
+  if (!facebookConfig) {
+    facebookConfig = validateFacebookConfig();
+  }
+
+  return facebookConfig;
+};
+
+export const isFacebookConfigured = () => (
+  Boolean(process.env.FACEBOOK_APP_ID && process.env.FACEBOOK_APP_SECRET)
+);
+
+export default getFacebookConfig;

--- a/src/config/google.config.js
+++ b/src/config/google.config.js
@@ -1,7 +1,6 @@
 /**
  * GOOGLE OAUTH CONFIGURATION
- * Centraliza y valida todas las variables de entorno para Google OAuth 2.0
- * Nunca debe contener valores hardcodeados
+ * Centraliza y valida las variables de entorno para Google OAuth 2.0.
  */
 
 const validateGoogleConfig = () => {
@@ -11,9 +10,8 @@ const validateGoogleConfig = () => {
     callbackUrl: process.env.GOOGLE_CALLBACK_URL || 'http://localhost:3000/api/auth/google/callback',
   };
 
-  // Validar que variables críticas estén definidas
   const missingVars = [];
-  
+
   if (!config.clientId) missingVars.push('GOOGLE_CLIENT_ID');
   if (!config.clientSecret) missingVars.push('GOOGLE_CLIENT_SECRET');
 
@@ -34,23 +32,28 @@ const validateGoogleConfig = () => {
   return config;
 };
 
-// Cargar y validar configuración
+export const getGoogleAuthUrlConfig = () => ({
+  clientId: process.env.GOOGLE_CLIENT_ID || 'your_client_id_here.apps.googleusercontent.com',
+  callbackUrl: process.env.GOOGLE_CALLBACK_URL || 'http://localhost:3000/api/auth/google/callback',
+  isConfigured: Boolean(process.env.GOOGLE_CLIENT_ID),
+});
+
 let googleConfig = null;
 
 export const getGoogleConfig = () => {
   if (!googleConfig) {
     googleConfig = validateGoogleConfig();
   }
+
   return googleConfig;
 };
 
-// Validar al importar si está en desarrollo
 if (process.env.NODE_ENV === 'development') {
   try {
     getGoogleConfig();
-    console.log('✓ Google OAuth configuration loaded successfully');
+    console.log('[OK] Google OAuth configuration loaded successfully');
   } catch (error) {
-    console.warn('⚠ Google OAuth not yet configured:', error.message);
+    console.warn('[AVISO] Google OAuth not yet configured:', error.message);
   }
 }
 

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -869,6 +869,12 @@ const findOrCreateFacebookUser = async ({ email, nombre, apellido, avatar_url })
   let user = await UsuarioModel.findByEmail(email);
 
   if (user) {
+    if (!user.activo) {
+      const error = new Error('Cuenta desactivada. Contacta al administrador.');
+      error.statusCode = 403;
+      throw error;
+    }
+
     await UsuarioModel.updateUltimoAcceso(user.id_usuario);
     return user;
   }
@@ -920,7 +926,16 @@ export const facebookLogin = async (req, res, next) => {
       return errorResponse(res, 'Token de Facebook invalido.', 401);
     }
 
-    const user = await findOrCreateFacebookUser(facebookUser);
+    let user;
+    try {
+      user = await findOrCreateFacebookUser(facebookUser);
+    } catch (error) {
+      if (error.statusCode) {
+        return errorResponse(res, error.message, error.statusCode);
+      }
+      throw error;
+    }
+
     if (!user) {
       return errorResponse(res, 'No fue posible autenticar con Facebook.', 400);
     }
@@ -959,7 +974,16 @@ export const facebookCallback = async (req, res, next) => {
       return errorResponse(res, 'No fue posible obtener informacion de Facebook.', 400);
     }
 
-    const user = await findOrCreateFacebookUser(facebookUser);
+    let user;
+    try {
+      user = await findOrCreateFacebookUser(facebookUser);
+    } catch (error) {
+      if (error.statusCode) {
+        return errorResponse(res, error.message, error.statusCode);
+      }
+      throw error;
+    }
+
     if (!user) {
       return errorResponse(res, 'No fue posible autenticar con Facebook.', 400);
     }

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -18,23 +18,51 @@ const hashPassword = (password) => {
   return `${salt}:${derivedKey}`;
 };
 
-const buildToken = (user) => {
+const getJwtSecret = () => {
   if (!process.env.JWT_SECRET) {
-    const error = new Error('JWT_SECRET no configurado ');
+    const error = new Error('JWT_SECRET no configurado');
     error.statusCode = 500;
     throw error;
   }
 
-  return jwt.sign(
+  return process.env.JWT_SECRET;
+};
+
+const validateGeneratedToken = (token, secret, user) => {
+  const decoded = jwt.verify(token, secret);
+
+  if (
+    Number(decoded.sub) !== Number(user.id_usuario) ||
+    decoded.email !== user.email ||
+    decoded.rol !== user.rol ||
+    (user.uuid && decoded.uuid !== user.uuid)
+  ) {
+    const error = new Error('JWT generado no coincide con el usuario autenticado');
+    error.statusCode = 500;
+    throw error;
+  }
+
+  return decoded;
+};
+
+const buildToken = (user) => {
+  const secret = getJwtSecret();
+  const expiresIn = process.env.JWT_EXPIRES_IN || '7d';
+
+  const token = jwt.sign(
     {
       sub: user.id_usuario,
       uuid: user.uuid,
       rol: user.rol,
       email: user.email,
     },
-    process.env.JWT_SECRET,
-    { expiresIn: '7d' }
+    secret,
+    { expiresIn }
   );
+
+  validateGeneratedToken(token, secret, user);
+
+  return token;
 };
 
 const toPublicUser = (user) => ({

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -854,7 +854,10 @@ export const getGoogleAuthUrl = async (req, res, next) => {
 
     return successResponse(
       res,
-      { authUrl: result.authUrl },
+      {
+        authUrl: result.authUrl,
+        configured: result.isConfigured,
+      },
       'URL de autenticación generada exitosamente.',
       200
     );

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -5,6 +5,12 @@ import { errorResponse, successResponse } from '../utils/response.js';
 import { enviarCorreo, enviarCorreoBienvenida, enviarCorreoVerificacion } from '../services/email.service.js';
 import { verifyGoogleToken, exchangeCodeForTokens, getGoogleUserInfo, generateAuthUrl } from '../services/google-oauth.service.js';
 import {
+  exchangeFacebookCodeForToken,
+  generateFacebookAuthUrl,
+  getFacebookStrategy,
+  getFacebookUserInfo,
+} from '../services/facebook-oauth.service.js';
+import {
   validarNombreUsuario,
   validarTelefono,
   validarPassword,
@@ -852,6 +858,117 @@ export const getGoogleAuthUrl = async (req, res, next) => {
       'URL de autenticación generada exitosamente.',
       200
     );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+// ============ METODOS PARA AUTENTICACION CON FACEBOOK OAUTH ============
+
+const findOrCreateFacebookUser = async ({ email, nombre, apellido, avatar_url }) => {
+  let user = await UsuarioModel.findByEmail(email);
+
+  if (user) {
+    await UsuarioModel.updateUltimoAcceso(user.id_usuario);
+    return user;
+  }
+
+  const idUsuario = await UsuarioModel.createFromFacebook({
+    email,
+    nombre: nombre || '',
+    apellido: apellido || '',
+    avatar_url,
+  });
+
+  if (!idUsuario) {
+    return null;
+  }
+
+  return UsuarioModel.findById(idUsuario);
+};
+
+export const getFacebookAuthUrl = async (req, res, next) => {
+  try {
+    getFacebookStrategy();
+    const result = generateFacebookAuthUrl();
+
+    if (!result.success) {
+      return errorResponse(res, 'No fue posible generar la URL de autenticacion con Facebook.', 500);
+    }
+
+    return successResponse(
+      res,
+      { authUrl: result.authUrl },
+      'URL de autenticacion con Facebook generada correctamente.',
+      200
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const facebookLogin = async (req, res, next) => {
+  try {
+    const { access_token } = req.body ?? {};
+
+    if (!access_token || typeof access_token !== 'string') {
+      return errorResponse(res, 'El access_token de Facebook es requerido.', 400);
+    }
+
+    const facebookUser = await getFacebookUserInfo(access_token);
+    if (!facebookUser.success) {
+      return errorResponse(res, 'Token de Facebook invalido.', 401);
+    }
+
+    const user = await findOrCreateFacebookUser(facebookUser);
+    if (!user) {
+      return errorResponse(res, 'No fue posible autenticar con Facebook.', 400);
+    }
+
+    const token = buildToken(user);
+
+    return successResponse(
+      res,
+      {
+        token,
+        user: toPublicUser(user),
+      },
+      'Autenticacion con Facebook exitosa.',
+      200
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const facebookCallback = async (req, res, next) => {
+  try {
+    const { code } = req.query ?? {};
+
+    if (!code || typeof code !== 'string') {
+      return errorResponse(res, 'Codigo de autorizacion de Facebook requerido.', 400);
+    }
+
+    const tokenExchange = await exchangeFacebookCodeForToken(code);
+    if (!tokenExchange.success) {
+      return errorResponse(res, 'No fue posible intercambiar el codigo de Facebook.', 400);
+    }
+
+    const facebookUser = await getFacebookUserInfo(tokenExchange.accessToken);
+    if (!facebookUser.success) {
+      return errorResponse(res, 'No fue posible obtener informacion de Facebook.', 400);
+    }
+
+    const user = await findOrCreateFacebookUser(facebookUser);
+    if (!user) {
+      return errorResponse(res, 'No fue posible autenticar con Facebook.', 400);
+    }
+
+    const token = buildToken(user);
+    const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:5173';
+    const redirectUrl = `${frontendUrl}/auth/callback?token=${token}&user=${encodeURIComponent(JSON.stringify(toPublicUser(user)))}`;
+
+    return res.redirect(redirectUrl);
   } catch (error) {
     return next(error);
   }

--- a/src/models/usuario.model.js
+++ b/src/models/usuario.model.js
@@ -427,4 +427,23 @@ export const UsuarioModel = {
     );
     return result.affectedRows > 0;
   },
+
+  // Crea usuario desde Facebook OAuth usando email verificado por Facebook
+  createFromFacebook: async ({ email, nombre, apellido, avatar_url }) => {
+    const uuid = randomUUID();
+
+    try {
+      const [result] = await pool.execute(
+        `INSERT INTO usuarios (uuid, email, nombre, apellido, avatar_url, rol, email_verificado)
+         VALUES (?, ?, ?, ?, ?, 'ciudadano', 1)`,
+        [uuid, email, nombre, apellido, avatar_url]
+      );
+      return result.insertId;
+    } catch (error) {
+      if (error.code === 'ER_DUP_ENTRY') {
+        return null;
+      }
+      throw error;
+    }
+  },
 };

--- a/src/services/facebook-oauth.service.js
+++ b/src/services/facebook-oauth.service.js
@@ -1,0 +1,140 @@
+import { Strategy as FacebookStrategy } from 'passport-facebook';
+import { getFacebookConfig } from '../config/facebook.config.js';
+
+let facebookStrategy = null;
+
+const getGraphApiBaseUrl = () => {
+  const { graphApiVersion } = getFacebookConfig();
+  return `https://graph.facebook.com/${graphApiVersion}`;
+};
+
+const normalizeFacebookProfile = (profile) => {
+  const fullName = profile.name || '';
+  const [firstName = '', ...lastNameParts] = fullName.trim().split(' ').filter(Boolean);
+
+  return {
+    facebookId: profile.id,
+    email: profile.email,
+    nombre: profile.first_name || firstName || '',
+    apellido: profile.last_name || lastNameParts.join(' ') || '',
+    avatar_url: profile.picture?.data?.url || null,
+  };
+};
+
+export const getFacebookStrategy = () => {
+  if (facebookStrategy) {
+    return facebookStrategy;
+  }
+
+  const config = getFacebookConfig();
+
+  facebookStrategy = new FacebookStrategy(
+    {
+      clientID: config.appId,
+      clientSecret: config.appSecret,
+      callbackURL: config.callbackUrl,
+      profileFields: ['id', 'displayName', 'name', 'emails', 'photos'],
+    },
+    (accessToken, refreshToken, profile, done) => {
+      const email = profile.emails?.[0]?.value;
+      const photo = profile.photos?.[0]?.value;
+
+      if (!email) {
+        return done(null, false, { message: 'Facebook no retorno un email.' });
+      }
+
+      return done(null, {
+        facebookId: profile.id,
+        email,
+        nombre: profile.name?.givenName || profile.displayName || '',
+        apellido: profile.name?.familyName || '',
+        avatar_url: photo || null,
+        accessToken,
+      });
+    }
+  );
+
+  return facebookStrategy;
+};
+
+export const generateFacebookAuthUrl = () => {
+  try {
+    const config = getFacebookConfig();
+    const params = new URLSearchParams({
+      client_id: config.appId,
+      redirect_uri: config.callbackUrl,
+      scope: 'email,public_profile',
+      response_type: 'code',
+    });
+
+    return {
+      success: true,
+      authUrl: `https://www.facebook.com/${config.graphApiVersion}/dialog/oauth?${params.toString()}`,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error.message,
+    };
+  }
+};
+
+export const exchangeFacebookCodeForToken = async (code) => {
+  try {
+    const config = getFacebookConfig();
+    const params = new URLSearchParams({
+      client_id: config.appId,
+      client_secret: config.appSecret,
+      redirect_uri: config.callbackUrl,
+      code,
+    });
+
+    const response = await fetch(`${getGraphApiBaseUrl()}/oauth/access_token?${params.toString()}`);
+    const data = await response.json();
+
+    if (!response.ok || !data.access_token) {
+      throw new Error(data?.error?.message || 'No fue posible obtener el access_token de Facebook.');
+    }
+
+    return {
+      success: true,
+      accessToken: data.access_token,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error.message,
+    };
+  }
+};
+
+export const getFacebookUserInfo = async (accessToken) => {
+  try {
+    const params = new URLSearchParams({
+      fields: 'id,name,first_name,last_name,email,picture',
+      access_token: accessToken,
+    });
+
+    const response = await fetch(`${getGraphApiBaseUrl()}/me?${params.toString()}`);
+    const data = await response.json();
+
+    if (!response.ok) {
+      throw new Error(data?.error?.message || 'No fue posible obtener informacion de Facebook.');
+    }
+
+    const userInfo = normalizeFacebookProfile(data);
+    if (!userInfo.email) {
+      throw new Error('Facebook no retorno un email para el usuario.');
+    }
+
+    return {
+      success: true,
+      ...userInfo,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error.message,
+    };
+  }
+};

--- a/src/services/google-oauth.service.js
+++ b/src/services/google-oauth.service.js
@@ -1,5 +1,5 @@
 import { OAuth2Client } from 'google-auth-library';
-import { getGoogleConfig } from '../config/google.config.js';
+import { getGoogleAuthUrlConfig, getGoogleConfig } from '../config/google.config.js';
 
 let oauthClient = null;
 
@@ -95,7 +95,11 @@ export const getGoogleUserInfo = async (accessToken) => {
 
 export const generateAuthUrl = () => {
   try {
-    const client = getOAuthClient();
+    const config = getGoogleAuthUrlConfig();
+    const client = new OAuth2Client({
+      clientId: config.clientId,
+      redirectUri: config.callbackUrl,
+    });
     const scopes = [
       'openid',
       'email',
@@ -111,6 +115,7 @@ export const generateAuthUrl = () => {
     return {
       success: true,
       authUrl,
+      isConfigured: config.isConfigured,
     };
   } catch (error) {
     return {

--- a/tests/auth/login.test.js
+++ b/tests/auth/login.test.js
@@ -40,7 +40,7 @@ const assert = (condition, testName) => {
 async function testConnection() {
   log.info('\n--- TEST 0: Connection ---');
   try {
-    const response = await fetch(`${API_URL}/auth/login`, {
+    const response = await fetch(`${API_URL}/api/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email: 'test@test.com', password: 'test' }),

--- a/tests/auth/password-reset.test.js
+++ b/tests/auth/password-reset.test.js
@@ -40,7 +40,7 @@ const assert = (condition, testName) => {
 async function testConnection() {
   log.info('\n--- TEST 0: Connection ---');
   try {
-    const response = await fetch(`${API_URL}/auth/login`, {
+    const response = await fetch(`${API_URL}/api/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email: 'test@test.com', password: 'test' }),

--- a/tests/auth/register.test.js
+++ b/tests/auth/register.test.js
@@ -38,7 +38,7 @@ const assert = (condition, testName) => {
 async function testConnection() {
   log.info('\n--- TEST 0: Connection ---');
   try {
-    const response = await fetch(`${API_URL}/auth/login`, {
+    const response = await fetch(`${API_URL}/api/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email: 'test@test.com', password: 'test' }),
@@ -56,7 +56,7 @@ async function testValidRegistration() {
   log.info('\n--- TEST 1: Valid Registration ---');
   try {
     const email = `test-${Date.now()}@ejemplo.com`;
-    const response = await fetch(`${API_URL}/auth/register`, {
+    const response = await fetch(`${API_URL}/api/auth/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -84,7 +84,7 @@ async function testValidRegistration() {
 async function testInvalidEmail() {
   log.info('\n--- TEST 2: Invalid Email (Should fail) ---');
   try {
-    const response = await fetch(`${API_URL}/auth/register`, {
+    const response = await fetch(`${API_URL}/api/auth/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -106,7 +106,7 @@ async function testInvalidEmail() {
 async function testShortPassword() {
   log.info('\n--- TEST 3: Short Password (Should fail) ---');
   try {
-    const response = await fetch(`${API_URL}/auth/register`, {
+    const response = await fetch(`${API_URL}/api/auth/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/tests/diagnose-routes.js
+++ b/tests/diagnose-routes.js
@@ -21,21 +21,21 @@ async function main() {
 
   // Test rutas básicas
   console.log('Rutas básicas:');
-  await testRoute('GET', '/health');
+  await testRoute('GET', '/api/health');
   await testRoute('GET', '/');
   
   // Test rutas auth
   console.log('\nRutas Auth:');
-  await testRoute('POST', '/auth/register');
-  await testRoute('POST', '/auth/login');
-  await testRoute('POST', '/auth/send-verification-email');
-  await testRoute('GET', '/auth/verify-email');
+  await testRoute('POST', '/api/auth/register');
+  await testRoute('POST', '/api/auth/login');
+  await testRoute('POST', '/api/auth/send-verification-email');
+  await testRoute('GET', '/api/auth/verify-email');
   
   // Test rutas reportes
   console.log('\nRutas Reportes:');
-  await testRoute('GET', '/reportes/mis-reportes');
-  await testRoute('GET', '/reportes');
-  await testRoute('POST', '/reportes');
+  await testRoute('GET', '/api/reportes/mis-reportes');
+  await testRoute('GET', '/api/reportes');
+  await testRoute('POST', '/api/reportes');
 
   // Test con headers adicionales
   console.log('\nRutas con Bearer token inválido:');
@@ -44,12 +44,12 @@ async function main() {
   };
   
   try {
-    const response = await fetch(`${BASE_URL}/auth/send-verification-email`, {
+    const response = await fetch(`${BASE_URL}/api/auth/send-verification-email`, {
       method: 'POST',
       headers,
       body: JSON.stringify({})
     });
-    console.log(`POST /auth/send-verification-email: ${response.status}`);
+    console.log(`POST /api/auth/send-verification-email: ${response.status}`);
     const data = await response.json();
     console.log(`Response:`, data);
   } catch (error) {

--- a/tests/email/verification.test.js
+++ b/tests/email/verification.test.js
@@ -41,7 +41,7 @@ const assert = (condition, testName) => {
 async function testConnection() {
   log.info('\n--- TEST 0: Connection to Server ---');
   try {
-    const response = await fetch(`${API_URL}/auth/login`, {
+    const response = await fetch(`${API_URL}/api/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email: 'test@test.com', password: 'test' }),
@@ -60,7 +60,7 @@ async function testConnection() {
 async function testRegister() {
   log.info('\n--- TEST 1: Register User ---');
   try {
-    const response = await fetch(`${API_URL}/auth/register`, {
+    const response = await fetch(`${API_URL}/api/auth/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -88,7 +88,7 @@ async function testRegister() {
 async function testSendVerification(jwt) {
   log.info('\n--- TEST 2: Send Verification Email ---');
   try {
-    const response = await fetch(`${API_URL}/auth/send-verification-email`, {
+    const response = await fetch(`${API_URL}/api/auth/send-verification-email`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -111,7 +111,7 @@ async function testSendVerification(jwt) {
 async function testNoAuth() {
   log.info('\n--- TEST 3: No Authentication (Should fail) ---');
   try {
-    const response = await fetch(`${API_URL}/auth/send-verification-email`, {
+    const response = await fetch(`${API_URL}/api/auth/send-verification-email`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
     });
@@ -132,7 +132,7 @@ async function testNoAuth() {
 async function testNoToken() {
   log.info('\n--- TEST 4: No Token in Query (Should fail) ---');
   try {
-    const response = await fetch(`${API_URL}/auth/verify-email`, {
+    const response = await fetch(`${API_URL}/api/auth/verify-email`, {
       method: 'GET',
     });
 
@@ -152,7 +152,7 @@ async function testNoToken() {
 async function testInvalidToken() {
   log.info('\n--- TEST 5: Invalid Token (Should fail) ---');
   try {
-    const response = await fetch(`${API_URL}/auth/verify-email?token=invalid_token_xyz123`, {
+    const response = await fetch(`${API_URL}/api/auth/verify-email?token=invalid_token_xyz123`, {
       method: 'GET',
     });
 

--- a/tests/integration-v2.test.js
+++ b/tests/integration-v2.test.js
@@ -77,7 +77,7 @@ async function runTests() {
 
   await test('Registro de usuario exitoso', async () => {
     testEmail = `test-${Date.now()}@example.com`;
-    const res = await apiRequest('POST', '/auth/register', {
+    const res = await apiRequest('POST', '/api/auth/register', {
       nombre: 'Test',
       apellido: 'User',
       email: testEmail,
@@ -99,7 +99,7 @@ async function runTests() {
       return;
     }
     
-    const res = await apiRequest('POST', '/auth/login', {
+    const res = await apiRequest('POST', '/api/auth/login', {
       email: testEmail,
       password: 'TestPass123!',
     });
@@ -112,21 +112,21 @@ async function runTests() {
   // ─── 2. ENDPOINTS OTP ───
   log.section('2. ENDPOINTS OTP EMAIL VERIFICATION');
 
-  await test('GET /auth/send-verification-email devuelve 401 sin token', async () => {
-    const res = await apiRequest('POST', '/auth/send-verification-email', {});
+  await test('GET /api/auth/send-verification-email devuelve 401 sin token', async () => {
+    const res = await apiRequest('POST', '/api/auth/send-verification-email', {});
     assert.strictEqual(res.status, 401, `Expected 401, got ${res.status}`);
   });
 
-  await test('GET /auth/verify-email devuelve 400/404 sin parámetros', async () => {
-    const res = await apiRequest('GET', '/auth/verify-email');
+  await test('GET /api/auth/verify-email devuelve 400/404 sin parámetros', async () => {
+    const res = await apiRequest('GET', '/api/auth/verify-email');
     assert([400, 404].includes(res.status), `Expected 400/404, got ${res.status}`);
   });
 
-  // ─── 3. GET /REPORTES/MIS-REPORTES ───
-  log.section('3. GET /REPORTES/MIS-REPORTES');
+  // ─── 3. GET /api/reportes/MIS-REPORTES ───
+  log.section('3. GET /api/reportes/MIS-REPORTES');
 
   await test('Acceso a mis-reportes requiere autenticación', async () => {
-    const res = await apiRequest('GET', '/reportes/mis-reportes');
+    const res = await apiRequest('GET', '/api/reportes/mis-reportes');
     assert.strictEqual(res.status, 401, `Expected 401, got ${res.status}`);
   });
 
@@ -136,7 +136,7 @@ async function runTests() {
       return;
     }
 
-    const res = await apiRequest('GET', '/reportes/mis-reportes', null, testToken);
+    const res = await apiRequest('GET', '/api/reportes/mis-reportes', null, testToken);
     assert.strictEqual(res.status, 200, `Expected 200, got ${res.status}`);
     assert(Array.isArray(res.data?.data?.reportes), 'Reportes debe ser array');
     assert(typeof res.data?.data?.total === 'number', 'Total es número');
@@ -153,7 +153,7 @@ async function runTests() {
       return;
     }
 
-    const res = await apiRequest('POST', '/reportes', {
+    const res = await apiRequest('POST', '/api/reportes', {
       tipo_contaminacion: 'inundacion',
       nivel_severidad: 'medio',
       titulo: 'Test Report Title',
@@ -175,13 +175,13 @@ async function runTests() {
   log.section('5. ENDPOINTS ADICIONALES');
 
   await test('Health check está disponible', async () => {
-    const res = await apiRequest('GET', '/health');
+    const res = await apiRequest('GET', '/api/health');
     assert.strictEqual(res.status, 200, `Expected 200, got ${res.status}`);
     assert(res.data?.status, 'Health status disponible');
   });
 
-  await test('GET /reportes devuelve lista pública', async () => {
-    const res = await apiRequest('GET', '/reportes');
+  await test('GET /api/reportes devuelve lista pública', async () => {
+    const res = await apiRequest('GET', '/api/reportes');
     assert.strictEqual(res.status, 200, `Expected 200, got ${res.status}`);
     assert(Array.isArray(res.data?.data?.reportes), 'Reportes debe ser array');
   });

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -2,7 +2,7 @@
 /**
  * Test Suite: Features implementadas
  * 1. OTP Email Verification
- * 2. GET /reportes/mis-reportes
+ * 2. GET /api/reportes/mis-reportes
  * 3. Report editing restrictions
  * 4. Moderation comments
  * 5. Welcome email
@@ -89,7 +89,7 @@ async function runTests() {
   log.section('1. REGISTRO Y AUTENTICACIÓN');
 
   await test('Registro de usuario exitoso', async () => {
-    const res = await apiRequest('POST', '/auth/register', {
+    const res = await apiRequest('POST', '/api/auth/register', {
       nombre: 'Test',
       apellido: 'User',
       email: `test-${Date.now()}@example.com`,
@@ -105,7 +105,7 @@ async function runTests() {
   });
 
   await test('Login exitoso', async () => {
-    const res = await apiRequest('POST', '/auth/login', {
+    const res = await apiRequest('POST', '/api/auth/login', {
       email: 'test-user@example.com',
       password: 'password123',
     });
@@ -118,14 +118,14 @@ async function runTests() {
   log.section('2. OTP EMAIL VERIFICATION');
 
   await test('Enviar verificación OTP requiere token', async () => {
-    const res = await apiRequest('POST', '/auth/send-verification-email', {});
+    const res = await apiRequest('POST', '/api/auth/send-verification-email', {});
     
     assert.strictEqual(res.status, 401, `Expected 401, got ${res.status}`);
     assert(res.data.message.includes('No autorizado'), 'Mensaje de error correcto');
   });
 
   await test('Verificación OTP con token inválido falla', async () => {
-    const res = await apiRequest('POST', '/auth/verify-email', 
+    const res = await apiRequest('POST', '/api/auth/verify-email', 
       { otp_code: '123456' },
       'invalid-token'
     );
@@ -133,11 +133,11 @@ async function runTests() {
     assert.strictEqual(res.status, 401, `Expected 401, got ${res.status}`);
   });
 
-  // ─── 3. GET /REPORTES/MIS-REPORTES ───
-  log.section('3. GET /REPORTES/MIS-REPORTES');
+  // ─── 3. GET /api/reportes/MIS-REPORTES ───
+  log.section('3. GET /api/reportes/MIS-REPORTES');
 
   await test('Acceso a mis-reportes requiere autenticación', async () => {
-    const res = await apiRequest('GET', '/reportes/mis-reportes');
+    const res = await apiRequest('GET', '/api/reportes/mis-reportes');
     
     assert.strictEqual(res.status, 401, `Expected 401, got ${res.status}`);
     assert(res.data.message.includes('No autorizado'), 'Mensaje de error correcto');
@@ -147,7 +147,7 @@ async function runTests() {
   log.section('4. CREAR REPORTE DE PRUEBA');
 
   // Necesito un token válido. Voy a crear un usuario de prueba
-  let res = await apiRequest('POST', '/auth/register', {
+  let res = await apiRequest('POST', '/api/auth/register', {
     nombre: 'Report',
     apellido: 'Tester',
     email: `reporter-${Date.now()}@example.com`,
@@ -158,7 +158,7 @@ async function runTests() {
     // Intentar login con este usuario (usar email del registro)
     const testEmail = res.data.usuario.email;
     
-    res = await apiRequest('POST', '/auth/login', {
+    res = await apiRequest('POST', '/api/auth/login', {
       email: testEmail,
       password: 'TestPass123!',
     });
@@ -168,7 +168,7 @@ async function runTests() {
       log.info(`Token obtenido: ${testToken.substring(0, 20)}...`);
 
       // Crear un reporte
-      res = await apiRequest('POST', '/reportes', 
+      res = await apiRequest('POST', '/api/reportes', 
         {
           id_categoria: 1,
           titulo: 'Test Report',
@@ -196,7 +196,7 @@ async function runTests() {
       return;
     }
 
-    const res = await apiRequest('GET', '/reportes/mis-reportes', null, testToken);
+    const res = await apiRequest('GET', '/api/reportes/mis-reportes', null, testToken);
     
     assert([200, 401].includes(res.status), `Expected 200 or 401, got ${res.status}`);
     if (res.status === 200) {
@@ -211,7 +211,7 @@ async function runTests() {
     }
 
     // Intentar cambiar estado (lo cual debería estar bloqueado después de pendiente)
-    const res = await apiRequest('PATCH', `/reportes/${testReporteId}`,
+    const res = await apiRequest('PATCH', `/api/reportes/${testReporteId}`,
       { estado: 'en_revision' },
       testToken
     );
@@ -231,7 +231,7 @@ async function runTests() {
     }
 
     // Intentar rechazar sin comentario
-    const res = await apiRequest('PATCH', `/reportes/${testReporteId}`,
+    const res = await apiRequest('PATCH', `/api/reportes/${testReporteId}`,
       { estado: 'rechazado' },
       testToken
     );
@@ -244,7 +244,7 @@ async function runTests() {
   log.section('7. ENDPOINTS ADICIONALES');
 
   await test('Health check está disponible', async () => {
-    const res = await apiRequest('GET', '/health');
+    const res = await apiRequest('GET', '/api/health');
     
     assert.strictEqual(res.status, 200, `Expected 200, got ${res.status}`);
     assert(res.data.status, 'Health status disponible');

--- a/validate-facebook-credentials.js
+++ b/validate-facebook-credentials.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+import 'dotenv/config';
+import { getFacebookConfig } from './src/config/facebook.config.js';
+
+const isPlaceholder = (value) => {
+  if (!value) return true;
+
+  const normalizedValue = value.toLowerCase();
+  return (
+    normalizedValue.includes('your_') ||
+    normalizedValue.includes('tu_') ||
+    normalizedValue.includes('app_id') ||
+    normalizedValue.includes('app_secret')
+  );
+};
+
+try {
+  const config = getFacebookConfig();
+  const warnings = [];
+
+  if (isPlaceholder(config.appId)) {
+    warnings.push('FACEBOOK_APP_ID parece ser un valor de ejemplo.');
+  }
+
+  if (isPlaceholder(config.appSecret)) {
+    warnings.push('FACEBOOK_APP_SECRET parece ser un valor de ejemplo.');
+  }
+
+  console.log('[OK] FACEBOOK_APP_ID configurado.');
+  console.log('[OK] FACEBOOK_APP_SECRET configurado.');
+  console.log(`[OK] FACEBOOK_CALLBACK_URL: ${config.callbackUrl}`);
+  console.log(`[OK] FACEBOOK_GRAPH_API_VERSION: ${config.graphApiVersion}`);
+
+  if (warnings.length > 0) {
+    console.log('\n[AVISO] Revisa estas advertencias:');
+    warnings.forEach((warning) => console.log(`- ${warning}`));
+    process.exit(1);
+  }
+
+  console.log('\n[SUCCESS] Credenciales de Facebook OAuth cargadas correctamente.');
+} catch (error) {
+  console.error('[ERROR] No se pudo validar Facebook OAuth.');
+  console.error(error.message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Cambio realizado

Se unificaron las rutas del backend para usar el prefijo `/api` en todo el sistema.

## Qué se hizo

- Las rutas reales del backend ahora se montan con `API_PREFIX=/api`.
- Autenticación queda como `/api/auth` en vez de `/auth`.
- Reportes queda como `/api/reportes` en vez de `/reportes`.
- Categorías queda como `/api/categorias` en vez de `/categorias`.
- Administración queda como `/api/admin` en vez de `/admin`.
- Health queda como `/api/health` en vez de `/health`.
- Se actualizó `GOOGLE_CALLBACK_URL` para usar `/api/auth/google/callback`.
- Se actualizó el `README.md` y las pruebas del backend para usar las rutas nuevas.

## Resultado

La ruta oficial ahora es `/api/...`, entonces ya no queda la inconsistencia entre backend y documentación.

## Verificación

- `GET /api/auth/google/url` responde correctamente.
- `GET /auth/google/url` ya no se usa como ruta válida.
