### PR TITLE
Issue 201 Soportar multiples evidencias en reportes

### DIFF
--- a/middlewares/errorHandler.js
+++ b/middlewares/errorHandler.js
@@ -11,7 +11,7 @@ export const notFoundHandler = (req, res, next) => {
 export const errorHandler = (err, req, res, next) => {
   console.error('error:', err.message);
 
-  const statusCode = err.statusCode || 500;
+  const statusCode = err.statusCode || (err.name === 'MulterError' ? 400 : 500);
 
   res.status(statusCode).json({
     status: 'error',

--- a/middlewares/upload.middleware.js
+++ b/middlewares/upload.middleware.js
@@ -22,11 +22,23 @@ const ALLOWED_MIME = [
   'video/mp4', 'video/quicktime',
 ];
 
+export const fileFilter = (_req, file, cb) => {
+  if (ALLOWED_MIME.includes(file.mimetype)) {
+    return cb(null, true);
+  }
+
+  const error = new Error('Tipo de archivo no permitido. Solo imagenes y videos.');
+  error.statusCode = 400;
+  return cb(error);
+};
+
 export const upload = multer({
   storage,
   limits: { fileSize: getMaxFileSize() },
-  fileFilter: (_req, file, cb) => {
-    if (ALLOWED_MIME.includes(file.mimetype)) cb(null, true);
-    else cb(new Error('Tipo de archivo no permitido. Solo imágenes y videos.'));
-  },
+  fileFilter,
 });
+
+export const uploadMultiple = upload.fields([
+  { name: 'file', maxCount: 1 },
+  { name: 'files', maxCount: 10 },
+]);

--- a/routes/reporte.routes.js
+++ b/routes/reporte.routes.js
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { optionalAuth, verifyToken, requireRoles } from '../middlewares/auth.middleware.js';
-import { upload } from '../middlewares/upload.middleware.js';
+import { upload, uploadMultiple } from '../middlewares/upload.middleware.js';
 import { validatePositiveIdParam } from '../middlewares/validate-id.middleware.js';
 import {
   createReporte,
@@ -54,10 +54,7 @@ reporteRouter.get('/:id', validatePositiveIdParam('id'), optionalAuth, getReport
 reporteRouter.post(
   '/',
   verifyToken,
-  upload.fields([
-    { name: 'file', maxCount: 1 },
-    { name: 'files', maxCount: 5 },
-  ]),
+  uploadMultiple,
   createReporte
 );
 reporteRouter.patch('/:id', validatePositiveIdParam('id'), verifyToken, updateReporte);

--- a/src/controllers/reporte.controller.js
+++ b/src/controllers/reporte.controller.js
@@ -87,6 +87,26 @@ const parseAnalyticsLimit = (value, defaultValue = 12, maxValue = 60) => {
   return Math.max(1, Math.min(maxValue, parsed));
 };
 
+const getUploadedFiles = (req) => ([
+  ...(req.file ? [req.file] : []),
+  ...(Array.isArray(req.files) ? req.files : []),
+  ...(Array.isArray(req.files?.file) ? req.files.file : []),
+  ...(Array.isArray(req.files?.files) ? req.files.files : []),
+]);
+
+const validateReporteEvidenceFiles = (files) => {
+  if (files.length > 10) {
+    return 'Solo puedes adjuntar hasta 10 evidencias por reporte.';
+  }
+
+  const videoCount = files.filter((file) => file.mimetype?.startsWith('video/')).length;
+  if (videoCount > 1) {
+    return 'Solo puedes adjuntar un video por reporte.';
+  }
+
+  return null;
+};
+
 const enrichLikedByMe = async (reportes, idUsuario) => {
   const items = Array.isArray(reportes) ? reportes : [reportes].filter(Boolean);
   if (!idUsuario || items.length === 0) return reportes;
@@ -136,6 +156,12 @@ export const createReporte = async (req, res, next) => {
 
     const tipoContaminacion = tipo_contaminacion.trim().toLowerCase();
     const nivelSeveridad = normalizeEnumValue(nivel_severidad);
+    const uploadedFiles = getUploadedFiles(req);
+    const evidenceError = validateReporteEvidenceFiles(uploadedFiles);
+
+    if (evidenceError) {
+      return errorResponse(res, evidenceError, 400);
+    }
 
     if (!NIVELES_SEVERIDAD_PERMITIDOS.includes(nivelSeveridad)) {
       return errorResponse(
@@ -219,14 +245,6 @@ export const createReporte = async (req, res, next) => {
 
     await ReporteModel.updateIaAnalysis(idReporte, iaAnalysis);
     reporte = await ReporteModel.findById(idReporte);
-
-    // Guardar evidencia si se adjuntó archivo
-    const uploadedFiles = [
-      ...(req.file ? [req.file] : []),
-      ...(Array.isArray(req.files) ? req.files : []),
-      ...(Array.isArray(req.files?.file) ? req.files.file : []),
-      ...(Array.isArray(req.files?.files) ? req.files.files : []),
-    ];
 
     for (const [index, file] of uploadedFiles.entries()) {
       const tipo = file.mimetype.startsWith('video/') ? 'video' : 'imagen';

--- a/tests/unit/reporte-upload-evidencias.test.js
+++ b/tests/unit/reporte-upload-evidencias.test.js
@@ -1,0 +1,187 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { fileFilter } from '../../middlewares/upload.middleware.js';
+import { createReporte } from '../../src/controllers/reporte.controller.js';
+import { CategoriaRiesgoModel } from '../../src/models/categoria-riesgo.model.js';
+import { EvidenciaModel } from '../../src/models/evidencia.model.js';
+import { ReporteModel } from '../../src/models/reporte.model.js';
+
+const createResponse = () => ({
+  statusCode: null,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+});
+
+const createFile = (index, mimetype = 'image/png') => ({
+  mimetype,
+  filename: `evidencia-${index}.${mimetype.startsWith('video/') ? 'mp4' : 'png'}`,
+  originalname: `original-${index}.${mimetype.startsWith('video/') ? 'mp4' : 'png'}`,
+  size: 1024 + index,
+});
+
+const createRequest = (files = [], bodyOverrides = {}) => ({
+  user: { sub: 7 },
+  body: {
+    tipo_contaminacion: 'agua',
+    nivel_severidad: 'alto',
+    subcategoria: 'rio_contaminado',
+    titulo: 'Reporte con evidencias',
+    descripcion: 'Descripcion del reporte',
+    direccion: 'Calle 10',
+    municipio: 'Valledupar',
+    departamento: 'Cesar',
+    latitud: 10.45,
+    longitud: -73.25,
+    ...bodyOverrides,
+  },
+  files: {
+    files,
+  },
+});
+
+const mockSuccessfulCreate = (t) => {
+  t.mock.method(CategoriaRiesgoModel, 'esValido', async () => true);
+  t.mock.method(ReporteModel, 'create', async () => 15);
+  t.mock.method(ReporteModel, 'findById', async () => ({
+    id_reporte: 15,
+    tipo_contaminacion: 'agua',
+    subcategoria: 'rio_contaminado',
+    estado: 'pendiente',
+  }));
+  t.mock.method(ReporteModel, 'updateIaAnalysis', async () => true);
+  t.mock.method(EvidenciaModel, 'create', async () => 1);
+};
+
+test('createReporte guarda multiples imagenes con metadata y orden', async (t) => {
+  mockSuccessfulCreate(t);
+
+  const req = createRequest([createFile(0), createFile(1), createFile(2)]);
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await createReporte(req, res, next);
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(EvidenciaModel.create.mock.callCount(), 3);
+  assert.deepEqual(EvidenciaModel.create.mock.calls[1].arguments[0], {
+    id_reporte: 15,
+    id_usuario: 7,
+    tipo_archivo: 'imagen',
+    url_archivo: '/uploads/evidencia-1.png',
+    nombre_original: 'original-1.png',
+    mime_type: 'image/png',
+    tamano_bytes: 1025,
+    orden: 1,
+  });
+  assert.equal(ReporteModel.create.mock.calls[0].arguments[0].subcategoria, 'rio_contaminado');
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('createReporte permite hasta 10 archivos en files', async (t) => {
+  mockSuccessfulCreate(t);
+
+  const req = createRequest(Array.from({ length: 10 }, (_, index) => createFile(index)));
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await createReporte(req, res, next);
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(EvidenciaModel.create.mock.callCount(), 10);
+  assert.equal(EvidenciaModel.create.mock.calls[9].arguments[0].orden, 9);
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('createReporte rechaza mas de 10 evidencias antes de crear reporte', async (t) => {
+  t.mock.method(CategoriaRiesgoModel, 'esValido', async () => {
+    throw new Error('No debe validar categoria con mas de 10 evidencias');
+  });
+  t.mock.method(ReporteModel, 'create', async () => {
+    throw new Error('No debe insertar reportes con mas de 10 evidencias');
+  });
+  t.mock.method(EvidenciaModel, 'create', async () => {
+    throw new Error('No debe insertar evidencias con mas de 10 archivos');
+  });
+
+  const req = createRequest(Array.from({ length: 11 }, (_, index) => createFile(index)));
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await createReporte(req, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.message, 'Solo puedes adjuntar hasta 10 evidencias por reporte.');
+  assert.equal(ReporteModel.create.mock.callCount(), 0);
+  assert.equal(EvidenciaModel.create.mock.callCount(), 0);
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('createReporte permite un video por reporte', async (t) => {
+  mockSuccessfulCreate(t);
+
+  const req = createRequest([
+    createFile(0, 'image/webp'),
+    createFile(1, 'video/mp4'),
+  ]);
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await createReporte(req, res, next);
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(EvidenciaModel.create.mock.callCount(), 2);
+  assert.equal(EvidenciaModel.create.mock.calls[1].arguments[0].tipo_archivo, 'video');
+  assert.equal(EvidenciaModel.create.mock.calls[1].arguments[0].mime_type, 'video/mp4');
+});
+
+test('createReporte rechaza dos videos antes de crear reporte', async (t) => {
+  t.mock.method(CategoriaRiesgoModel, 'esValido', async () => {
+    throw new Error('No debe validar categoria con dos videos');
+  });
+  t.mock.method(ReporteModel, 'create', async () => {
+    throw new Error('No debe insertar reportes con dos videos');
+  });
+  t.mock.method(EvidenciaModel, 'create', async () => {
+    throw new Error('No debe insertar evidencias con dos videos');
+  });
+
+  const req = createRequest([
+    createFile(0, 'video/mp4'),
+    createFile(1, 'video/quicktime'),
+  ]);
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await createReporte(req, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.message, 'Solo puedes adjuntar un video por reporte.');
+  assert.equal(ReporteModel.create.mock.callCount(), 0);
+  assert.equal(EvidenciaModel.create.mock.callCount(), 0);
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('fileFilter rechaza mime invalido como error 400', () => {
+  let callbackError;
+  let accepted;
+
+  fileFilter(
+    {},
+    { mimetype: 'application/pdf' },
+    (error, value) => {
+      callbackError = error;
+      accepted = value;
+    }
+  );
+
+  assert.equal(callbackError.statusCode, 400);
+  assert.equal(callbackError.message, 'Tipo de archivo no permitido. Solo imagenes y videos.');
+  assert.equal(accepted, undefined);
+});


### PR DESCRIPTION
# Closes #201 

## Descripción

Se agregó soporte para subir múltiples evidencias al crear reportes usando `files`, manteniendo compatibilidad con `file`. Ahora se aceptan hasta 10 archivos, se valida máximo 1 video por reporte y se conserva la validación de tipo y tamaño configurables.
También se asegura que cada evidencia se guarde con orden, tipo, MIME, tamaño, usuario y URL pública `/uploads/<filename>`, y se agregaron tests para imágenes múltiples, video permitido, rechazo de dos videos y MIME inválido.

<img width="806" height="908" alt="image" src="https://github.com/user-attachments/assets/f512c7df-28d4-4fdb-9982-7de54bf81142" />

