### PR TITLE
Ajustar prefijo de rutas del backend

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+.env
+.git
+.github
+coverage
+dist
+uploads
+tests
+docs
+*.log

--- a/.env.example
+++ b/.env.example
@@ -43,16 +43,16 @@ FRONTEND_URL=http://localhost:5173
 # Ver: GOOGLE_OAUTH_SETUP.md para obtener estas credenciales
 GOOGLE_CLIENT_ID=your_client_id_here.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your_client_secret_here
-GOOGLE_CALLBACK_URL=http://localhost:3000/api/auth/google/callback
+GOOGLE_CALLBACK_URL=http://localhost:3000/auth/google/callback
 
 # Facebook OAuth Configuration
 # Ver README.md para obtener estas credenciales
 FACEBOOK_APP_ID=your_facebook_app_id
 FACEBOOK_APP_SECRET=your_facebook_app_secret
-FACEBOOK_CALLBACK_URL=http://localhost:3000/api/auth/facebook/callback
+FACEBOOK_CALLBACK_URL=http://localhost:3000/auth/facebook/callback
 FACEBOOK_GRAPH_API_VERSION=v20.0
 FACEBOOK_CALLBACK_RESPONSE=json
 
 # API Configuration
-API_PREFIX=/api
+API_PREFIX=
 API_PUBLIC_URL=http://localhost:3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+COPY . .
+
+EXPOSE 3000
+
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ npm run test:email   # Ejecuta prueba SMTP, requiere configuracion de email
 | `FACEBOOK_CALLBACK_URL` | Callback backend de Facebook OAuth. |
 | `FACEBOOK_GRAPH_API_VERSION` | Version de Facebook Graph API. |
 | `FACEBOOK_CALLBACK_RESPONSE` | Modo de respuesta del callback de Facebook. |
-| `API_PREFIX` | Prefijo base de la API. Por defecto `/api`. |
+| `API_PREFIX` | Prefijo base opcional de la API. Por defecto vacio para desarrollo con Vite. |
 | `API_PUBLIC_URL` | URL publica del backend para enlaces enviados por email. |
 
 ## Estructura real
@@ -174,13 +174,17 @@ El backend incluye:
 
 ## Prefijo de API
 
-Todas las rutas se montan bajo `API_PREFIX`, que por defecto es `/api`.
+Por defecto `API_PREFIX` es vacio y las rutas se montan sin prefijo:
 
 Ejemplo:
 
 ```text
-http://localhost:3000/api/auth/login
+http://localhost:3000/auth/login
 ```
+
+En desarrollo, el frontend puede seguir llamando `/api/*` porque Vite reescribe ese prefijo antes de enviar la peticion al backend. Por ejemplo, `/api/reportes` en el navegador llega al backend como `/reportes`.
+
+Si necesitas publicar el backend directamente bajo `/api`, define `API_PREFIX=/api`. No se montan ambos prefijos al mismo tiempo.
 
 ## Rutas
 
@@ -188,57 +192,57 @@ http://localhost:3000/api/auth/login
 
 | Metodo | Ruta | Descripcion |
 | --- | --- | --- |
-| `GET` | `/api/health` | Verifica servidor y conexion a base de datos. |
+| `GET` | `/health` | Verifica servidor y conexion a base de datos. |
 
 ### Autenticacion
 
 | Metodo | Ruta | Protegida | Descripcion |
 | --- | --- | --- | --- |
