### PR TITLE
Pruebas CI con Tests

### DIFF
--- a/.github/workflows/Maven.yml
+++ b/.github/workflows/Maven.yml
@@ -9,6 +9,41 @@ jobs:
   backend-validation:
     name: Validate backend
     runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: green_alert_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+    env:
+      NODE_ENV: test
+      PORT: 3000
+      API_URL: http://localhost:3000
+      API_PREFIX: /api
+      API_PUBLIC_URL: http://localhost:3000
+      FRONTEND_URL: http://localhost:5173
+      JWT_SECRET: ci-test-secret
+      JWT_EXPIRES_IN: 15m
+      REFRESH_TOKEN_EXPIRES_DAYS: 7
+      DB_HOST: 127.0.0.1
+      DB_PORT: 3306
+      DB_USER: root
+      DB_PASSWORD: root
+      DB_NAME: green_alert_test
+      EMAIL_TRANSPORT: json
+      EMAIL_HOST: localhost
+      EMAIL_PORT: 587
+      EMAIL_USER: ci@example.com
+      EMAIL_PASS: ci-password
+      EMAIL_FROM: noreply@greenalert.test
+      EMAIL_TEST_TO: test@greenalert.test
 
     steps:
       - name: Checkout repository
@@ -22,6 +57,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Initialize test database
+        run: mysql -h 127.0.0.1 -uroot -proot green_alert_test < DATABASE_SCHEMA_COMPLETE.sql
+
       - name: Validate JavaScript syntax
         run: |
           find . \
@@ -29,10 +67,17 @@ jobs:
             -path ./.git -prune -o \
             -name "*.js" -print0 | xargs -0 -n1 node --check
 
-      - name: Run tests if configured
+      - name: Start backend server
         run: |
-          if node -e "const pkg = require('./package.json'); process.exit(pkg.scripts && pkg.scripts.test ? 0 : 1);"; then
-            npm test
-          else
-            echo "No standard test script configured; skipping tests."
-          fi
+          npm start > server.log 2>&1 &
+          for i in {1..30}; do
+            if curl --fail http://localhost:3000/api/health; then
+              exit 0
+            fi
+            sleep 2
+          done
+          cat server.log
+          exit 1
+
+      - name: Run tests
+        run: npm test

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "nodemon src/server.js",
     "start": "node src/server.js",
+    "test": "node tests/run-all.js",
     "test:email": "node tests/email/smtp-send.test.js"
   },
   "dependencies": {
@@ -17,6 +18,7 @@
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
     "mysql2": "^3.9.8",
+    "node-fetch": "^3.3.2",
     "nodemailer": "^8.0.5"
   },
   "devDependencies": {

--- a/src/services/email.service.js
+++ b/src/services/email.service.js
@@ -7,15 +7,19 @@ const getTransporter = () => {
   if (!cachedTransporter) {
     const { host, port, user, pass } = getEmailConfig();
 
-    cachedTransporter = nodemailer.createTransport({
-      host,
-      port,
-      secure: port === 465,
-      auth: {
-        user,
-        pass,
-      },
-    });
+    if (process.env.EMAIL_TRANSPORT === 'json') {
+      cachedTransporter = nodemailer.createTransport({ jsonTransport: true });
+    } else {
+      cachedTransporter = nodemailer.createTransport({
+        host,
+        port,
+        secure: port === 465,
+        auth: {
+          user,
+          pass,
+        },
+      });
+    }
   }
 
   return cachedTransporter;

--- a/tests/models/usuario.pagination.test.js
+++ b/tests/models/usuario.pagination.test.js
@@ -1,5 +1,6 @@
 import assert from 'assert';
-import UsuarioModel from '../../src/models/usuario.model.js';
+import { fileURLToPath } from 'url';
+import { UsuarioModel } from '../../src/models/usuario.model.js';
 
 const testName = 'Usuario Model - Pagination (LIMIT/OFFSET)';
 
@@ -149,3 +150,22 @@ export const tests = [
     }
   }
 ];
+
+const isMainModule = process.argv[1] === fileURLToPath(import.meta.url);
+
+if (isMainModule) {
+  let failed = 0;
+
+  for (const test of tests) {
+    try {
+      await test.run();
+      console.log(`[PASS] ${test.name}`);
+    } catch (error) {
+      failed++;
+      console.error(`[FAIL] ${test.name}`);
+      console.error(`  ${error.message}`);
+    }
+  }
+
+  process.exit(failed > 0 ? 1 : 0);
+}


### PR DESCRIPTION
Se configuró el CI del backend para que ejecute las pruebas existentes: se agregó `"test": "node tests/run-all.js"` en `Backend/package.json`, se actualizó `Backend/.github/workflows/Maven.yml` para levantar MySQL, cargar `DATABASE_SCHEMA_COMPLETE.sql`, definir las variables de entorno necesarias, iniciar el servidor y correr `npm test`; además se añadió soporte de email falso con `EMAIL_TRANSPORT=json` en `email.service.js` para no enviar correos reales en CI, se corrigió el import de `UsuarioModel` en `tests/models/usuario.pagination.test.js` y se declaró `node-fetch` como dependencia explícita porque los tests lo usan directamente.