### PR TITLE
fix #138: unificar estado inicial de reportes como pendiente

### DIFF
--- a/DATABASE_SCHEMA_COMPLETE.sql
+++ b/DATABASE_SCHEMA_COMPLETE.sql
@@ -85,7 +85,7 @@ CREATE TABLE IF NOT EXISTS reportes (
   uuid VARCHAR(36) UNIQUE NOT NULL,
   id_usuario BIGINT UNSIGNED NOT NULL,
   tipo_contaminacion VARCHAR(50) NOT NULL,
-  estado ENUM('pendiente', 'en_revision', 'verificado', 'en_proceso', 'rechazado', 'resuelto') DEFAULT 'en_revision',
+  estado ENUM('pendiente', 'en_revision', 'verificado', 'en_proceso', 'rechazado', 'resuelto') DEFAULT 'pendiente',
   nivel_severidad ENUM('bajo', 'medio', 'alto', 'critico') DEFAULT 'medio',
   titulo VARCHAR(255) NOT NULL,
   descripcion TEXT NULL,

--- a/migrations/007_set_reportes_estado_default_pendiente.sql
+++ b/migrations/007_set_reportes_estado_default_pendiente.sql
@@ -1,0 +1,7 @@
+-- Migracion: alinear estado inicial de reportes con reglas de edicion
+-- Los reportes nuevos deben iniciar como 'pendiente' para que el creador
+-- pueda editarlos antes de que pasen a revision.
+
+ALTER TABLE reportes
+  MODIFY estado ENUM('pendiente', 'en_revision', 'verificado', 'en_proceso', 'rechazado', 'resuelto')
+  DEFAULT 'pendiente';

--- a/src/controllers/reporte.controller.js
+++ b/src/controllers/reporte.controller.js
@@ -1,4 +1,4 @@
-import { ReporteModel }   from '../models/reporte.model.js';
+import { ESTADO_INICIAL_REPORTE, ReporteModel } from '../models/reporte.model.js';
 import { UsuarioModel }   from '../models/usuario.model.js';
 import { EvidenciaModel } from '../models/evidencia.model.js';
 import { errorResponse, successResponse } from '../utils/response.js';
@@ -259,8 +259,8 @@ export const updateReporte = async (req, res, next) => {
       return errorResponse(res, 'No tienes permiso para editar este reporte.', 403);
     }
 
-    // Owners solo pueden editar reportes en estado 'pendiente'
-    if (isOwner && !isMod && reporte.estado !== 'pendiente') {
+    // Owners solo pueden editar reportes en estado inicial.
+    if (isOwner && !isMod && reporte.estado !== ESTADO_INICIAL_REPORTE) {
       return errorResponse(
         res,
         'No puedes editar un reporte que ya está en revisión o procesado.',
@@ -314,8 +314,8 @@ export const deleteReporte = async (req, res, next) => {
       return errorResponse(res, 'No tienes permiso para eliminar este reporte.', 403);
     }
 
-    // Owners solo pueden eliminar reportes en estado 'pendiente'
-    if (isOwner && !isMod && reporte.estado !== 'pendiente') {
+    // Owners solo pueden eliminar reportes en estado inicial.
+    if (isOwner && !isMod && reporte.estado !== ESTADO_INICIAL_REPORTE) {
       return errorResponse(
         res,
         'No puedes eliminar un reporte que ya está en revisión o procesado.',

--- a/src/models/reporte.model.js
+++ b/src/models/reporte.model.js
@@ -1,6 +1,8 @@
 import pool from '../config/database.js';
 import { randomUUID } from 'crypto';
 
+export const ESTADO_INICIAL_REPORTE = 'pendiente';
+
 export const ReporteModel = {
   
     // Lista reportes con filtros opcionales y paginación
@@ -175,15 +177,15 @@ export const ReporteModel = {
     if (hasCoords) {
       const [result] = await pool.execute(
         `INSERT INTO reportes
-           (uuid, id_usuario, tipo_contaminacion, nivel_severidad, titulo, descripcion,
+           (uuid, id_usuario, tipo_contaminacion, estado, nivel_severidad, titulo, descripcion,
             latitud, longitud, direccion, municipio, departamento, punto_geo)
          VALUES
-           (?, ?, ?, ?, ?, ?,
+           (?, ?, ?, ?, ?, ?, ?,
             ?, ?, ?, ?, ?,
             ST_GeomFromText(CONCAT('POINT(', ?, ' ', ?, ')'), 4326))`,
         [
           uuid,
-          id_usuario, tipo_contaminacion, nivel_severidad, titulo, descripcion,
+          id_usuario, tipo_contaminacion, ESTADO_INICIAL_REPORTE, nivel_severidad, titulo, descripcion,
           latitud, longitud, direccion, municipio, departamento,
           longitud, latitud,
         ]
@@ -192,11 +194,11 @@ export const ReporteModel = {
     } else {
       const [result] = await pool.execute(
         `INSERT INTO reportes
-           (uuid, id_usuario, tipo_contaminacion, nivel_severidad, titulo, descripcion,
+           (uuid, id_usuario, tipo_contaminacion, estado, nivel_severidad, titulo, descripcion,
             latitud, longitud, direccion, municipio, departamento)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         [uuid,
-         id_usuario, tipo_contaminacion, nivel_severidad, titulo, descripcion,
+         id_usuario, tipo_contaminacion, ESTADO_INICIAL_REPORTE, nivel_severidad, titulo, descripcion,
          null, null, direccion, municipio, departamento]
       );
       return result.insertId;

--- a/tests/unit/reporte-estado-inicial.test.js
+++ b/tests/unit/reporte-estado-inicial.test.js
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { ESTADO_INICIAL_REPORTE } from '../../src/models/reporte.model.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const backendRoot = path.resolve(path.dirname(__filename), '../..');
+
+const readBackendFile = (relativePath) => {
+  return fs.readFileSync(path.join(backendRoot, relativePath), 'utf8');
+};
+
+test('schema define pendiente como estado inicial de reportes', () => {
+  const schema = readBackendFile('DATABASE_SCHEMA_COMPLETE.sql');
+
+  assert.match(
+    schema,
+    /estado ENUM\('pendiente', 'en_revision', 'verificado', 'en_proceso', 'rechazado', 'resuelto'\) DEFAULT 'pendiente'/
+  );
+});
+
+test('modelo crea reportes nuevos con estado pendiente explicito', () => {
+  const model = readBackendFile('src/models/reporte.model.js');
+
+  const createStart = model.indexOf('create: async');
+  const updateStart = model.indexOf('update: async', createStart);
+  const createSection = model.slice(createStart, updateStart);
+
+  assert.match(createSection, /tipo_contaminacion, estado, nivel_severidad/);
+  assert.equal(ESTADO_INICIAL_REPORTE, 'pendiente');
+  assert.equal((createSection.match(/ESTADO_INICIAL_REPORTE/g) ?? []).length, 2);
+});
+
+test('controlador permite editar al propietario solo cuando el reporte esta pendiente', () => {
+  const controller = readBackendFile('src/controllers/reporte.controller.js');
+
+  assert.match(controller, /reporte\.estado !== ESTADO_INICIAL_REPORTE/);
+  assert.match(controller, /const allowed = isOwner\s*\?\s*\['titulo', 'descripcion', 'direccion', 'municipio', 'departamento'\]/);
+});


### PR DESCRIPTION
## Closes  #138 
**Descripción**
Se unificó el estado inicial de los reportes como `pendiente`.

Cambios realizados:
- El esquema ahora define `reportes.estado` con `DEFAULT 'pendiente'`.
- El modelo crea reportes nuevos explícitamente con estado `pendiente`.
- El controlador usa ese mismo estado inicial para permitir edición/eliminación al creador.
- Se agregó una migración para actualizar bases existentes.
- Se añadió una prueba unitaria para validar esquema, creación y edición.

Pruebas: `npm run test:unit` pasó correctamente con `14/14` tests.

<img width="880" height="620" alt="Image" src="https://github.com/user-attachments/assets/3e2b7e98-c40f-4d1e-9860-28c0e70611b8" />
