### PR TITLE
Issue 202 likes vistas unicas trending

### DIFF
--- a/middlewares/errorHandler.js
+++ b/middlewares/errorHandler.js
@@ -11,7 +11,7 @@ export const notFoundHandler = (req, res, next) => {
 export const errorHandler = (err, req, res, next) => {
   console.error('error:', err.message);
 
-  const statusCode = err.statusCode || 500;
+  const statusCode = err.statusCode || (err.name === 'MulterError' ? 400 : 500);
 
   res.status(statusCode).json({
     status: 'error',

--- a/middlewares/upload.middleware.js
+++ b/middlewares/upload.middleware.js
@@ -22,11 +22,23 @@ const ALLOWED_MIME = [
   'video/mp4', 'video/quicktime',
 ];
 
+export const fileFilter = (_req, file, cb) => {
+  if (ALLOWED_MIME.includes(file.mimetype)) {
+    return cb(null, true);
+  }
+
+  const error = new Error('Tipo de archivo no permitido. Solo imagenes y videos.');
+  error.statusCode = 400;
+  return cb(error);
+};
+
 export const upload = multer({
   storage,
   limits: { fileSize: getMaxFileSize() },
-  fileFilter: (_req, file, cb) => {
-    if (ALLOWED_MIME.includes(file.mimetype)) cb(null, true);
-    else cb(new Error('Tipo de archivo no permitido. Solo imágenes y videos.'));
-  },
+  fileFilter,
 });
+
+export const uploadMultiple = upload.fields([
+  { name: 'file', maxCount: 1 },
+  { name: 'files', maxCount: 10 },
+]);

--- a/migrations/009_create_reporte_likes.sql
+++ b/migrations/009_create_reporte_likes.sql
@@ -1,0 +1,16 @@
+-- Migracion: likes persistentes por usuario y reporte
+CREATE TABLE IF NOT EXISTS reporte_likes (
+  id_like BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  id_reporte INT NOT NULL,
+  id_usuario INT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id_like),
+  UNIQUE KEY uk_reporte_likes_reporte_usuario (id_reporte, id_usuario),
+  KEY idx_reporte_likes_usuario (id_usuario),
+  CONSTRAINT fk_reporte_likes_reporte
+    FOREIGN KEY (id_reporte) REFERENCES reportes(id_reporte)
+    ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT fk_reporte_likes_usuario
+    FOREIGN KEY (id_usuario) REFERENCES usuarios(id_usuario)
+    ON DELETE CASCADE ON UPDATE CASCADE
+);

--- a/migrations/010_create_reporte_vistas.sql
+++ b/migrations/010_create_reporte_vistas.sql
@@ -1,0 +1,16 @@
+-- Migracion: vistas unicas persistentes para usuarios autenticados
+CREATE TABLE IF NOT EXISTS reporte_vistas (
+  id_vista BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  id_reporte INT NOT NULL,
+  id_usuario INT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id_vista),
+  UNIQUE KEY uk_reporte_vistas_reporte_usuario (id_reporte, id_usuario),
+  KEY idx_reporte_vistas_usuario (id_usuario),
+  CONSTRAINT fk_reporte_vistas_reporte
+    FOREIGN KEY (id_reporte) REFERENCES reportes(id_reporte)
+    ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT fk_reporte_vistas_usuario
+    FOREIGN KEY (id_usuario) REFERENCES usuarios(id_usuario)
+    ON DELETE CASCADE ON UPDATE CASCADE
+);

--- a/routes/reporte.routes.js
+++ b/routes/reporte.routes.js
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { optionalAuth, verifyToken, requireRoles } from '../middlewares/auth.middleware.js';
-import { upload } from '../middlewares/upload.middleware.js';
+import { upload, uploadMultiple } from '../middlewares/upload.middleware.js';
 import { validatePositiveIdParam } from '../middlewares/validate-id.middleware.js';
 import {
   createReporte,
@@ -54,10 +54,7 @@ reporteRouter.get('/:id', validatePositiveIdParam('id'), optionalAuth, getReport
 reporteRouter.post(
   '/',
   verifyToken,
-  upload.fields([
-    { name: 'file', maxCount: 1 },
-    { name: 'files', maxCount: 5 },
-  ]),
+  uploadMultiple,
   createReporte
 );
 reporteRouter.patch('/:id', validatePositiveIdParam('id'), verifyToken, updateReporte);

--- a/src/controllers/reporte.controller.js
+++ b/src/controllers/reporte.controller.js
@@ -7,8 +7,12 @@ import {
 import { CategoriaRiesgoModel } from '../models/categoria-riesgo.model.js';
 import { UsuarioModel }   from '../models/usuario.model.js';
 import { EvidenciaModel } from '../models/evidencia.model.js';
+import { LikeModel } from '../models/like.model.js';
 import { analyzeReporte } from '../services/ia.service.js';
 import { errorResponse, successResponse } from '../utils/response.js';
+
+const ANONYMOUS_VIEW_THROTTLE_MS = 5 * 60 * 1000;
+const anonymousViewThrottle = new Map();
 
 const parseCoordinate = (value, { field, min, max }) => {
   if (value === undefined || value === null || value === '') {
@@ -107,11 +111,37 @@ const validateReporteEvidenceFiles = (files) => {
   return null;
 };
 
+const getAnonymousViewerKey = (req, idReporte) => {
+  const ip = req.ip || req.socket?.remoteAddress || 'unknown-ip';
+  const userAgent = req.get?.('user-agent') || req.headers?.['user-agent'] || 'unknown-agent';
+  return `${idReporte}:${ip}:${userAgent}`;
+};
+
+const registerReporteView = async (req, idReporte) => {
+  if (req.query?.skip_view === 'true') return false;
+
+  if (req.user?.sub) {
+    return ReporteModel.registrarVistaUsuario(idReporte, req.user.sub);
+  }
+
+  const now = Date.now();
+  const key = getAnonymousViewerKey(req, idReporte);
+  const lastSeenAt = anonymousViewThrottle.get(key) || 0;
+
+  if (now - lastSeenAt < ANONYMOUS_VIEW_THROTTLE_MS) {
+    return false;
+  }
+
+  anonymousViewThrottle.set(key, now);
+  await ReporteModel.incrementarVistas(idReporte);
+  return true;
+};
+
 const enrichLikedByMe = async (reportes, idUsuario) => {
   const items = Array.isArray(reportes) ? reportes : [reportes].filter(Boolean);
   if (!idUsuario || items.length === 0) return reportes;
 
-  const likedSet = await ReporteModel.likedSet(
+  const likedSet = await LikeModel.likedSet(
     items.map((reporte) => reporte.id_reporte),
     idUsuario
   );
@@ -514,7 +544,7 @@ export const toggleLikeReporte = async (req, res, next) => {
       return errorResponse(res, 'No puedes reaccionar a tu propio reporte.', 400);
     }
 
-    const result = await ReporteModel.toggleLike(id, idUsuario);
+    const result = await LikeModel.toggle(id, idUsuario);
 
     return successResponse(
       res,
@@ -675,9 +705,7 @@ export const getReporteById = async (req, res, next) => {
     const id = Number(req.params.id);
     const reporte = await ReporteModel.findById(id);
     if (!reporte) return errorResponse(res, 'Reporte no encontrado.', 404);
-    if (req.query?.skip_view !== 'true') {
-      await ReporteModel.incrementarVistas(id);
-    }
+    await registerReporteView(req, id);
     const enrichedReporte = await enrichLikedByMe(reporte, req.user?.sub);
 
     // Fetch related data in parallel

--- a/src/controllers/reporte.controller.js
+++ b/src/controllers/reporte.controller.js
@@ -87,6 +87,26 @@ const parseAnalyticsLimit = (value, defaultValue = 12, maxValue = 60) => {
   return Math.max(1, Math.min(maxValue, parsed));
 };
 
+const getUploadedFiles = (req) => ([
+  ...(req.file ? [req.file] : []),
+  ...(Array.isArray(req.files) ? req.files : []),
+  ...(Array.isArray(req.files?.file) ? req.files.file : []),
+  ...(Array.isArray(req.files?.files) ? req.files.files : []),
+]);
+
+const validateReporteEvidenceFiles = (files) => {
+  if (files.length > 10) {
+    return 'Solo puedes adjuntar hasta 10 evidencias por reporte.';
+  }
+
+  const videoCount = files.filter((file) => file.mimetype?.startsWith('video/')).length;
+  if (videoCount > 1) {
+    return 'Solo puedes adjuntar un video por reporte.';
+  }
+
+  return null;
+};
+
 const enrichLikedByMe = async (reportes, idUsuario) => {
   const items = Array.isArray(reportes) ? reportes : [reportes].filter(Boolean);
   if (!idUsuario || items.length === 0) return reportes;
@@ -136,6 +156,12 @@ export const createReporte = async (req, res, next) => {
 
     const tipoContaminacion = tipo_contaminacion.trim().toLowerCase();
     const nivelSeveridad = normalizeEnumValue(nivel_severidad);
+    const uploadedFiles = getUploadedFiles(req);
+    const evidenceError = validateReporteEvidenceFiles(uploadedFiles);
+
+    if (evidenceError) {
+      return errorResponse(res, evidenceError, 400);
+    }
 
     if (!NIVELES_SEVERIDAD_PERMITIDOS.includes(nivelSeveridad)) {
       return errorResponse(
@@ -219,14 +245,6 @@ export const createReporte = async (req, res, next) => {
 
     await ReporteModel.updateIaAnalysis(idReporte, iaAnalysis);
     reporte = await ReporteModel.findById(idReporte);
-
-    // Guardar evidencia si se adjuntó archivo
-    const uploadedFiles = [
-      ...(req.file ? [req.file] : []),
-      ...(Array.isArray(req.files) ? req.files : []),
-      ...(Array.isArray(req.files?.file) ? req.files.file : []),
-      ...(Array.isArray(req.files?.files) ? req.files.files : []),
-    ];
 
     for (const [index, file] of uploadedFiles.entries()) {
       const tipo = file.mimetype.startsWith('video/') ? 'video' : 'imagen';

--- a/src/models/like.model.js
+++ b/src/models/like.model.js
@@ -1,0 +1,103 @@
+import pool from '../config/database.js';
+import { tableExists } from '../config/schema-compat.js';
+
+export const LikeModel = {
+  toggle: async (id_reporte, id_usuario) => {
+    if (!await tableExists('reporte_likes')) {
+      return { liked: false, votos_relevancia: 0 };
+    }
+
+    const connection = await pool.getConnection();
+    try {
+      await connection.beginTransaction();
+
+      const [existingRows] = await connection.execute(
+        `SELECT id_like
+         FROM reporte_likes
+         WHERE id_reporte = ? AND id_usuario = ?
+         LIMIT 1
+         FOR UPDATE`,
+        [id_reporte, id_usuario]
+      );
+
+      const liked = existingRows.length === 0;
+      if (liked) {
+        await connection.execute(
+          `INSERT INTO reporte_likes (id_reporte, id_usuario)
+           VALUES (?, ?)`,
+          [id_reporte, id_usuario]
+        );
+        await connection.execute(
+          `UPDATE reportes
+           SET votos_relevancia = votos_relevancia + 1
+           WHERE id_reporte = ? AND deleted_at IS NULL`,
+          [id_reporte]
+        );
+      } else {
+        await connection.execute(
+          `DELETE FROM reporte_likes
+           WHERE id_reporte = ? AND id_usuario = ?`,
+          [id_reporte, id_usuario]
+        );
+        await connection.execute(
+          `UPDATE reportes
+           SET votos_relevancia = GREATEST(votos_relevancia - 1, 0)
+           WHERE id_reporte = ? AND deleted_at IS NULL`,
+          [id_reporte]
+        );
+      }
+
+      const [[row]] = await connection.execute(
+        `SELECT votos_relevancia
+         FROM reportes
+         WHERE id_reporte = ?`,
+        [id_reporte]
+      );
+
+      await connection.commit();
+      return {
+        liked,
+        votos_relevancia: Number(row?.votos_relevancia) || 0,
+      };
+    } catch (error) {
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  },
+
+  hasLiked: async (id_reporte, id_usuario) => {
+    if (!id_usuario || !await tableExists('reporte_likes')) {
+      return false;
+    }
+
+    const [rows] = await pool.execute(
+      `SELECT id_like
+       FROM reporte_likes
+       WHERE id_reporte = ? AND id_usuario = ?
+       LIMIT 1`,
+      [id_reporte, id_usuario]
+    );
+
+    return rows.length > 0;
+  },
+
+  likedSet: async (id_reportes = [], id_usuario) => {
+    const ids = [...new Set(id_reportes.map(Number).filter(Number.isFinite))];
+
+    if (!id_usuario || ids.length === 0 || !await tableExists('reporte_likes')) {
+      return new Set();
+    }
+
+    const placeholders = ids.map(() => '?').join(', ');
+    const [rows] = await pool.execute(
+      `SELECT id_reporte
+       FROM reporte_likes
+       WHERE id_usuario = ? AND id_reporte IN (${placeholders})`,
+      [id_usuario, ...ids]
+    );
+
+    return new Set(rows.map((row) => Number(row.id_reporte)));
+  },
+};

--- a/src/models/reporte.model.js
+++ b/src/models/reporte.model.js
@@ -320,6 +320,26 @@ export const ReporteModel = {
     );
   },
 
+  registrarVistaUsuario: async (id_reporte, id_usuario) => {
+    if (!id_usuario || !await tableExists('reporte_vistas')) {
+      await ReporteModel.incrementarVistas(id_reporte);
+      return true;
+    }
+
+    const [result] = await pool.execute(
+      `INSERT IGNORE INTO reporte_vistas (id_reporte, id_usuario)
+       VALUES (?, ?)`,
+      [id_reporte, id_usuario]
+    );
+
+    if (result.affectedRows === 0) {
+      return false;
+    }
+
+    await ReporteModel.incrementarVistas(id_reporte);
+    return true;
+  },
+
   
     // Soft-delete de un reporte
   
@@ -500,94 +520,6 @@ export const ReporteModel = {
     return rows;
   },
 
-  toggleLike: async (id_reporte, id_usuario) => {
-    if (!await tableExists('reporte_likes')) {
-      await ReporteModel.incrementarVistas(id_reporte);
-      const reporte = await ReporteModel.findById(id_reporte);
-      return {
-        liked: false,
-        votos_relevancia: Number(reporte?.votos_relevancia) || 0,
-      };
-    }
-
-    const connection = await pool.getConnection();
-    try {
-      await connection.beginTransaction();
-
-      const [existingRows] = await connection.execute(
-        `SELECT id_like
-         FROM reporte_likes
-         WHERE id_reporte = ? AND id_usuario = ?
-         LIMIT 1
-         FOR UPDATE`,
-        [id_reporte, id_usuario]
-      );
-
-      const liked = existingRows.length === 0;
-      if (liked) {
-        await connection.execute(
-          `INSERT INTO reporte_likes (id_reporte, id_usuario)
-           VALUES (?, ?)`,
-          [id_reporte, id_usuario]
-        );
-        await connection.execute(
-          `UPDATE reportes
-           SET votos_relevancia = votos_relevancia + 1
-           WHERE id_reporte = ? AND deleted_at IS NULL`,
-          [id_reporte]
-        );
-      } else {
-        await connection.execute(
-          `DELETE FROM reporte_likes
-           WHERE id_reporte = ? AND id_usuario = ?`,
-          [id_reporte, id_usuario]
-        );
-        await connection.execute(
-          `UPDATE reportes
-           SET votos_relevancia = GREATEST(votos_relevancia - 1, 0)
-           WHERE id_reporte = ? AND deleted_at IS NULL`,
-          [id_reporte]
-        );
-      }
-
-      const [[row]] = await connection.execute(
-        `SELECT votos_relevancia
-         FROM reportes
-         WHERE id_reporte = ?`,
-        [id_reporte]
-      );
-
-      await connection.commit();
-      return {
-        liked,
-        votos_relevancia: Number(row?.votos_relevancia) || 0,
-      };
-    } catch (error) {
-      await connection.rollback();
-      throw error;
-    } finally {
-      connection.release();
-    }
-  },
-
-  likedSet: async (id_reportes = [], id_usuario) => {
-    const ids = [...new Set(id_reportes.map(Number).filter(Number.isFinite))];
-
-    if (!id_usuario || ids.length === 0 || !await tableExists('reporte_likes')) {
-      return new Set();
-    }
-
-    const placeholders = ids.map(() => '?').join(', ');
-    const [rows] = await pool.execute(
-      `SELECT id_reporte
-       FROM reporte_likes
-       WHERE id_usuario = ? AND id_reporte IN (${placeholders})`,
-      [id_usuario, ...ids]
-    );
-
-    return new Set(rows.map((row) => Number(row.id_reporte)));
-  },
-
   findTrending: async ({ limit = 12 } = {}) => {
     const safeLimit = Math.max(1, Math.min(50, parseInt(limit, 10) || 12));
     const [rows] = await pool.execute(
@@ -604,7 +536,10 @@ export const ReporteModel = {
        LIMIT ${safeLimit}`
     );
 
-    return rows;
+    return rows.map((row) => ({
+      ...row,
+      trending_score: Number(row.trending_score) || 0,
+    }));
   },
 
   getStatsIA: async ({ dias = 30 } = {}) => {

--- a/tests/unit/likes-vistas-trending.test.js
+++ b/tests/unit/likes-vistas-trending.test.js
@@ -1,0 +1,194 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { LikeModel } from '../../src/models/like.model.js';
+import { ReporteModel } from '../../src/models/reporte.model.js';
+import { EvidenciaModel } from '../../src/models/evidencia.model.js';
+import { UsuarioModel } from '../../src/models/usuario.model.js';
+import pool from '../../src/config/database.js';
+import { clearSchemaCompatCache } from '../../src/config/schema-compat.js';
+import {
+  getReporteById,
+  getReportes,
+  getTrendingReportes,
+  toggleLikeReporte,
+} from '../../src/controllers/reporte.controller.js';
+
+const createResponse = () => ({
+  statusCode: null,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+});
+
+const createConnection = ({ likedInitially = false } = {}) => {
+  let liked = likedInitially;
+  let votos = liked ? 1 : 0;
+
+  return {
+    beginTransaction: async () => {},
+    commit: async () => {},
+    rollback: async () => {},
+    release: () => {},
+    execute: async (sql) => {
+      if (String(sql).includes('SELECT id_like')) {
+        return [liked ? [{ id_like: 1 }] : []];
+      }
+
+      if (String(sql).includes('INSERT INTO reporte_likes')) {
+        liked = true;
+        votos += 1;
+        return [{ affectedRows: 1 }];
+      }
+
+      if (String(sql).includes('DELETE FROM reporte_likes')) {
+        liked = false;
+        votos = Math.max(0, votos - 1);
+        return [{ affectedRows: 1 }];
+      }
+
+      if (String(sql).includes('UPDATE reportes')) {
+        return [{ affectedRows: 1 }];
+      }
+
+      if (String(sql).includes('SELECT votos_relevancia')) {
+        return [[{ votos_relevancia: votos }]];
+      }
+
+      return [[]];
+    },
+  };
+};
+
+test('LikeModel.toggle alterna like y unlike para el mismo usuario', async (t) => {
+  clearSchemaCompatCache();
+  t.mock.method(pool, 'execute', async () => [[{ total: 1 }]]);
+  const connection = createConnection();
+  t.mock.method(pool, 'getConnection', async () => connection);
+
+  const liked = await LikeModel.toggle(10, 21);
+  const unliked = await LikeModel.toggle(10, 21);
+
+  assert.deepEqual(liked, { liked: true, votos_relevancia: 1 });
+  assert.deepEqual(unliked, { liked: false, votos_relevancia: 0 });
+});
+
+test('toggleLikeReporte prohibe like al propio reporte', async (t) => {
+  t.mock.method(ReporteModel, 'findById', async () => ({
+    id_reporte: 10,
+    id_usuario: 21,
+  }));
+  t.mock.method(LikeModel, 'toggle', async () => {
+    throw new Error('No debe crear like propio');
+  });
+
+  const req = {
+    params: { id: '10' },
+    user: { sub: 21 },
+  };
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await toggleLikeReporte(req, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.message, 'No puedes reaccionar a tu propio reporte.');
+  assert.equal(LikeModel.toggle.mock.callCount(), 0);
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('getReportes y getTrendingReportes agregan liked_by_me con sesion opcional', async (t) => {
+  const reportes = [
+    { id_reporte: 10, titulo: 'Reporte 10' },
+    { id_reporte: 11, titulo: 'Reporte 11', trending_score: 8 },
+  ];
+  t.mock.method(ReporteModel, 'findAll', async () => reportes);
+  t.mock.method(ReporteModel, 'countAll', async () => 2);
+  t.mock.method(ReporteModel, 'findTrending', async () => reportes);
+  t.mock.method(LikeModel, 'likedSet', async () => new Set([11]));
+
+  const listRes = createResponse();
+  await getReportes({ query: {}, user: { sub: 21 } }, listRes, t.mock.fn());
+
+  assert.equal(listRes.body.data.reportes[0].liked_by_me, false);
+  assert.equal(listRes.body.data.reportes[1].liked_by_me, true);
+
+  const trendingRes = createResponse();
+  await getTrendingReportes({ query: {}, user: { sub: 21 } }, trendingRes, t.mock.fn());
+
+  assert.equal(trendingRes.body.data.reportes[0].liked_by_me, false);
+  assert.equal(trendingRes.body.data.reportes[1].liked_by_me, true);
+});
+
+test('registrarVistaUsuario solo incrementa con primera vista persistida', async (t) => {
+  clearSchemaCompatCache();
+  const calls = [];
+  let firstInsert = true;
+
+  t.mock.method(pool, 'execute', async (sql) => {
+    calls.push(String(sql));
+    if (String(sql).includes('INFORMATION_SCHEMA.TABLES')) {
+      return [[{ total: 1 }]];
+    }
+
+    if (String(sql).includes('INSERT IGNORE INTO reporte_vistas')) {
+      const affectedRows = firstInsert ? 1 : 0;
+      firstInsert = false;
+      return [{ affectedRows }];
+    }
+
+    return [{ affectedRows: 1 }];
+  });
+  t.mock.method(ReporteModel, 'incrementarVistas', async () => {});
+
+  const first = await ReporteModel.registrarVistaUsuario(10, 21);
+  const second = await ReporteModel.registrarVistaUsuario(10, 21);
+
+  assert.equal(first, true);
+  assert.equal(second, false);
+  assert.equal(ReporteModel.incrementarVistas.mock.callCount(), 1);
+  assert.ok(calls.some((sql) => sql.includes('INSERT IGNORE INTO reporte_vistas')));
+});
+
+test('getReporteById aplica throttle de vistas anonimas por refresh inmediato', async (t) => {
+  t.mock.method(ReporteModel, 'findById', async () => ({
+    id_reporte: 10,
+    id_usuario: 99,
+    titulo: 'Reporte',
+  }));
+  t.mock.method(ReporteModel, 'incrementarVistas', async () => {});
+  t.mock.method(EvidenciaModel, 'findByReporte', async () => []);
+  t.mock.method(UsuarioModel, 'findById', async () => null);
+
+  const createReq = () => ({
+    params: { id: '10' },
+    query: {},
+    headers: { 'user-agent': 'test-agent' },
+    ip: '127.0.0.1',
+    get(header) {
+      return this.headers[String(header).toLowerCase()];
+    },
+  });
+
+  await getReporteById(createReq(), createResponse(), t.mock.fn());
+  await getReporteById(createReq(), createResponse(), t.mock.fn());
+
+  assert.equal(ReporteModel.incrementarVistas.mock.callCount(), 1);
+});
+
+test('findTrending devuelve trending_score numerico', async (t) => {
+  t.mock.method(pool, 'execute', async () => [[{
+    id_reporte: 10,
+    titulo: 'Reporte',
+    trending_score: '42',
+  }]]);
+
+  const [reporte] = await ReporteModel.findTrending();
+
+  assert.equal(reporte.trending_score, 42);
+});

--- a/tests/unit/optional-auth.test.js
+++ b/tests/unit/optional-auth.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import http from 'node:http';
 import jwt from 'jsonwebtoken';
 import { optionalAuth } from '../../middlewares/auth.middleware.js';
+import { LikeModel } from '../../src/models/like.model.js';
 import { ReporteModel } from '../../src/models/reporte.model.js';
 
 process.env.API_PREFIX = '';
@@ -101,7 +102,7 @@ test('GET /reportes responde anonimo y enriquece liked_by_me con token valido', 
   ];
   t.mock.method(ReporteModel, 'findAll', async () => reportes);
   t.mock.method(ReporteModel, 'countAll', async () => 2);
-  t.mock.method(ReporteModel, 'likedSet', async (_ids, idUsuario) => (
+  t.mock.method(LikeModel, 'likedSet', async (_ids, idUsuario) => (
     Number(idUsuario) === 21 ? new Set([10]) : new Set()
   ));
 

--- a/tests/unit/reporte-upload-evidencias.test.js
+++ b/tests/unit/reporte-upload-evidencias.test.js
@@ -1,0 +1,187 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { fileFilter } from '../../middlewares/upload.middleware.js';
+import { createReporte } from '../../src/controllers/reporte.controller.js';
+import { CategoriaRiesgoModel } from '../../src/models/categoria-riesgo.model.js';
+import { EvidenciaModel } from '../../src/models/evidencia.model.js';
+import { ReporteModel } from '../../src/models/reporte.model.js';
+
+const createResponse = () => ({
+  statusCode: null,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+});
+
+const createFile = (index, mimetype = 'image/png') => ({
+  mimetype,
+  filename: `evidencia-${index}.${mimetype.startsWith('video/') ? 'mp4' : 'png'}`,
+  originalname: `original-${index}.${mimetype.startsWith('video/') ? 'mp4' : 'png'}`,
+  size: 1024 + index,
+});
+
+const createRequest = (files = [], bodyOverrides = {}) => ({
+  user: { sub: 7 },
+  body: {
+    tipo_contaminacion: 'agua',
+    nivel_severidad: 'alto',
+    subcategoria: 'rio_contaminado',
+    titulo: 'Reporte con evidencias',
+    descripcion: 'Descripcion del reporte',
+    direccion: 'Calle 10',
+    municipio: 'Valledupar',
+    departamento: 'Cesar',
+    latitud: 10.45,
+    longitud: -73.25,
+    ...bodyOverrides,
+  },
+  files: {
+    files,
+  },
+});
+
+const mockSuccessfulCreate = (t) => {
+  t.mock.method(CategoriaRiesgoModel, 'esValido', async () => true);
+  t.mock.method(ReporteModel, 'create', async () => 15);
+  t.mock.method(ReporteModel, 'findById', async () => ({
+    id_reporte: 15,
+    tipo_contaminacion: 'agua',
+    subcategoria: 'rio_contaminado',
+    estado: 'pendiente',
+  }));
+  t.mock.method(ReporteModel, 'updateIaAnalysis', async () => true);
+  t.mock.method(EvidenciaModel, 'create', async () => 1);
+};
+
+test('createReporte guarda multiples imagenes con metadata y orden', async (t) => {
+  mockSuccessfulCreate(t);
+
+  const req = createRequest([createFile(0), createFile(1), createFile(2)]);
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await createReporte(req, res, next);
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(EvidenciaModel.create.mock.callCount(), 3);
+  assert.deepEqual(EvidenciaModel.create.mock.calls[1].arguments[0], {
+    id_reporte: 15,
+    id_usuario: 7,
+    tipo_archivo: 'imagen',
+    url_archivo: '/uploads/evidencia-1.png',
+    nombre_original: 'original-1.png',
+    mime_type: 'image/png',
+    tamano_bytes: 1025,
+    orden: 1,
+  });
+  assert.equal(ReporteModel.create.mock.calls[0].arguments[0].subcategoria, 'rio_contaminado');
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('createReporte permite hasta 10 archivos en files', async (t) => {
+  mockSuccessfulCreate(t);
+
+  const req = createRequest(Array.from({ length: 10 }, (_, index) => createFile(index)));
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await createReporte(req, res, next);
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(EvidenciaModel.create.mock.callCount(), 10);
+  assert.equal(EvidenciaModel.create.mock.calls[9].arguments[0].orden, 9);
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('createReporte rechaza mas de 10 evidencias antes de crear reporte', async (t) => {
+  t.mock.method(CategoriaRiesgoModel, 'esValido', async () => {
+    throw new Error('No debe validar categoria con mas de 10 evidencias');
+  });
+  t.mock.method(ReporteModel, 'create', async () => {
+    throw new Error('No debe insertar reportes con mas de 10 evidencias');
+  });
+  t.mock.method(EvidenciaModel, 'create', async () => {
+    throw new Error('No debe insertar evidencias con mas de 10 archivos');
+  });
+
+  const req = createRequest(Array.from({ length: 11 }, (_, index) => createFile(index)));
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await createReporte(req, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.message, 'Solo puedes adjuntar hasta 10 evidencias por reporte.');
+  assert.equal(ReporteModel.create.mock.callCount(), 0);
+  assert.equal(EvidenciaModel.create.mock.callCount(), 0);
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('createReporte permite un video por reporte', async (t) => {
+  mockSuccessfulCreate(t);
+
+  const req = createRequest([
+    createFile(0, 'image/webp'),
+    createFile(1, 'video/mp4'),
+  ]);
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await createReporte(req, res, next);
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(EvidenciaModel.create.mock.callCount(), 2);
+  assert.equal(EvidenciaModel.create.mock.calls[1].arguments[0].tipo_archivo, 'video');
+  assert.equal(EvidenciaModel.create.mock.calls[1].arguments[0].mime_type, 'video/mp4');
+});
+
+test('createReporte rechaza dos videos antes de crear reporte', async (t) => {
+  t.mock.method(CategoriaRiesgoModel, 'esValido', async () => {
+    throw new Error('No debe validar categoria con dos videos');
+  });
+  t.mock.method(ReporteModel, 'create', async () => {
+    throw new Error('No debe insertar reportes con dos videos');
+  });
+  t.mock.method(EvidenciaModel, 'create', async () => {
+    throw new Error('No debe insertar evidencias con dos videos');
+  });
+
+  const req = createRequest([
+    createFile(0, 'video/mp4'),
+    createFile(1, 'video/quicktime'),
+  ]);
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await createReporte(req, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.message, 'Solo puedes adjuntar un video por reporte.');
+  assert.equal(ReporteModel.create.mock.callCount(), 0);
+  assert.equal(EvidenciaModel.create.mock.callCount(), 0);
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('fileFilter rechaza mime invalido como error 400', () => {
+  let callbackError;
+  let accepted;
+
+  fileFilter(
+    {},
+    { mimetype: 'application/pdf' },
+    (error, value) => {
+      callbackError = error;
+      accepted = value;
+    }
+  );
+
+  assert.equal(callbackError.statusCode, 400);
+  assert.equal(callbackError.message, 'Tipo de archivo no permitido. Solo imagenes y videos.');
+  assert.equal(accepted, undefined);
+});


### PR DESCRIPTION
# Closes #202 

## Descripción

Se mejoró el sistema de likes, vistas y trending en reportes.
Ahora los likes se manejan con `LikeModel` y una tabla puente `reporte_likes`, permitiendo alternar like/unlike por usuario. También se mantiene la restricción para que un usuario no pueda dar like a su propio reporte.
Se agregó soporte para `liked_by_me` en respuestas de reportes cuando llega una sesión válida, vistas únicas persistentes para usuarios autenticados con `reporte_vistas`, y throttle en memoria para evitar que usuarios anónimos inflen vistas con refresh inmediato.
También se agregaron migraciones SQL y tests para toggle de likes, anti-auto-like, `liked_by_me`, vistas únicas, throttle anónimo y `trending_score` numérico.

<img width="781" height="817" alt="image" src="https://github.com/user-attachments/assets/e57a137b-b12d-4e29-8c08-33976888d5a6" />
