### PR TITLE
fix #139: validar categoria activar al crear resportes

### DIFF
--- a/DATABASE_SCHEMA_COMPLETE.sql
+++ b/DATABASE_SCHEMA_COMPLETE.sql
@@ -85,7 +85,7 @@ CREATE TABLE IF NOT EXISTS reportes (
   uuid VARCHAR(36) UNIQUE NOT NULL,
   id_usuario BIGINT UNSIGNED NOT NULL,
   tipo_contaminacion VARCHAR(50) NOT NULL,
-  estado ENUM('pendiente', 'en_revision', 'verificado', 'en_proceso', 'rechazado', 'resuelto') DEFAULT 'en_revision',
+  estado ENUM('pendiente', 'en_revision', 'verificado', 'en_proceso', 'rechazado', 'resuelto') DEFAULT 'pendiente',
   nivel_severidad ENUM('bajo', 'medio', 'alto', 'critico') DEFAULT 'medio',
   titulo VARCHAR(255) NOT NULL,
   descripcion TEXT NULL,

--- a/migrations/007_set_reportes_estado_default_pendiente.sql
+++ b/migrations/007_set_reportes_estado_default_pendiente.sql
@@ -1,0 +1,7 @@
+-- Migracion: alinear estado inicial de reportes con reglas de edicion
+-- Los reportes nuevos deben iniciar como 'pendiente' para que el creador
+-- pueda editarlos antes de que pasen a revision.
+
+ALTER TABLE reportes
+  MODIFY estado ENUM('pendiente', 'en_revision', 'verificado', 'en_proceso', 'rechazado', 'resuelto')
+  DEFAULT 'pendiente';

--- a/src/controllers/reporte.controller.js
+++ b/src/controllers/reporte.controller.js
@@ -1,4 +1,5 @@
 import { ESTADO_INICIAL_REPORTE, ReporteModel } from '../models/reporte.model.js';
+import { CategoriaRiesgoModel } from '../models/categoria-riesgo.model.js';
 import { UsuarioModel }   from '../models/usuario.model.js';
 import { EvidenciaModel } from '../models/evidencia.model.js';
 import { errorResponse, successResponse } from '../utils/response.js';
@@ -53,12 +54,19 @@ export const createReporte = async (req, res, next) => {
       return errorResponse(res, 'La dirección es requerida.', 400);
     }
 
+    const tipoContaminacion = tipo_contaminacion.trim().toLowerCase();
+    const categoriaValida = await CategoriaRiesgoModel.esValido(tipoContaminacion);
+
+    if (!categoriaValida) {
+      return errorResponse(res, 'La categoría de contaminación no existe o está inactiva.', 400);
+    }
+
     const lat = parseCoord(latitud);
     const lng = parseCoord(longitud);
 
     const idReporte = await ReporteModel.create({
       id_usuario:       req.user.sub,
-      tipo_contaminacion: tipo_contaminacion.trim(),
+      tipo_contaminacion: tipoContaminacion,
       nivel_severidad:    nivel_severidad.trim(),
       titulo:             titulo.trim(),
       descripcion:        descripcion?.trim() || null,

--- a/src/controllers/reporte.controller.js
+++ b/src/controllers/reporte.controller.js
@@ -1,4 +1,4 @@
-import { ReporteModel }   from '../models/reporte.model.js';
+import { ESTADO_INICIAL_REPORTE, ReporteModel } from '../models/reporte.model.js';
 import { UsuarioModel }   from '../models/usuario.model.js';
 import { EvidenciaModel } from '../models/evidencia.model.js';
 import { errorResponse, successResponse } from '../utils/response.js';
@@ -259,8 +259,8 @@ export const updateReporte = async (req, res, next) => {
       return errorResponse(res, 'No tienes permiso para editar este reporte.', 403);
     }
 
-    // Owners solo pueden editar reportes en estado 'pendiente'
-    if (isOwner && !isMod && reporte.estado !== 'pendiente') {
+    // Owners solo pueden editar reportes en estado inicial.
+    if (isOwner && !isMod && reporte.estado !== ESTADO_INICIAL_REPORTE) {
       return errorResponse(
         res,
         'No puedes editar un reporte que ya está en revisión o procesado.',
@@ -314,8 +314,8 @@ export const deleteReporte = async (req, res, next) => {
       return errorResponse(res, 'No tienes permiso para eliminar este reporte.', 403);
     }
 
-    // Owners solo pueden eliminar reportes en estado 'pendiente'
-    if (isOwner && !isMod && reporte.estado !== 'pendiente') {
+    // Owners solo pueden eliminar reportes en estado inicial.
+    if (isOwner && !isMod && reporte.estado !== ESTADO_INICIAL_REPORTE) {
       return errorResponse(
         res,
         'No puedes eliminar un reporte que ya está en revisión o procesado.',

--- a/src/models/categoria-riesgo.model.js
+++ b/src/models/categoria-riesgo.model.js
@@ -119,7 +119,7 @@ export const CategoriaRiesgoModel = {
    */
   esValido: async (codigo) => {
     try {
-      const categoria = await this.findByCodigo(codigo);
+      const categoria = await CategoriaRiesgoModel.findByCodigo(codigo);
       return categoria !== null;
     } catch (error) {
       console.error('Error en CategoriaRiesgoModel.esValido:', error);

--- a/src/models/reporte.model.js
+++ b/src/models/reporte.model.js
@@ -1,6 +1,8 @@
 import pool from '../config/database.js';
 import { randomUUID } from 'crypto';
 
+export const ESTADO_INICIAL_REPORTE = 'pendiente';
+
 export const ReporteModel = {
   
     // Lista reportes con filtros opcionales y paginación
@@ -175,15 +177,15 @@ export const ReporteModel = {
     if (hasCoords) {
       const [result] = await pool.execute(
         `INSERT INTO reportes
-           (uuid, id_usuario, tipo_contaminacion, nivel_severidad, titulo, descripcion,
+           (uuid, id_usuario, tipo_contaminacion, estado, nivel_severidad, titulo, descripcion,
             latitud, longitud, direccion, municipio, departamento, punto_geo)
          VALUES
-           (?, ?, ?, ?, ?, ?,
+           (?, ?, ?, ?, ?, ?, ?,
             ?, ?, ?, ?, ?,
             ST_GeomFromText(CONCAT('POINT(', ?, ' ', ?, ')'), 4326))`,
         [
           uuid,
-          id_usuario, tipo_contaminacion, nivel_severidad, titulo, descripcion,
+          id_usuario, tipo_contaminacion, ESTADO_INICIAL_REPORTE, nivel_severidad, titulo, descripcion,
           latitud, longitud, direccion, municipio, departamento,
           longitud, latitud,
         ]
@@ -192,11 +194,11 @@ export const ReporteModel = {
     } else {
       const [result] = await pool.execute(
         `INSERT INTO reportes
-           (uuid, id_usuario, tipo_contaminacion, nivel_severidad, titulo, descripcion,
+           (uuid, id_usuario, tipo_contaminacion, estado, nivel_severidad, titulo, descripcion,
             latitud, longitud, direccion, municipio, departamento)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         [uuid,
-         id_usuario, tipo_contaminacion, nivel_severidad, titulo, descripcion,
+         id_usuario, tipo_contaminacion, ESTADO_INICIAL_REPORTE, nivel_severidad, titulo, descripcion,
          null, null, direccion, municipio, departamento]
       );
       return result.insertId;

--- a/tests/unit/categoria-riesgo.test.js
+++ b/tests/unit/categoria-riesgo.test.js
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { CategoriaRiesgoModel } from '../../src/models/categoria-riesgo.model.js';
+
+test('CategoriaRiesgoModel.esValido retorna true cuando la categoria existe y esta activa', async (t) => {
+  t.mock.method(CategoriaRiesgoModel, 'findByCodigo', async (codigo) => ({
+    codigo,
+    activo: 1,
+  }));
+
+  assert.equal(await CategoriaRiesgoModel.esValido('inundacion'), true);
+  assert.equal(CategoriaRiesgoModel.findByCodigo.mock.callCount(), 1);
+});
+
+test('CategoriaRiesgoModel.esValido retorna false cuando la categoria no existe o esta inactiva', async (t) => {
+  t.mock.method(CategoriaRiesgoModel, 'findByCodigo', async () => null);
+
+  assert.equal(await CategoriaRiesgoModel.esValido('categoria_inexistente'), false);
+});

--- a/tests/unit/reporte-categoria-validacion.test.js
+++ b/tests/unit/reporte-categoria-validacion.test.js
@@ -1,0 +1,75 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createReporte } from '../../src/controllers/reporte.controller.js';
+import { CategoriaRiesgoModel } from '../../src/models/categoria-riesgo.model.js';
+import { ReporteModel } from '../../src/models/reporte.model.js';
+
+const createMockResponse = () => ({
+  statusCode: null,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+});
+
+const createValidRequest = (overrides = {}) => ({
+  user: { sub: 7 },
+  body: {
+    tipo_contaminacion: ' Inundacion ',
+    nivel_severidad: 'alto',
+    titulo: 'Reporte de inundacion',
+    descripcion: 'Nivel alto de agua en la zona',
+    direccion: 'Calle 10',
+    municipio: 'Valledupar',
+    departamento: 'Cesar',
+    latitud: 10.45,
+    longitud: -73.25,
+    ...overrides,
+  },
+});
+
+test('createReporte rechaza categoria inexistente o inactiva antes de insertar', async (t) => {
+  t.mock.method(CategoriaRiesgoModel, 'esValido', async () => false);
+  t.mock.method(ReporteModel, 'create', async () => {
+    throw new Error('No debe insertar reportes con categoria invalida');
+  });
+
+  const req = createValidRequest({ tipo_contaminacion: 'categoria_inexistente' });
+  const res = createMockResponse();
+  const next = t.mock.fn();
+
+  await createReporte(req, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.status, 'error');
+  assert.equal(res.body.message, 'La categoría de contaminación no existe o está inactiva.');
+  assert.equal(ReporteModel.create.mock.callCount(), 0);
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('createReporte crea reporte cuando la categoria existe y esta activa', async (t) => {
+  t.mock.method(CategoriaRiesgoModel, 'esValido', async () => true);
+  t.mock.method(ReporteModel, 'create', async () => 15);
+  t.mock.method(ReporteModel, 'findById', async () => ({
+    id_reporte: 15,
+    tipo_contaminacion: 'inundacion',
+    estado: 'pendiente',
+  }));
+
+  const req = createValidRequest();
+  const res = createMockResponse();
+  const next = t.mock.fn();
+
+  await createReporte(req, res, next);
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(res.body.status, 'success');
+  assert.equal(res.body.data.reporte.tipo_contaminacion, 'inundacion');
+  assert.equal(ReporteModel.create.mock.calls[0].arguments[0].tipo_contaminacion, 'inundacion');
+  assert.equal(next.mock.callCount(), 0);
+});

--- a/tests/unit/reporte-estado-inicial.test.js
+++ b/tests/unit/reporte-estado-inicial.test.js
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { ESTADO_INICIAL_REPORTE } from '../../src/models/reporte.model.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const backendRoot = path.resolve(path.dirname(__filename), '../..');
+
+const readBackendFile = (relativePath) => {
+  return fs.readFileSync(path.join(backendRoot, relativePath), 'utf8');
+};
+
+test('schema define pendiente como estado inicial de reportes', () => {
+  const schema = readBackendFile('DATABASE_SCHEMA_COMPLETE.sql');
+
+  assert.match(
+    schema,
+    /estado ENUM\('pendiente', 'en_revision', 'verificado', 'en_proceso', 'rechazado', 'resuelto'\) DEFAULT 'pendiente'/
+  );
+});
+
+test('modelo crea reportes nuevos con estado pendiente explicito', () => {
+  const model = readBackendFile('src/models/reporte.model.js');
+
+  const createStart = model.indexOf('create: async');
+  const updateStart = model.indexOf('update: async', createStart);
+  const createSection = model.slice(createStart, updateStart);
+
+  assert.match(createSection, /tipo_contaminacion, estado, nivel_severidad/);
+  assert.equal(ESTADO_INICIAL_REPORTE, 'pendiente');
+  assert.equal((createSection.match(/ESTADO_INICIAL_REPORTE/g) ?? []).length, 2);
+});
+
+test('controlador permite editar al propietario solo cuando el reporte esta pendiente', () => {
+  const controller = readBackendFile('src/controllers/reporte.controller.js');
+
+  assert.match(controller, /reporte\.estado !== ESTADO_INICIAL_REPORTE/);
+  assert.match(controller, /const allowed = isOwner\s*\?\s*\['titulo', 'descripcion', 'direccion', 'municipio', 'departamento'\]/);
+});


### PR DESCRIPTION
## Closes #139 
**Descripción**
Se reforzó la creación de reportes para evitar que se guarden con tipos de contaminación inexistentes o inactivos.

Primero se corrigió `CategoriaRiesgoModel.esValido`, que no estaba funcionando bien porque usaba `this.findByCodigo` dentro de una función arrow. Luego se conectó esa validación en `createReporte`, antes de llamar a `ReporteModel.create`.

Ahora el flujo es:
- Se recibe `tipo_contaminacion`.
- Se normaliza con `trim().toLowerCase()`.
- Se valida contra la tabla `categorias_riesgo`.
- Si la categoría no existe o está inactiva, el backend responde `400`.
- Si es válida, el reporte se crea normalmente.

También se agregaron pruebas unitarias para confirmar que una categoría inválida no inserta el reporte y que una categoría válida sí permite crearlo.

<img width="929" height="713" alt="Image" src="https://github.com/user-attachments/assets/444d3500-0357-4735-806d-5b9f1dd05f0b" />

