### PR TITLE
200 auth opcional endpoints publicos

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+.env
+.git
+.github
+coverage
+dist
+uploads
+tests
+docs
+*.log

--- a/.env.example
+++ b/.env.example
@@ -43,16 +43,16 @@ FRONTEND_URL=http://localhost:5173
 # Ver: GOOGLE_OAUTH_SETUP.md para obtener estas credenciales
 GOOGLE_CLIENT_ID=your_client_id_here.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your_client_secret_here
-GOOGLE_CALLBACK_URL=http://localhost:3000/api/auth/google/callback
+GOOGLE_CALLBACK_URL=http://localhost:3000/auth/google/callback
 
 # Facebook OAuth Configuration
 # Ver README.md para obtener estas credenciales
 FACEBOOK_APP_ID=your_facebook_app_id
 FACEBOOK_APP_SECRET=your_facebook_app_secret
-FACEBOOK_CALLBACK_URL=http://localhost:3000/api/auth/facebook/callback
+FACEBOOK_CALLBACK_URL=http://localhost:3000/auth/facebook/callback
 FACEBOOK_GRAPH_API_VERSION=v20.0
 FACEBOOK_CALLBACK_RESPONSE=json
 
 # API Configuration
-API_PREFIX=/api
+API_PREFIX=
 API_PUBLIC_URL=http://localhost:3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+COPY . .
+
+EXPOSE 3000
+
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ npm run test:email   # Ejecuta prueba SMTP, requiere configuracion de email
 | `FACEBOOK_CALLBACK_URL` | Callback backend de Facebook OAuth. |
 | `FACEBOOK_GRAPH_API_VERSION` | Version de Facebook Graph API. |
 | `FACEBOOK_CALLBACK_RESPONSE` | Modo de respuesta del callback de Facebook. |
-| `API_PREFIX` | Prefijo base de la API. Por defecto `/api`. |
+| `API_PREFIX` | Prefijo base opcional de la API. Por defecto vacio para desarrollo con Vite. |
 | `API_PUBLIC_URL` | URL publica del backend para enlaces enviados por email. |
 
 ## Estructura real
@@ -174,13 +174,17 @@ El backend incluye:
 
 ## Prefijo de API
 
-Todas las rutas se montan bajo `API_PREFIX`, que por defecto es `/api`.
+Por defecto `API_PREFIX` es vacio y las rutas se montan sin prefijo:
 
 Ejemplo:
 
 ```text
-http://localhost:3000/api/auth/login
+http://localhost:3000/auth/login
 ```
+
+En desarrollo, el frontend puede seguir llamando `/api/*` porque Vite reescribe ese prefijo antes de enviar la peticion al backend. Por ejemplo, `/api/reportes` en el navegador llega al backend como `/reportes`.
+
+Si necesitas publicar el backend directamente bajo `/api`, define `API_PREFIX=/api`. No se montan ambos prefijos al mismo tiempo.
 
 ## Rutas
 
@@ -188,57 +192,57 @@ http://localhost:3000/api/auth/login
 
 | Metodo | Ruta | Descripcion |
 | --- | --- | --- |
-| `GET` | `/api/health` | Verifica servidor y conexion a base de datos. |
+| `GET` | `/health` | Verifica servidor y conexion a base de datos. |
 
 ### Autenticacion
 
 | Metodo | Ruta | Protegida | Descripcion |
 | --- | --- | --- | --- |
