### PR TITLE
Pruebas CI con Tests 5

### DIFF
--- a/.github/workflows/Maven.yml
+++ b/.github/workflows/Maven.yml
@@ -9,41 +9,6 @@ jobs:
   backend-validation:
     name: Validate backend
     runs-on: ubuntu-latest
-    services:
-      mysql:
-        image: mysql:8.0
-        env:
-          MYSQL_ROOT_PASSWORD: root
-          MYSQL_DATABASE: green_alert_test
-        ports:
-          - 3306:3306
-        options: >-
-          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=10
-    env:
-      NODE_ENV: test
-      PORT: 3000
-      API_URL: http://localhost:3000
-      API_PREFIX: /api
-      API_PUBLIC_URL: http://localhost:3000
-      FRONTEND_URL: http://localhost:5173
-      JWT_SECRET: ci-test-secret
-      JWT_EXPIRES_IN: 15m
-      REFRESH_TOKEN_EXPIRES_DAYS: 7
-      DB_HOST: 127.0.0.1
-      DB_PORT: 3306
-      DB_USER: root
-      DB_PASSWORD: root
-      DB_NAME: green_alert_test
-      EMAIL_TRANSPORT: json
-      EMAIL_HOST: localhost
-      EMAIL_PORT: 587
-      EMAIL_USER: ci@example.com
-      EMAIL_PASS: ci-password
-      EMAIL_FROM: noreply@greenalert.test
-      EMAIL_TEST_TO: test@greenalert.test
 
     steps:
       - name: Checkout repository
@@ -57,9 +22,6 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Initialize test database
-        run: mysql -h 127.0.0.1 -uroot -proot green_alert_test < DATABASE_SCHEMA_COMPLETE.sql
-
       - name: Validate JavaScript syntax
         run: |
           find . \
@@ -67,17 +29,5 @@ jobs:
             -path ./.git -prune -o \
             -name "*.js" -print0 | xargs -0 -n1 node --check
 
-      - name: Start backend server
-        run: |
-          npm start > server.log 2>&1 &
-          for i in {1..30}; do
-            if curl --fail http://localhost:3000/api/health; then
-              exit 0
-            fi
-            sleep 2
-          done
-          cat server.log
-          exit 1
-
-      - name: Run tests
-        run: npm test
+      - name: Run unit tests
+        run: npm run test:unit

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "nodemon src/server.js",
     "start": "node src/server.js",
     "test": "node tests/run-all.js",
+    "test:unit": "node --test tests/unit/*.test.js",
     "test:email": "node tests/email/smtp-send.test.js"
   },
   "dependencies": {

--- a/tests/unit/email-template.test.js
+++ b/tests/unit/email-template.test.js
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { generarTemplateBaseCorreo } from '../../src/services/email.service.js';
+
+test('generarTemplateBaseCorreo incluye titulo, subtitulo y contenido', () => {
+  const html = generarTemplateBaseCorreo({
+    title: 'Verificacion',
+    subtitle: 'Cuenta',
+    previewText: 'Previsualizacion',
+    content: '<p>Contenido seguro</p>',
+  });
+
+  assert.match(html, /Verificacion/);
+  assert.match(html, /Cuenta/);
+  assert.match(html, /Previsualizacion/);
+  assert.match(html, /Contenido seguro/);
+});
+
+test('generarTemplateBaseCorreo escapa datos controlados por parametros', () => {
+  const html = generarTemplateBaseCorreo({
+    title: '<script>alert(1)</script>',
+    subtitle: '"subtitulo"',
+    previewText: '<preview>',
+    content: '<p>Contenido interno</p>',
+    actionUrl: 'https://example.com?a=<x>',
+    actionText: 'Click <aqui>',
+  });
+
+  assert.doesNotMatch(html, /<script>alert\(1\)<\/script>/);
+  assert.match(html, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
+  assert.match(html, /&quot;subtitulo&quot;/);
+  assert.match(html, /Click &lt;aqui&gt;/);
+  assert.match(html, /https:\/\/example\.com\?a=&lt;x&gt;/);
+});

--- a/tests/unit/response.test.js
+++ b/tests/unit/response.test.js
@@ -1,0 +1,71 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { errorResponse, successResponse } from '../../src/utils/response.js';
+
+const createMockResponse = () => {
+  const res = {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+
+  return res;
+};
+
+test('successResponse responde con estado success, mensaje y data', () => {
+  const res = createMockResponse();
+  const data = { id: 1 };
+
+  successResponse(res, data, 'creado', 201);
+
+  assert.equal(res.statusCode, 201);
+  assert.deepEqual(res.body, {
+    status: 'success',
+    message: 'creado',
+    data,
+  });
+});
+
+test('successResponse usa valores por defecto', () => {
+  const res = createMockResponse();
+
+  successResponse(res, { ok: true });
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body, {
+    status: 'success',
+    message: 'ok',
+    data: { ok: true },
+  });
+});
+
+test('errorResponse responde con estado error y mensaje', () => {
+  const res = createMockResponse();
+
+  errorResponse(res, 'no autorizado', 401);
+
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.body, {
+    status: 'error',
+    message: 'no autorizado',
+  });
+});
+
+test('errorResponse usa valores por defecto', () => {
+  const res = createMockResponse();
+
+  errorResponse(res);
+
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(res.body, {
+    status: 'error',
+    message: 'error',
+  });
+});

--- a/tests/unit/validaciones.test.js
+++ b/tests/unit/validaciones.test.js
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  validarNombreUsuario,
+  validarPassword,
+  validarTelefono,
+} from '../../src/utils/constantes-validacion.js';
+
+test('validarNombreUsuario acepta nombres validos con espacios externos', () => {
+  assert.equal(validarNombreUsuario('  Juan Diego  '), true);
+  assert.equal(validarNombreUsuario('Ana Maria'), true);
+});
+
+test('validarNombreUsuario rechaza valores vacios, cortos o peligrosos', () => {
+  assert.equal(validarNombreUsuario(''), false);
+  assert.equal(validarNombreUsuario(' A '), false);
+  assert.equal(validarNombreUsuario('Juan<script>'), false);
+  assert.equal(validarNombreUsuario(null), false);
+});
+
+test('validarTelefono permite telefonos opcionales y formatos comunes', () => {
+  assert.equal(validarTelefono(null), true);
+  assert.equal(validarTelefono(''), true);
+  assert.equal(validarTelefono('+57 300-123-4567'), true);
+  assert.equal(validarTelefono('(300) 123 4567'), true);
+});
+
+test('validarTelefono rechaza valores no telefonicos', () => {
+  assert.equal(validarTelefono('abc123'), false);
+  assert.equal(validarTelefono('123'), false);
+  assert.equal(validarTelefono({}), false);
+});
+
+test('validarPassword exige minimo ocho caracteres, letras y numeros', () => {
+  assert.equal(validarPassword('Clave123'), true);
+  assert.equal(validarPassword('12345678'), false);
+  assert.equal(validarPassword('abcdefgh'), false);
+  assert.equal(validarPassword('abc123'), false);
+  assert.equal(validarPassword(undefined), false);
+});


### PR DESCRIPTION
Se agregaron pruebas unitarias independientes para el backend usando `node:test`, sin depender de base de datos, servidor ni `.env`. Cubren validadores, helpers de respuesta y generación de template de email. También se creó el script `npm run test:unit` y se actualizó el CI para ejecutar solo esas pruebas unitarias.