-| `POST` | `/api/auth/register` | No | Registro de usuario. |
-| `POST` | `/api/auth/login` | No | Inicio de sesion con email y contrasena. |
-| `POST` | `/api/auth/refresh` | No | Renueva access token y rota refresh token. |
-| `POST` | `/api/auth/oauth/exchange` | No | Canjea codigo temporal OAuth por tokens backend. |
-| `POST` | `/api/auth/logout` | Parcial | Logout individual con refresh token; logout global requiere JWT. |
-| `GET` | `/api/auth/verify-email` | No | Verifica email por token de enlace. |
-| `POST` | `/api/auth/forgot-password` | No | Solicita recuperacion de contrasena. |
-| `POST` | `/api/auth/reset-password` | No | Restablece contrasena con token. |
-| `GET` | `/api/auth/perfil` | Si | Obtiene perfil del usuario autenticado. |
-| `PATCH` | `/api/auth/perfil` | Si | Actualiza perfil. |
-| `PATCH` | `/api/auth/cambiar-contrasena` | Si | Cambia contrasena y revoca refresh tokens. |
-| `PATCH` | `/api/auth/notificaciones` | Si | Actualiza preferencias de notificaciones. |
-| `POST` | `/api/auth/enviar-verificacion` | Si | Envia OTP de verificacion de email. |
-| `POST` | `/api/auth/verificar-email` | Si | Verifica OTP de email. |
-| `GET` | `/api/auth/google/url` | No | Genera URL de login con Google. |
-| `POST` | `/api/auth/google/login` | No | Login con `id_token` de Google. |
-| `GET` | `/api/auth/google/callback` | No | Callback OAuth de Google. |
-| `GET` | `/api/auth/facebook/url` | No | Genera URL de login con Facebook. |
-| `GET` | `/api/auth/facebook/callback` | No | Callback OAuth de Facebook. |
+| `POST` | `/auth/register` | No | Registro de usuario. |
+| `POST` | `/auth/login` | No | Inicio de sesion con email y contrasena. |
+| `POST` | `/auth/refresh` | No | Renueva access token y rota refresh token. |
+| `POST` | `/auth/oauth/exchange` | No | Canjea codigo temporal OAuth por tokens backend. |
+| `POST` | `/auth/logout` | Parcial | Logout individual con refresh token; logout global requiere JWT. |
+| `GET` | `/auth/verify-email` | No | Verifica email por token de enlace. |
+| `POST` | `/auth/forgot-password` | No | Solicita recuperacion de contrasena. |
+| `POST` | `/auth/reset-password` | No | Restablece contrasena con token. |
+| `GET` | `/auth/perfil` | Si | Obtiene perfil del usuario autenticado. |
+| `PATCH` | `/auth/perfil` | Si | Actualiza perfil. |
+| `PATCH` | `/auth/cambiar-contrasena` | Si | Cambia contrasena y revoca refresh tokens. |
+| `PATCH` | `/auth/notificaciones` | Si | Actualiza preferencias de notificaciones. |
+| `POST` | `/auth/enviar-verificacion` | Si | Envia OTP de verificacion de email. |
+| `POST` | `/auth/verificar-email` | Si | Verifica OTP de email. |
+| `GET` | `/auth/google/url` | No | Genera URL de login con Google. |
+| `POST` | `/auth/google/login` | No | Login con `id_token` de Google. |
+| `GET` | `/auth/google/callback` | No | Callback OAuth de Google. |
+| `GET` | `/auth/facebook/url` | No | Genera URL de login con Facebook. |
+| `GET` | `/auth/facebook/callback` | No | Callback OAuth de Facebook. |
 
 ### Reportes
 
 | Metodo | Ruta | Protegida | Descripcion |
 | --- | --- | --- | --- |
-| `GET` | `/api/reportes/stats` | No | Estadisticas generales de reportes. |
-| `GET` | `/api/reportes/stats/categoria` | No | Estadisticas por categoria. |
-| `GET` | `/api/reportes/stats/timeline` | No | Serie temporal de reportes. |
-| `GET` | `/api/reportes/stats/heatmap` | No | Puntos para heatmap. |
-| `GET` | `/api/reportes/export` | Si, admin o moderador | Exporta reportes. |
-| `GET` | `/api/reportes/mis-reportes` | Si | Lista reportes del usuario autenticado. |
-| `GET` | `/api/reportes` | No | Lista reportes con filtros. |
-| `GET` | `/api/reportes/:id` | No | Obtiene un reporte por ID. |
-| `POST` | `/api/reportes` | Si | Crea reporte, con archivo opcional en campo `file`. |
-| `PATCH` | `/api/reportes/:id` | Si | Actualiza reporte. |
-| `DELETE` | `/api/reportes/:id` | Si | Elimina reporte logicamente. |
+| `GET` | `/reportes/stats` | No | Estadisticas generales de reportes. |
+| `GET` | `/reportes/stats/categoria` | No | Estadisticas por categoria. |
+| `GET` | `/reportes/stats/timeline` | No | Serie temporal de reportes. |
+| `GET` | `/reportes/stats/heatmap` | No | Puntos para heatmap. |
+| `GET` | `/reportes/export` | Si, admin o moderador | Exporta reportes. |
+| `GET` | `/reportes/mis-reportes` | Si | Lista reportes del usuario autenticado. |
+| `GET` | `/reportes` | No | Lista reportes con filtros. |
+| `GET` | `/reportes/:id` | No | Obtiene un reporte por ID. |
+| `POST` | `/reportes` | Si | Crea reporte, con archivo opcional en campo `file`. |
+| `PATCH` | `/reportes/:id` | Si | Actualiza reporte. |
+| `DELETE` | `/reportes/:id` | Si | Elimina reporte logicamente. |
 
 ### Categorias de riesgo
 
 | Metodo | Ruta | Descripcion |
 | --- | --- | --- |