-| `POST` | `/api/auth/register` | No | Registro de usuario. |
-| `POST` | `/api/auth/login` | No | Inicio de sesion con email y contrasena. |
-| `POST` | `/api/auth/refresh` | No | Renueva access token y rota refresh token. |
-| `POST` | `/api/auth/oauth/exchange` | No | Canjea codigo temporal OAuth por tokens backend. |
-| `POST` | `/api/auth/logout` | Parcial | Logout individual con refresh token; logout global requiere JWT. |
-| `GET` | `/api/auth/verify-email` | No | Verifica email por token de enlace. |
-| `POST` | `/api/auth/forgot-password` | No | Solicita recuperacion de contrasena. |
-| `POST` | `/api/auth/reset-password` | No | Restablece contrasena con token. |
-| `GET` | `/api/auth/perfil` | Si | Obtiene perfil del usuario autenticado. |
-| `PATCH` | `/api/auth/perfil` | Si | Actualiza perfil. |
-| `PATCH` | `/api/auth/cambiar-contrasena` | Si | Cambia contrasena y revoca refresh tokens. |
-| `PATCH` | `/api/auth/notificaciones` | Si | Actualiza preferencias de notificaciones. |
-| `POST` | `/api/auth/enviar-verificacion` | Si | Envia OTP de verificacion de email. |
-| `POST` | `/api/auth/verificar-email` | Si | Verifica OTP de email. |
-| `GET` | `/api/auth/google/url` | No | Genera URL de login con Google. |
-| `POST` | `/api/auth/google/login` | No | Login con `id_token` de Google. |
-| `GET` | `/api/auth/google/callback` | No | Callback OAuth de Google. |
-| `GET` | `/api/auth/facebook/url` | No | Genera URL de login con Facebook. |
-| `GET` | `/api/auth/facebook/callback` | No | Callback OAuth de Facebook. |
+| `POST` | `/auth/register` | No | Registro de usuario. |
+| `POST` | `/auth/login` | No | Inicio de sesion con email y contrasena. |
+| `POST` | `/auth/refresh` | No | Renueva access token y rota refresh token. |
+| `POST` | `/auth/oauth/exchange` | No | Canjea codigo temporal OAuth por tokens backend. |
+| `POST` | `/auth/logout` | Parcial | Logout individual con refresh token; logout global requiere JWT. |
+| `GET` | `/auth/verify-email` | No | Verifica email por token de enlace. |
+| `POST` | `/auth/forgot-password` | No | Solicita recuperacion de contrasena. |
+| `POST` | `/auth/reset-password` | No | Restablece contrasena con token. |
+| `GET` | `/auth/perfil` | Si | Obtiene perfil del usuario autenticado. |
+| `PATCH` | `/auth/perfil` | Si | Actualiza perfil. |
+| `PATCH` | `/auth/cambiar-contrasena` | Si | Cambia contrasena y revoca refresh tokens. |
+| `PATCH` | `/auth/notificaciones` | Si | Actualiza preferencias de notificaciones. |
+| `POST` | `/auth/enviar-verificacion` | Si | Envia OTP de verificacion de email. |
+| `POST` | `/auth/verificar-email` | Si | Verifica OTP de email. |
+| `GET` | `/auth/google/url` | No | Genera URL de login con Google. |
+| `POST` | `/auth/google/login` | No | Login con `id_token` de Google. |
+| `GET` | `/auth/google/callback` | No | Callback OAuth de Google. |
+| `GET` | `/auth/facebook/url` | No | Genera URL de login con Facebook. |
+| `GET` | `/auth/facebook/callback` | No | Callback OAuth de Facebook. |
 
 ### Reportes
 
 | Metodo | Ruta | Protegida | Descripcion |
 | --- | --- | --- | --- |
-| `GET` | `/api/reportes/stats` | No | Estadisticas generales de reportes. |
-| `GET` | `/api/reportes/stats/categoria` | No | Estadisticas por categoria. |
-| `GET` | `/api/reportes/stats/timeline` | No | Serie temporal de reportes. |
-| `GET` | `/api/reportes/stats/heatmap` | No | Puntos para heatmap. |
-| `GET` | `/api/reportes/export` | Si, admin o moderador | Exporta reportes. |
-| `GET` | `/api/reportes/mis-reportes` | Si | Lista reportes del usuario autenticado. |
-| `GET` | `/api/reportes` | No | Lista reportes con filtros. |
-| `GET` | `/api/reportes/:id` | No | Obtiene un reporte por ID. |
-| `POST` | `/api/reportes` | Si | Crea reporte, con archivo opcional en campo `file`. |
-| `PATCH` | `/api/reportes/:id` | Si | Actualiza reporte. |
-| `DELETE` | `/api/reportes/:id` | Si | Elimina reporte logicamente. |
+| `GET` | `/reportes/stats` | No | Estadisticas generales de reportes. |
+| `GET` | `/reportes/stats/categoria` | No | Estadisticas por categoria. |
+| `GET` | `/reportes/stats/timeline` | No | Serie temporal de reportes. |
+| `GET` | `/reportes/stats/heatmap` | No | Puntos para heatmap. |
+| `GET` | `/reportes/export` | Si, admin o moderador | Exporta reportes. |
+| `GET` | `/reportes/mis-reportes` | Si | Lista reportes del usuario autenticado. |
+| `GET` | `/reportes` | No | Lista reportes con filtros. |
+| `GET` | `/reportes/:id` | No | Obtiene un reporte por ID. |
+| `POST` | `/reportes` | Si | Crea reporte, con archivo opcional en campo `file`. |
+| `PATCH` | `/reportes/:id` | Si | Actualiza reporte. |
+| `DELETE` | `/reportes/:id` | Si | Elimina reporte logicamente. |
 
 ### Categorias de riesgo
 
 | Metodo | Ruta | Descripcion |
 | --- | --- | --- |