-| `GET` | `/api/categorias/estadisticas/resumen` | Resumen por categorias. |
-| `GET` | `/api/categorias/estadisticas/por-severidad` | Estadisticas por severidad. |
-| `GET` | `/api/categorias` | Lista categorias activas. |
-| `GET` | `/api/categorias/:codigo/reportes` | Reportes de una categoria. |
-| `GET` | `/api/categorias/:codigo` | Detalle de categoria. |
+| `GET` | `/categorias/estadisticas/resumen` | Resumen por categorias. |
+| `GET` | `/categorias/estadisticas/por-severidad` | Estadisticas por severidad. |
+| `GET` | `/categorias` | Lista categorias activas. |
+| `GET` | `/categorias/:codigo/reportes` | Reportes de una categoria. |
+| `GET` | `/categorias/:codigo` | Detalle de categoria. |
 
 ### Administracion
 
@@ -246,12 +250,12 @@ Todas las rutas de administracion requieren JWT con rol `admin`.
 
 | Metodo | Ruta | Descripcion |
 | --- | --- | --- |
-| `GET` | `/api/admin/usuarios/stats` | Estadisticas de usuarios y reportes. |
-| `GET` | `/api/admin/usuarios` | Lista usuarios. |
-| `GET` | `/api/admin/usuarios/:id` | Obtiene usuario por ID. |
-| `PATCH` | `/api/admin/usuarios/:id/rol` | Cambia rol de usuario. |
-| `PATCH` | `/api/admin/usuarios/:id/estado` | Activa o desactiva usuario. |
-| `DELETE` | `/api/admin/usuarios/:id` | Elimina usuario logicamente. |
+| `GET` | `/admin/usuarios/stats` | Estadisticas de usuarios y reportes. |
+| `GET` | `/admin/usuarios` | Lista usuarios. |
+| `GET` | `/admin/usuarios/:id` | Obtiene usuario por ID. |
+| `PATCH` | `/admin/usuarios/:id/rol` | Cambia rol de usuario. |
+| `PATCH` | `/admin/usuarios/:id/estado` | Activa o desactiva usuario. |
+| `DELETE` | `/admin/usuarios/:id` | Elimina usuario logicamente. |
 
 ## OAuth
 
@@ -259,12 +263,12 @@ El backend soporta Google y Facebook.
 
 Flujo recomendado con callbacks:
 
-1. El frontend solicita `/api/auth/google/url` o `/api/auth/facebook/url`.
+1. El frontend solicita `/api/auth/google/url` o `/api/auth/facebook/url` en desarrollo con Vite, que reescribe a `/auth/google/url` o `/auth/facebook/url` en el backend.
 2. El usuario autentica con el proveedor.
 3. El proveedor redirige al callback backend.
 4. El backend crea o vincula el usuario.
 5. El backend redirige al frontend con un codigo temporal en el fragmento `#oauth_code=...`.
-6. El frontend canjea ese codigo en `/api/auth/oauth/exchange`.
+6. El frontend canjea ese codigo en `/api/auth/oauth/exchange`; Vite lo reescribe a `/auth/oauth/exchange`.
 
 Los access tokens y refresh tokens del backend no se envian por query string.
 
@@ -289,7 +293,7 @@ Los archivos se sirven desde `/uploads`.
 
 ## Preferencias de notificaciones
 
-El endpoint `PATCH /api/auth/notificaciones` persiste las preferencias en `usuarios.notification_preferences`.
+El endpoint `PATCH /auth/notificaciones` persiste las preferencias en `usuarios.notification_preferences`.
 
 Estructura soportada:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,9 @@ node tests/run-all.js config
 
 ## 📊 Contenido por Categoría
 
+### Mejoras Backend
+- `DOCKER_SERVICIOS.md` - Dockerizacion individual de servicios backend sin Docker Compose.
+
 ### 🧪 Tests Automatizados
 - `tests/EMAIL_CONFIG.md` - 8 tests de configuración
 - `tests/EMAIL_VERIFICATION.md` - Tests de verificación

--- a/src/app.js
+++ b/src/app.js
@@ -10,15 +10,10 @@ import adminRouter from '../routes/admin.routes.js';
 import chatbotRouter from '../routes/chatbot.routes.js';
 import { getCorsOptions, getHelmetOptions } from './config/security.config.js';
 import { getUploadDir } from './config/upload.config.js';
+import { getApiPrefix } from './config/api-prefix.config.js';
 
 const app = express();
-const normalizeApiPrefix = (prefix = '/api') => {
-  const trimmedPrefix = prefix.trim();
-  const withLeadingSlash = trimmedPrefix.startsWith('/') ? trimmedPrefix : `/${trimmedPrefix}`;
-  return withLeadingSlash.replace(/\/+$/, '') || '/api';
-};
-
-const apiPrefix = normalizeApiPrefix(process.env.API_PREFIX);
+const apiPrefix = getApiPrefix();
 
 app.use(helmet(getHelmetOptions()));
 app.use(cors(getCorsOptions()));

--- a/src/config/api-prefix.config.js
+++ b/src/config/api-prefix.config.js
@@ -1,0 +1,11 @@
+export const normalizeApiPrefix = (prefix) => {
+  if (typeof prefix !== 'string') return '';
+
+  const trimmedPrefix = prefix.trim();
+  if (!trimmedPrefix || trimmedPrefix === '/') return '';
+
+  const withLeadingSlash = trimmedPrefix.startsWith('/') ? trimmedPrefix : `/${trimmedPrefix}`;
+  return withLeadingSlash.replace(/\/+$/, '');
+};
+
+export const getApiPrefix = () => normalizeApiPrefix(process.env.API_PREFIX);