-| `GET` | `/api/categorias/estadisticas/resumen` | Resumen por categorias. |
-| `GET` | `/api/categorias/estadisticas/por-severidad` | Estadisticas por severidad. |
-| `GET` | `/api/categorias` | Lista categorias activas. |
-| `GET` | `/api/categorias/:codigo/reportes` | Reportes de una categoria. |
-| `GET` | `/api/categorias/:codigo` | Detalle de categoria. |
+| `GET` | `/categorias/estadisticas/resumen` | Resumen por categorias. |
+| `GET` | `/categorias/estadisticas/por-severidad` | Estadisticas por severidad. |
+| `GET` | `/categorias` | Lista categorias activas. |
+| `GET` | `/categorias/:codigo/reportes` | Reportes de una categoria. |
+| `GET` | `/categorias/:codigo` | Detalle de categoria. |
 
 ### Administracion
 
@@ -246,12 +250,12 @@ Todas las rutas de administracion requieren JWT con rol `admin`.
 
 | Metodo | Ruta | Descripcion |
 | --- | --- | --- |
-| `GET` | `/api/admin/usuarios/stats` | Estadisticas de usuarios y reportes. |
-| `GET` | `/api/admin/usuarios` | Lista usuarios. |
-| `GET` | `/api/admin/usuarios/:id` | Obtiene usuario por ID. |
-| `PATCH` | `/api/admin/usuarios/:id/rol` | Cambia rol de usuario. |
-| `PATCH` | `/api/admin/usuarios/:id/estado` | Activa o desactiva usuario. |
-| `DELETE` | `/api/admin/usuarios/:id` | Elimina usuario logicamente. |
+| `GET` | `/admin/usuarios/stats` | Estadisticas de usuarios y reportes. |
+| `GET` | `/admin/usuarios` | Lista usuarios. |
+| `GET` | `/admin/usuarios/:id` | Obtiene usuario por ID. |
+| `PATCH` | `/admin/usuarios/:id/rol` | Cambia rol de usuario. |
+| `PATCH` | `/admin/usuarios/:id/estado` | Activa o desactiva usuario. |
+| `DELETE` | `/admin/usuarios/:id` | Elimina usuario logicamente. |
 
 ## OAuth
 
@@ -259,12 +263,12 @@ El backend soporta Google y Facebook.
 
 Flujo recomendado con callbacks:
 
-1. El frontend solicita `/api/auth/google/url` o `/api/auth/facebook/url`.
+1. El frontend solicita `/api/auth/google/url` o `/api/auth/facebook/url` en desarrollo con Vite, que reescribe a `/auth/google/url` o `/auth/facebook/url` en el backend.
 2. El usuario autentica con el proveedor.
 3. El proveedor redirige al callback backend.
 4. El backend crea o vincula el usuario.
 5. El backend redirige al frontend con un codigo temporal en el fragmento `#oauth_code=...`.
-6. El frontend canjea ese codigo en `/api/auth/oauth/exchange`.
+6. El frontend canjea ese codigo en `/api/auth/oauth/exchange`; Vite lo reescribe a `/auth/oauth/exchange`.
 
 Los access tokens y refresh tokens del backend no se envian por query string.
 
@@ -289,7 +293,7 @@ Los archivos se sirven desde `/uploads`.
 
 ## Preferencias de notificaciones
 
-El endpoint `PATCH /api/auth/notificaciones` persiste las preferencias en `usuarios.notification_preferences`.
+El endpoint `PATCH /auth/notificaciones` persiste las preferencias en `usuarios.notification_preferences`.
 
 Estructura soportada:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,9 @@ node tests/run-all.js config
 
 ## 📊 Contenido por Categoría
 