--- a/src/config/facebook.config.js
+++ b/src/config/facebook.config.js
@@ -8,7 +8,7 @@ const validateFacebookConfig = () => {
   const config = {
     appId: process.env.FACEBOOK_APP_ID,
     appSecret: process.env.FACEBOOK_APP_SECRET,
-    callbackUrl: process.env.FACEBOOK_CALLBACK_URL || 'http://localhost:3000/api/auth/facebook/callback',
+    callbackUrl: process.env.FACEBOOK_CALLBACK_URL || 'http://localhost:3000/auth/facebook/callback',
     graphApiVersion: process.env.FACEBOOK_GRAPH_API_VERSION || 'v20.0',
   };
 

--- a/src/config/google.config.js
+++ b/src/config/google.config.js
@@ -7,7 +7,7 @@ const validateGoogleConfig = () => {
   const config = {
     clientId: process.env.GOOGLE_CLIENT_ID,
     clientSecret: process.env.GOOGLE_CLIENT_SECRET,
-    callbackUrl: process.env.GOOGLE_CALLBACK_URL || 'http://localhost:3000/api/auth/google/callback',
+    callbackUrl: process.env.GOOGLE_CALLBACK_URL || 'http://localhost:3000/auth/google/callback',
   };
 
   const missingVars = [];
@@ -34,7 +34,7 @@ const validateGoogleConfig = () => {
 
 export const getGoogleAuthUrlConfig = () => ({
   clientId: process.env.GOOGLE_CLIENT_ID || 'your_client_id_here.apps.googleusercontent.com',
-  callbackUrl: process.env.GOOGLE_CALLBACK_URL || 'http://localhost:3000/api/auth/google/callback',
+  callbackUrl: process.env.GOOGLE_CALLBACK_URL || 'http://localhost:3000/auth/google/callback',
   isConfigured: Boolean(process.env.GOOGLE_CLIENT_ID),
 });
 

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -22,6 +22,7 @@ import {
   consumeOAuthCallbackCode,
   createOAuthCallbackCode,
 } from '../services/oauth-callback-code.service.js';
+import { getApiPrefix } from '../config/api-prefix.config.js';
 
 /**
  * ESTRATEGIA DE AUTENTICACIÓN CON FACEBOOK
@@ -253,7 +254,7 @@ const getVerificationTokenExpiration = () => {
 
 const buildEmailVerificationLink = (token) => {
   const apiBaseUrl = process.env.API_PUBLIC_URL || `http://localhost:${process.env.PORT || 3000}`;
-  const apiPrefix = (process.env.API_PREFIX || '/api').replace(/\/+$/, '');
+  const apiPrefix = getApiPrefix();
   return `${apiBaseUrl}${apiPrefix}/auth/verify-email?token=${token}`;
 };
 

--- a/tests/unit/route-prefix.test.js
+++ b/tests/unit/route-prefix.test.js
@@ -1,0 +1,73 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+
+process.env.API_PREFIX = '';
+
+const { default: pool } = await import('../../src/config/database.js');
+pool.query = async () => [[{ ok: 1 }], []];
+pool.execute = async (sql) => {
+  if (String(sql).includes('FROM reportes')) {
+    return [[{
+      total_reportes: 0,
+      reportes_este_mes: 0,
+      en_revision: 0,
+      resueltos: 0,
+      municipios_activos: 0,
+      con_seguimiento: 0,
+    }], []];
+  }
+
+  if (String(sql).includes('FROM usuarios')) {
+    return [[{ total_usuarios: 0 }], []];
+  }
+
+  return [[], []];
+};
+
+const { default: app } = await import('../../src/app.js');
+const { normalizeApiPrefix } = await import('../../src/config/api-prefix.config.js');
+
+const listen = () => new Promise((resolve) => {
+  const server = http.createServer(app);
+  server.listen(0, () => resolve(server));
+});
+
+const close = (server) => new Promise((resolve, reject) => {
+  server.close((error) => (error ? reject(error) : resolve()));
+});
+
+const request = async (server, path, options = {}) => {
+  const { port } = server.address();
+  return fetch(`http://127.0.0.1:${port}${path}`, options);
+};
+
+test('API_PREFIX por defecto monta rutas sin prefijo para el proxy de Vite', async () => {
+  const server = await listen();
+
+  try {
+    const health = await request(server, '/health');
+    const stats = await request(server, '/reportes/stats');
+    const login = await request(server, '/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    const prefixedHealth = await request(server, '/api/health');
+
+    assert.equal(health.status, 200);
+    assert.equal(stats.status, 200);
+    assert.equal(login.status, 400);
+    assert.equal(prefixedHealth.status, 404);
+  } finally {
+    await close(server);
+  }
+});
+
+test('normaliza API_PREFIX vacio, raiz o con barras sin forzar /api', () => {
+  assert.equal(normalizeApiPrefix(undefined), '');
+  assert.equal(normalizeApiPrefix(''), '');
+  assert.equal(normalizeApiPrefix('/'), '');
+  assert.equal(normalizeApiPrefix('api'), '/api');
+  assert.equal(normalizeApiPrefix('/api/'), '/api');
+});


### PR DESCRIPTION
## Closes #199 - Compatibilidad de rutas y contrato HTTP

### Resumen

Alinea el montaje de rutas del backend con el contrato que consume el frontend en desarrollo. El frontend sigue llamando `/api/*`, pero Vite reescribe ese prefijo antes de enviar la peticion al backend, por lo que el backend ahora responde sin prefijo por defecto.

### Cambios

- Monta rutas sin prefijo por defecto: `/health`, `/auth`, `/reportes`, `/categorias`, `/admin`, `/chatbot`.
- Mantiene `/uploads` sin prefijo.
- Permite configurar `API_PREFIX=/api` solo si se necesita, sin montar rutas duplicadas.
- Actualiza `.env`, `.env.example`, callbacks OAuth y README para reflejar el contrato correcto.
- Agrega test de contrato para validar `/health`, `/reportes/stats`, `/auth/login` y que `/api/health` no responda cuando no se configura prefijo.

<img width="949" height="912" alt="image" src="https://github.com/user-attachments/assets/b5624f7a-4a5d-474d-9aa7-bd9a5075816e" />