+### Mejoras Backend
+- `DOCKER_SERVICIOS.md` - Dockerizacion individual de servicios backend sin Docker Compose.
+
 ### 🧪 Tests Automatizados
 - `tests/EMAIL_CONFIG.md` - 8 tests de configuración
 - `tests/EMAIL_VERIFICATION.md` - Tests de verificación

--- a/middlewares/auth.middleware.js
+++ b/middlewares/auth.middleware.js
@@ -1,9 +1,15 @@
 import jwt from 'jsonwebtoken';
 
+const getBearerToken = (req) => {
+  const authHeader = req.headers['authorization'];
+  const [scheme, token] = typeof authHeader === 'string' ? authHeader.split(' ') : [];
+
+  return scheme?.toLowerCase() === 'bearer' && token ? token : null;
+};
+
 // protege rutas privadas verificando el token bearer
 export const verifyToken = (req, res, next) => {
-  const authHeader = req.headers['authorization'];
-  const token = authHeader && authHeader.split(' ')[1];
+  const token = getBearerToken(req);
 
   if (!token) {
     return res.status(401).json({
@@ -21,6 +27,23 @@ export const verifyToken = (req, res, next) => {
       message: 'token inválido o expirado.',
     });
   }
+};
+
+export const optionalAuth = (req, _res, next) => {
+  const token = getBearerToken(req);
+
+  if (!token) {
+    delete req.user;
+    return next();
+  }
+
+  try {
+    req.user = jwt.verify(token, process.env.JWT_SECRET);
+  } catch {
+    delete req.user;
+  }
+
+  return next();
 };
 
 export const verifyTokenWhenAllDevicesLogout = (req, res, next) => {

--- a/routes/chatbot.routes.js
+++ b/routes/chatbot.routes.js
@@ -3,10 +3,11 @@ import {
   enviarMensajeChatbot,
   obtenerFaqsChatbot,
 } from '../src/controllers/chatbot.controller.js';
+import { optionalAuth } from '../middlewares/auth.middleware.js';
 
 const chatbotRouter = Router();
 
-chatbotRouter.post('/mensaje', enviarMensajeChatbot);
+chatbotRouter.post('/mensaje', optionalAuth, enviarMensajeChatbot);
 chatbotRouter.get('/faqs', obtenerFaqsChatbot);
 
 export default chatbotRouter;

--- a/routes/reporte.routes.js
+++ b/routes/reporte.routes.js
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { verifyToken, requireRoles } from '../middlewares/auth.middleware.js';
+import { optionalAuth, verifyToken, requireRoles } from '../middlewares/auth.middleware.js';
 import { upload } from '../middlewares/upload.middleware.js';
 import { validatePositiveIdParam } from '../middlewares/validate-id.middleware.js';
 import {
@@ -35,11 +35,11 @@ reporteRouter.get('/stats/heatmap', getHeatmapPoints);
 reporteRouter.get('/stats/ia', verifyToken, requireRoles('admin', 'moderador'), getStatsIA);
 reporteRouter.get('/zonas-riesgo', verifyToken, requireRoles('admin', 'moderador'), getZonasRiesgo);
 reporteRouter.get('/alertas-predictivas', getAlertasPredictivas);
-reporteRouter.get('/trending', getTrendingReportes);
+reporteRouter.get('/trending', optionalAuth, getTrendingReportes);
 reporteRouter.get('/export', verifyToken, requireRoles('admin', 'moderador'), exportReportes);
 reporteRouter.get('/mis-reportes', verifyToken, getMisReportes);
 reporteRouter.post('/analizar-imagen', verifyToken, upload.single('imagen'), analizarImagen);
-reporteRouter.get('/',      getReportes);
+reporteRouter.get('/', optionalAuth, getReportes);
 reporteRouter.post('/:id/like', validatePositiveIdParam('id'), verifyToken, toggleLikeReporte);
 reporteRouter.get('/:id/evidencias', validatePositiveIdParam('id'), verifyToken, listEvidenciasReporte);
 reporteRouter.post('/:id/evidencias', validatePositiveIdParam('id'), verifyToken, upload.single('file'), addEvidenciaReporte);
@@ -50,7 +50,7 @@ reporteRouter.delete(
   verifyToken,
   deleteEvidenciaReporte
 );
-reporteRouter.get('/:id',   validatePositiveIdParam('id'), getReporteById);
+reporteRouter.get('/:id', validatePositiveIdParam('id'), optionalAuth, getReporteById);
 reporteRouter.post(
   '/',
   verifyToken,

--- a/src/app.js
+++ b/src/app.js
@@ -10,15 +10,10 @@ import adminRouter from '../routes/admin.routes.js';
 import chatbotRouter from '../routes/chatbot.routes.js';
 import { getCorsOptions, getHelmetOptions } from './config/security.config.js';
 import { getUploadDir } from './config/upload.config.js';
+import { getApiPrefix } from './config/api-prefix.config.js';
 
 const app = express();
-const normalizeApiPrefix = (prefix = '/api') => {
-  const trimmedPrefix = prefix.trim();
-  const withLeadingSlash = trimmedPrefix.startsWith('/') ? trimmedPrefix : `/${trimmedPrefix}`;
-  return withLeadingSlash.replace(/\/+$/, '') || '/api';
-};
-
-const apiPrefix = normalizeApiPrefix(process.env.API_PREFIX);
+const apiPrefix = getApiPrefix();
 
 app.use(helmet(getHelmetOptions()));
 app.use(cors(getCorsOptions()));

--- a/src/config/api-prefix.config.js
+++ b/src/config/api-prefix.config.js
@@ -1,0 +1,11 @@
+export const normalizeApiPrefix = (prefix) => {
+  if (typeof prefix !== 'string') return '';
+
+  const trimmedPrefix = prefix.trim();
+  if (!trimmedPrefix || trimmedPrefix === '/') return '';
+
+  const withLeadingSlash = trimmedPrefix.startsWith('/') ? trimmedPrefix : `/${trimmedPrefix}`;
+  return withLeadingSlash.replace(/\/+$/, '');
+};
+
+export const getApiPrefix = () => normalizeApiPrefix(process.env.API_PREFIX);

--- a/src/config/facebook.config.js
+++ b/src/config/facebook.config.js
@@ -8,7 +8,7 @@ const validateFacebookConfig = () => {
   const config = {
     appId: process.env.FACEBOOK_APP_ID,
     appSecret: process.env.FACEBOOK_APP_SECRET,
-    callbackUrl: process.env.FACEBOOK_CALLBACK_URL || 'http://localhost:3000/api/auth/facebook/callback',
+    callbackUrl: process.env.FACEBOOK_CALLBACK_URL || 'http://localhost:3000/auth/facebook/callback',
     graphApiVersion: process.env.FACEBOOK_GRAPH_API_VERSION || 'v20.0',
   };
 

--- a/src/config/google.config.js
+++ b/src/config/google.config.js
@@ -7,7 +7,7 @@ const validateGoogleConfig = () => {
   const config = {
     clientId: process.env.GOOGLE_CLIENT_ID,
     clientSecret: process.env.GOOGLE_CLIENT_SECRET,
-    callbackUrl: process.env.GOOGLE_CALLBACK_URL || 'http://localhost:3000/api/auth/google/callback',
+    callbackUrl: process.env.GOOGLE_CALLBACK_URL || 'http://localhost:3000/auth/google/callback',
   };
 
   const missingVars = [];
@@ -34,7 +34,7 @@ const validateGoogleConfig = () => {
 
 export const getGoogleAuthUrlConfig = () => ({
   clientId: process.env.GOOGLE_CLIENT_ID || 'your_client_id_here.apps.googleusercontent.com',
-  callbackUrl: process.env.GOOGLE_CALLBACK_URL || 'http://localhost:3000/api/auth/google/callback',
+  callbackUrl: process.env.GOOGLE_CALLBACK_URL || 'http://localhost:3000/auth/google/callback',
   isConfigured: Boolean(process.env.GOOGLE_CLIENT_ID),
 });
 

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -22,6 +22,7 @@ import {
   consumeOAuthCallbackCode,
   createOAuthCallbackCode,
 } from '../services/oauth-callback-code.service.js';
+import { getApiPrefix } from '../config/api-prefix.config.js';
 
 /**
  * ESTRATEGIA DE AUTENTICACIÓN CON FACEBOOK
@@ -253,7 +254,7 @@ const getVerificationTokenExpiration = () => {
 
 const buildEmailVerificationLink = (token) => {
   const apiBaseUrl = process.env.API_PUBLIC_URL || `http://localhost:${process.env.PORT || 3000}`;
-  const apiPrefix = (process.env.API_PREFIX || '/api').replace(/\/+$/, '');
+  const apiPrefix = getApiPrefix();
   return `${apiBaseUrl}${apiPrefix}/auth/verify-email?token=${token}`;
 };
 

--- a/src/controllers/reporte.controller.js
+++ b/src/controllers/reporte.controller.js
@@ -87,6 +87,22 @@ const parseAnalyticsLimit = (value, defaultValue = 12, maxValue = 60) => {
   return Math.max(1, Math.min(maxValue, parsed));
 };
 
+const enrichLikedByMe = async (reportes, idUsuario) => {
+  const items = Array.isArray(reportes) ? reportes : [reportes].filter(Boolean);
+  if (!idUsuario || items.length === 0) return reportes;
+
+  const likedSet = await ReporteModel.likedSet(
+    items.map((reporte) => reporte.id_reporte),
+    idUsuario
+  );
+  const enriched = items.map((reporte) => ({
+    ...reporte,
+    liked_by_me: likedSet.has(Number(reporte.id_reporte)),
+  }));
+
+  return Array.isArray(reportes) ? enriched : enriched[0];
+};
+
 export const createReporte = async (req, res, next) => {
   try {
     const {
@@ -250,9 +266,10 @@ export const getReportes = async (req, res, next) => {
       ReporteModel.findAll(filters),
       ReporteModel.countAll(countFilters),
     ]);
+    const enrichedReportes = await enrichLikedByMe(reportes, req.user?.sub);
 
     return successResponse(res, {
-      reportes,
+      reportes: enrichedReportes,
       total,
       limit: Math.max(1, Math.min(100, parseInt(limit, 10) || 20)),
       offset: Math.max(0, parseInt(offset, 10) || 0),
@@ -456,9 +473,10 @@ export const getAlertasPredictivas = async (req, res, next) => {
 export const getTrendingReportes = async (req, res, next) => {
   try {
     const reportes = await ReporteModel.findTrending({ limit: req.query?.limit });
+    const enrichedReportes = await enrichLikedByMe(reportes, req.user?.sub);
     return successResponse(
       res,
-      { reportes, total: reportes.length },
+      { reportes: enrichedReportes, total: reportes.length },
       'Reportes en tendencia obtenidos correctamente.'
     );
   } catch (error) {
@@ -642,6 +660,7 @@ export const getReporteById = async (req, res, next) => {
     if (req.query?.skip_view !== 'true') {
       await ReporteModel.incrementarVistas(id);
     }
+    const enrichedReporte = await enrichLikedByMe(reporte, req.user?.sub);
 
     // Fetch related data in parallel
     const [evidencias, usuario] = await Promise.all([
@@ -654,7 +673,7 @@ export const getReporteById = async (req, res, next) => {
       ? { nombre: usuario.nombre, apellido: usuario.apellido, rol: usuario.rol, avatar_url: usuario.avatar_url ?? null }
       : null;
 
-    return successResponse(res, { reporte, evidencias, autor });
+    return successResponse(res, { reporte: enrichedReporte, evidencias, autor });
   } catch (error) {
     return next(error);
   }

--- a/src/models/reporte.model.js
+++ b/src/models/reporte.model.js
@@ -570,6 +570,24 @@ export const ReporteModel = {
     }
   },
 
+  likedSet: async (id_reportes = [], id_usuario) => {
+    const ids = [...new Set(id_reportes.map(Number).filter(Number.isFinite))];
+
+    if (!id_usuario || ids.length === 0 || !await tableExists('reporte_likes')) {
+      return new Set();
+    }
+
+    const placeholders = ids.map(() => '?').join(', ');
+    const [rows] = await pool.execute(
+      `SELECT id_reporte
+       FROM reporte_likes
+       WHERE id_usuario = ? AND id_reporte IN (${placeholders})`,
+      [id_usuario, ...ids]
+    );
+
+    return new Set(rows.map((row) => Number(row.id_reporte)));
+  },
+
   findTrending: async ({ limit = 12 } = {}) => {
     const safeLimit = Math.max(1, Math.min(50, parseInt(limit, 10) || 12));
     const [rows] = await pool.execute(

--- a/tests/unit/optional-auth.test.js
+++ b/tests/unit/optional-auth.test.js
@@ -1,0 +1,172 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import jwt from 'jsonwebtoken';
+import { optionalAuth } from '../../middlewares/auth.middleware.js';
+import { ReporteModel } from '../../src/models/reporte.model.js';
+
+process.env.API_PREFIX = '';
+process.env.JWT_SECRET = 'optional-auth-test-secret';
+
+const createResponse = () => ({
+  statusCode: null,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+});
+
+const listen = async () => {
+  const { default: app } = await import('../../src/app.js');
+
+  return new Promise((resolve) => {
+    const server = http.createServer(app);
+    server.listen(0, () => resolve(server));
+  });
+};
+
+const close = (server) => new Promise((resolve, reject) => {
+  server.close((error) => (error ? reject(error) : resolve()));
+});
+
+const request = async (server, path, options = {}) => {
+  const { port } = server.address();
+  return fetch(`http://127.0.0.1:${port}${path}`, options);
+};
+
+test('optionalAuth permite continuar sin token como anonimo', () => {
+  const req = { headers: {} };
+  const res = createResponse();
+  let nextCalled = false;
+
+  optionalAuth(req, res, () => {
+    nextCalled = true;
+  });
+
+  assert.equal(nextCalled, true);
+  assert.equal(req.user, undefined);
+  assert.equal(res.statusCode, null);
+});
+
+test('optionalAuth llena req.user con token valido', () => {
+  const token = jwt.sign(
+    { sub: 21, email: 'user@example.com', rol: 'ciudadano' },
+    process.env.JWT_SECRET
+  );
+  const req = {
+    headers: {
+      authorization: `Bearer ${token}`,
+    },
+  };
+  const res = createResponse();
+  let nextCalled = false;
+
+  optionalAuth(req, res, () => {
+    nextCalled = true;
+  });
+
+  assert.equal(nextCalled, true);
+  assert.equal(req.user.sub, 21);
+  assert.equal(res.statusCode, null);
+});
+
+test('optionalAuth ignora token invalido y continua como anonimo', () => {
+  const req = {
+    headers: {
+      authorization: 'Bearer token-invalido',
+    },
+    user: { sub: 99 },
+  };
+  const res = createResponse();
+  let nextCalled = false;
+
+  optionalAuth(req, res, () => {
+    nextCalled = true;
+  });
+
+  assert.equal(nextCalled, true);
+  assert.equal(req.user, undefined);
+  assert.equal(res.statusCode, null);
+});
+
+test('GET /reportes responde anonimo y enriquece liked_by_me con token valido', async (t) => {
+  const reportes = [
+    { id_reporte: 10, titulo: 'Reporte 10' },
+    { id_reporte: 11, titulo: 'Reporte 11' },
+  ];
+  t.mock.method(ReporteModel, 'findAll', async () => reportes);
+  t.mock.method(ReporteModel, 'countAll', async () => 2);
+  t.mock.method(ReporteModel, 'likedSet', async (_ids, idUsuario) => (
+    Number(idUsuario) === 21 ? new Set([10]) : new Set()
+  ));
+
+  const server = await listen();
+
+  try {
+    const anon = await request(server, '/reportes');
+    const anonBody = await anon.json();
+
+    assert.equal(anon.status, 200);
+    assert.equal(anonBody.data.reportes[0].liked_by_me, undefined);
+
+    const token = jwt.sign(
+      { sub: 21, email: 'user@example.com', rol: 'ciudadano' },
+      process.env.JWT_SECRET
+    );
+    const authenticated = await request(server, '/reportes', {
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    });
+    const authenticatedBody = await authenticated.json();
+
+    assert.equal(authenticated.status, 200);
+    assert.equal(authenticatedBody.data.reportes[0].liked_by_me, true);
+    assert.equal(authenticatedBody.data.reportes[1].liked_by_me, false);
+
+    const invalid = await request(server, '/reportes', {
+      headers: {
+        authorization: 'Bearer token-invalido',
+      },
+    });
+    const invalidBody = await invalid.json();
+
+    assert.equal(invalid.status, 200);
+    assert.equal(invalidBody.data.reportes[0].liked_by_me, undefined);
+  } finally {
+    await close(server);
+  }
+});
+
+test('POST /chatbot/mensaje ignora token invalido y responde como anonimo', async (t) => {
+  t.mock.method(ReporteModel, 'getStats', async () => ({
+    total_reportes: 0,
+    municipios_activos: 0,
+  }));
+  t.mock.method(ReporteModel, 'getAlertasPredictivas', async () => []);
+
+  const server = await listen();
+
+  try {
+    const response = await request(server, '/chatbot/mensaje', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: 'Bearer token-invalido',
+      },
+      body: JSON.stringify({ mensaje: 'Como crear un reporte?' }),
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.status, 'success');
+    assert.equal(body.data.intent, 'reportes');
+  } finally {
+    await close(server);
+  }
+});

--- a/tests/unit/route-prefix.test.js
+++ b/tests/unit/route-prefix.test.js
@@ -1,0 +1,73 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+
+process.env.API_PREFIX = '';
+
+const { default: pool } = await import('../../src/config/database.js');
+pool.query = async () => [[{ ok: 1 }], []];
+pool.execute = async (sql) => {
+  if (String(sql).includes('FROM reportes')) {
+    return [[{
+      total_reportes: 0,
+      reportes_este_mes: 0,
+      en_revision: 0,
+      resueltos: 0,
+      municipios_activos: 0,
+      con_seguimiento: 0,
+    }], []];
+  }
+
+  if (String(sql).includes('FROM usuarios')) {
+    return [[{ total_usuarios: 0 }], []];
+  }
+
+  return [[], []];
+};
+
+const { default: app } = await import('../../src/app.js');
+const { normalizeApiPrefix } = await import('../../src/config/api-prefix.config.js');
+
+const listen = () => new Promise((resolve) => {
+  const server = http.createServer(app);
+  server.listen(0, () => resolve(server));
+});
+
+const close = (server) => new Promise((resolve, reject) => {
+  server.close((error) => (error ? reject(error) : resolve()));
+});
+
+const request = async (server, path, options = {}) => {
+  const { port } = server.address();
+  return fetch(`http://127.0.0.1:${port}${path}`, options);
+};
+
+test('API_PREFIX por defecto monta rutas sin prefijo para el proxy de Vite', async () => {
+  const server = await listen();
+
+  try {
+    const health = await request(server, '/health');
+    const stats = await request(server, '/reportes/stats');
+    const login = await request(server, '/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    const prefixedHealth = await request(server, '/api/health');
+
+    assert.equal(health.status, 200);
+    assert.equal(stats.status, 200);
+    assert.equal(login.status, 400);
+    assert.equal(prefixedHealth.status, 404);
+  } finally {
+    await close(server);
+  }
+});
+
+test('normaliza API_PREFIX vacio, raiz o con barras sin forzar /api', () => {
+  assert.equal(normalizeApiPrefix(undefined), '');
+  assert.equal(normalizeApiPrefix(''), '');
+  assert.equal(normalizeApiPrefix('/'), '');
+  assert.equal(normalizeApiPrefix('api'), '/api');
+  assert.equal(normalizeApiPrefix('/api/'), '/api');
+});


### PR DESCRIPTION
## Closes #200 - Auth opcional y compatibilidad de sesion

### Resumen

Agrega autenticacion opcional para endpoints publicos que pueden enriquecer la respuesta cuando llega un JWT valido, sin rechazar usuarios anonimos ni tokens invalidos.

### Cambios

- Agrega `optionalAuth` en `middlewares/auth.middleware.js`.
- Aplica `optionalAuth` en:
  - `GET /reportes`
  - `GET /reportes/:id`
  - `GET /reportes/trending`
  - `POST /chatbot/mensaje`
- Trata tokens invalidos como usuario anonimo en endpoints opcionales.
- Enriquece reportes con `liked_by_me` cuando llega un JWT valido.
- Mantiene intactos `verifyTokenWhenAllDevicesLogout`, refresh tokens y logout global.
- Agrega tests para anonimo, token valido, token invalido, `/reportes` y `/chatbot/mensaje`.

## Issues relacionadas

Closes #199
Closes #200

## Pruebas

`npm test`

Resultado: `71/71` tests pasan.

<img width="949" height="912" alt="Screenshot 2026-05-18 092807" src="https://github.com/user-attachments/assets/e9d5a38e-2118-403f-887f-861732aabfe9" />
