### PR TITLE
Issue 203 Agregar clasificacion de imagen y persistencia IA

### DIFF
--- a/src/controllers/reporte.controller.js
+++ b/src/controllers/reporte.controller.js
@@ -4,11 +4,13 @@ import {
   NIVELES_SEVERIDAD_PERMITIDOS,
   ReporteModel,
 } from '../models/reporte.model.js';
+import fs from 'node:fs/promises';
 import { CategoriaRiesgoModel } from '../models/categoria-riesgo.model.js';
 import { UsuarioModel }   from '../models/usuario.model.js';
 import { EvidenciaModel } from '../models/evidencia.model.js';
 import { LikeModel } from '../models/like.model.js';
 import { analyzeReporte } from '../services/ia.service.js';
+import { clasificarImagen } from '../services/clasificacion.service.js';
 import { errorResponse, successResponse } from '../utils/response.js';
 
 const ANONYMOUS_VIEW_THROTTLE_MS = 5 * 60 * 1000;
@@ -111,6 +113,45 @@ const validateReporteEvidenceFiles = (files) => {
   return null;
 };
 
+const parseBooleanLike = (value) => (
+  value === true || value === 1 || value === '1' || String(value).toLowerCase() === 'true'
+);
+
+const parseAcceptedIaPayload = ({ ia_etiquetas, ia_confianza, ia_procesado }) => {
+  if (!parseBooleanLike(ia_procesado)) {
+    return { procesado: false };
+  }
+
+  let etiquetas = [];
+  if (typeof ia_etiquetas === 'string') {
+    try {
+      etiquetas = JSON.parse(ia_etiquetas);
+    } catch {
+      return { error: 'ia_etiquetas debe ser un arreglo JSON valido.' };
+    }
+  } else {
+    etiquetas = ia_etiquetas ?? [];
+  }
+
+  if (!Array.isArray(etiquetas)) {
+    return { error: 'ia_etiquetas debe ser un arreglo.' };
+  }
+
+  const confianza = Number(ia_confianza);
+  if (!Number.isFinite(confianza) || confianza < 0 || confianza > 100) {
+    return { error: 'ia_confianza debe ser un numero entre 0 y 100.' };
+  }
+
+  return {
+    procesado: true,
+    analysis: {
+      etiquetas,
+      confianza,
+      procesado: true,
+    },
+  };
+};
+
 const getAnonymousViewerKey = (req, idReporte) => {
   const ip = req.ip || req.socket?.remoteAddress || 'unknown-ip';
   const userAgent = req.get?.('user-agent') || req.headers?.['user-agent'] || 'unknown-agent';
@@ -188,9 +229,14 @@ export const createReporte = async (req, res, next) => {
     const nivelSeveridad = normalizeEnumValue(nivel_severidad);
     const uploadedFiles = getUploadedFiles(req);
     const evidenceError = validateReporteEvidenceFiles(uploadedFiles);
+    const iaPayload = parseAcceptedIaPayload({ ia_etiquetas, ia_confianza, ia_procesado });
 
     if (evidenceError) {
       return errorResponse(res, evidenceError, 400);
+    }
+
+    if (iaPayload.error) {
+      return errorResponse(res, iaPayload.error, 400);
     }
 
     if (!NIVELES_SEVERIDAD_PERMITIDOS.includes(nivelSeveridad)) {
@@ -244,20 +290,8 @@ export const createReporte = async (req, res, next) => {
     let reporte = await ReporteModel.findById(idReporte);
 
     let iaAnalysis;
-    if (String(ia_procesado) === '1') {
-      let etiquetas = [];
-      try {
-        etiquetas = typeof ia_etiquetas === 'string'
-          ? JSON.parse(ia_etiquetas)
-          : (ia_etiquetas ?? []);
-      } catch {
-        etiquetas = [];
-      }
-      iaAnalysis = {
-        etiquetas,
-        confianza: Number(ia_confianza) || 0,
-        procesado: true,
-      };
+    if (iaPayload.procesado) {
+      iaAnalysis = iaPayload.analysis;
     } else {
       iaAnalysis = analyzeReporte({
         ...reporte,
@@ -562,28 +596,18 @@ export const analizarImagen = async (req, res, next) => {
       return errorResponse(res, 'Imagen requerida.', 400);
     }
 
-    const analysis = analyzeReporte({
-      titulo: req.file.originalname || '',
-      descripcion: req.file.originalname || '',
-    });
-    const [top] = analysis.etiquetas ?? [];
-
+    const analysis = await clasificarImagen(req.file);
     return successResponse(
       res,
-      {
-        categoria: top?.label || 'otro',
-        nombre: top?.nombre || 'Otro',
-        confianza: top?.score || analysis.confianza || 0,
-        subcategoria: null,
-        confianza_subcategoria: 0,
-        severidad: null,
-        confianza_severidad: 0,
-        etiquetas: analysis.etiquetas ?? [],
-      },
+      analysis,
       'Imagen analizada correctamente.'
     );
   } catch (error) {
     return next(error);
+  } finally {
+    if (req.file?.path) {
+      await fs.unlink(req.file.path).catch(() => {});
+    }
   }
 };
 

--- a/src/models/reporte.model.js
+++ b/src/models/reporte.model.js
@@ -51,6 +51,34 @@ const buildReportesFilter = ({
   };
 };
 
+export const normalizeReporteIA = (reporte) => {
+  if (!reporte) return reporte;
+
+  let etiquetas = [];
+  if (Array.isArray(reporte.ia_etiquetas)) {
+    etiquetas = reporte.ia_etiquetas;
+  } else if (typeof reporte.ia_etiquetas === 'string' && reporte.ia_etiquetas.trim()) {
+    try {
+      const parsed = JSON.parse(reporte.ia_etiquetas);
+      etiquetas = Array.isArray(parsed) ? parsed : [];
+    } catch {
+      etiquetas = [];
+    }
+  }
+  const confianza = Number(reporte.ia_confianza);
+
+  return {
+    ...reporte,
+    ia_etiquetas: etiquetas,
+    ia_confianza: reporte.ia_confianza === null || reporte.ia_confianza === undefined
+      ? null
+      : (Number.isFinite(confianza) ? confianza : null),
+    ia_procesado: reporte.ia_procesado === true ||
+      reporte.ia_procesado === 'true' ||
+      Boolean(Number(reporte.ia_procesado)),
+  };
+};
+
 export const ReporteModel = {
   
     // Lista reportes con filtros opcionales y paginación
@@ -77,6 +105,7 @@ export const ReporteModel = {
               r.tipo_contaminacion, r.subcategoria, r.estado, r.nivel_severidad,
               r.titulo, r.descripcion,
               r.latitud, r.longitud, r.direccion, r.municipio, r.departamento,
+              r.ia_etiquetas, r.ia_confianza, r.ia_procesado,
               r.votos_relevancia, r.vistas,
               r.created_at, r.updated_at,
               u.nombre AS autor_nombre, u.apellido AS autor_apellido, u.rol AS autor_rol
@@ -87,7 +116,7 @@ export const ReporteModel = {
        LIMIT ${safeLimit} OFFSET ${safeOffset}`,
       params
     );
-    return rows;
+    return rows.map(normalizeReporteIA);
   },
 
   countAll: async ({
@@ -169,7 +198,7 @@ export const ReporteModel = {
       params
     );
 
-    return rows;
+    return rows.map(normalizeReporteIA);
   },
 
   
@@ -190,7 +219,7 @@ export const ReporteModel = {
        LIMIT 1`,
       [id_reporte]
     );
-    return rows[0] ?? null;
+    return normalizeReporteIA(rows[0] ?? null);
   },
 
   
@@ -201,7 +230,8 @@ export const ReporteModel = {
     const safeOffset = Math.max(0,               parseInt(offset, 10) || 0);
     const [rows] = await pool.execute(
       `SELECT id_reporte, uuid, tipo_contaminacion, subcategoria, estado, nivel_severidad,
-              titulo, municipio, departamento, votos_relevancia, vistas,
+              titulo, municipio, departamento, ia_etiquetas, ia_confianza, ia_procesado,
+              votos_relevancia, vistas,
               created_at, updated_at
        FROM reportes
        WHERE id_usuario = ? AND deleted_at IS NULL
@@ -209,7 +239,7 @@ export const ReporteModel = {
        LIMIT ${safeLimit} OFFSET ${safeOffset}`,
       [id_usuario]
     );
-    return rows;
+    return rows.map(normalizeReporteIA);
   },
 
   
@@ -527,6 +557,7 @@ export const ReporteModel = {
               r.tipo_contaminacion, r.subcategoria, r.estado, r.nivel_severidad,
               r.titulo, r.descripcion,
               r.latitud, r.longitud, r.direccion, r.municipio, r.departamento,
+              r.ia_etiquetas, r.ia_confianza, r.ia_procesado,
               r.votos_relevancia, r.vistas,
               r.created_at, r.updated_at,
               (r.votos_relevancia * 3 + r.vistas + GREATEST(0, 30 - TIMESTAMPDIFF(DAY, r.created_at, NOW()))) AS trending_score

--- a/src/services/clasificacion.service.js
+++ b/src/services/clasificacion.service.js
@@ -1,0 +1,69 @@
+import { CATEGORIAS_FALLBACK } from '../models/categoria-riesgo.model.js';
+
+const CATEGORY_HINTS = [
+  {
+    categoria: 'agua',
+    subcategoria: 'vertimiento',
+    severidad: 'alto',
+    keywords: ['agua', 'rio', 'quebrada', 'inundacion', 'vertimiento', 'alcantarilla'],
+  },
+  {
+    categoria: 'aire',
+    subcategoria: 'humo',
+    severidad: 'medio',
+    keywords: ['aire', 'humo', 'quema', 'gases', 'polvo'],
+  },
+  {
+    categoria: 'residuos',
+    subcategoria: 'basuras',
+    severidad: 'medio',
+    keywords: ['basura', 'residuo', 'escombro', 'desecho', 'lixiviado'],
+  },
+  {
+    categoria: 'deforestacion',
+    subcategoria: 'tala',
+    severidad: 'alto',
+    keywords: ['arbol', 'bosque', 'tala', 'deforestacion', 'vegetacion'],
+  },
+  {
+    categoria: 'otro',
+    subcategoria: null,
+    severidad: 'medio',
+    keywords: [],
+  },
+];
+
+const normalizeText = (value) => (
+  typeof value === 'string'
+    ? value.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase()
+    : ''
+);
+
+const getCategoriaNombre = (codigo) => (
+  CATEGORIAS_FALLBACK.find((categoria) => categoria.codigo === codigo)?.nombre || 'Otro'
+);
+
+export const clasificarImagen = async ({ originalname = '', mimetype = '' } = {}) => {
+  const text = normalizeText(`${originalname} ${mimetype}`);
+  const match = CATEGORY_HINTS.find((hint) => (
+    hint.keywords.some((keyword) => text.includes(keyword))
+  )) || CATEGORY_HINTS[CATEGORY_HINTS.length - 1];
+  const matchedKeywords = match.keywords.filter((keyword) => text.includes(keyword));
+  const confidence = Math.min(0.95, 0.55 + (matchedKeywords.length * 0.12));
+  const etiquetas = [
+    match.categoria,
+    ...(match.subcategoria ? [match.subcategoria] : []),
+    ...matchedKeywords,
+  ];
+
+  return {
+    categoria: match.categoria,
+    nombre: getCategoriaNombre(match.categoria),
+    confianza: Number(confidence.toFixed(2)),
+    subcategoria: match.subcategoria,
+    confianza_subcategoria: match.subcategoria ? Number(Math.max(0.45, confidence - 0.08).toFixed(2)) : 0,
+    severidad: match.severidad,
+    confianza_severidad: Number(Math.max(0.5, confidence - 0.1).toFixed(2)),
+    etiquetas: [...new Set(etiquetas)].slice(0, 8),
+  };
+};

--- a/tests/unit/clasificacion-ia.test.js
+++ b/tests/unit/clasificacion-ia.test.js
@@ -1,0 +1,180 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { clasificarImagen } from '../../src/services/clasificacion.service.js';
+import { analizarImagen, createReporte } from '../../src/controllers/reporte.controller.js';
+import { CategoriaRiesgoModel } from '../../src/models/categoria-riesgo.model.js';
+import { EvidenciaModel } from '../../src/models/evidencia.model.js';
+import { normalizeReporteIA, ReporteModel } from '../../src/models/reporte.model.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const testsDir = path.dirname(__filename);
+
+const createResponse = () => ({
+  statusCode: null,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+});
+
+const createValidRequest = (overrides = {}) => ({
+  user: { sub: 7 },
+  body: {
+    tipo_contaminacion: 'agua',
+    nivel_severidad: 'alto',
+    titulo: 'Reporte con IA',
+    descripcion: 'Vertimiento en rio',
+    direccion: 'Calle 10',
+    municipio: 'Valledupar',
+    departamento: 'Cesar',
+    latitud: 10.45,
+    longitud: -73.25,
+    ...overrides,
+  },
+});
+
+const mockReporteCreate = (t) => {
+  t.mock.method(CategoriaRiesgoModel, 'esValido', async () => true);
+  t.mock.method(ReporteModel, 'create', async () => 15);
+  t.mock.method(ReporteModel, 'findById', async () => ({
+    id_reporte: 15,
+    tipo_contaminacion: 'agua',
+    estado: 'pendiente',
+  }));
+  t.mock.method(ReporteModel, 'updateIaAnalysis', async () => true);
+  t.mock.method(EvidenciaModel, 'create', async () => 1);
+};
+
+test('clasificarImagen devuelve contrato esperado con fallback deterministico', async () => {
+  const result = await clasificarImagen({
+    originalname: 'foto-rio-agua-contaminada.jpg',
+    mimetype: 'image/jpeg',
+  });
+
+  assert.equal(result.categoria, 'agua');
+  assert.equal(result.nombre, 'Contaminacion de Agua');
+  assert.equal(result.subcategoria, 'vertimiento');
+  assert.equal(result.severidad, 'alto');
+  assert.ok(result.confianza > 0);
+  assert.ok(result.confianza_subcategoria > 0);
+  assert.ok(result.confianza_severidad > 0);
+  assert.ok(result.etiquetas.includes('agua'));
+
+  const fallback = await clasificarImagen({ originalname: 'sin-pistas.jpg' });
+  assert.equal(fallback.categoria, 'otro');
+  assert.equal(fallback.nombre, 'Otro');
+  assert.deepEqual(fallback.etiquetas, ['otro']);
+});
+
+test('analizarImagen exige imagen', async (t) => {
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await analizarImagen({ file: null }, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.message, 'Imagen requerida.');
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('analizarImagen clasifica y borra archivo temporal', async (t) => {
+  const tempPath = path.join(testsDir, 'tmp-analizar-imagen.jpg');
+  await fs.writeFile(tempPath, 'fake image bytes');
+
+  const req = {
+    file: {
+      path: tempPath,
+      originalname: 'agua-rio.jpg',
+      mimetype: 'image/jpeg',
+    },
+  };
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await analizarImagen(req, res, next);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.data.categoria, 'agua');
+  assert.equal(res.body.data.nombre, 'Contaminacion de Agua');
+  assert.equal(res.body.data.severidad, 'alto');
+  await assert.rejects(() => fs.access(tempPath));
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('createReporte persiste payload IA valido aceptado por el usuario', async (t) => {
+  mockReporteCreate(t);
+
+  const req = createValidRequest({
+    ia_procesado: '1',
+    ia_confianza: '0.82',
+    ia_etiquetas: JSON.stringify(['agua', 'vertimiento']),
+  });
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await createReporte(req, res, next);
+
+  assert.equal(res.statusCode, 201);
+  assert.deepEqual(ReporteModel.updateIaAnalysis.mock.calls[0].arguments[1], {
+    etiquetas: ['agua', 'vertimiento'],
+    confianza: 0.82,
+    procesado: true,
+  });
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('createReporte rechaza payload IA invalido sin crear reporte', async (t) => {
+  t.mock.method(CategoriaRiesgoModel, 'esValido', async () => {
+    throw new Error('No debe validar categoria con IA invalida');
+  });
+  t.mock.method(ReporteModel, 'create', async () => {
+    throw new Error('No debe insertar reporte con IA invalida');
+  });
+
+  const req = createValidRequest({
+    ia_procesado: '1',
+    ia_confianza: '0.82',
+    ia_etiquetas: '{json-invalido',
+  });
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await createReporte(req, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.message, 'ia_etiquetas debe ser un arreglo JSON valido.');
+  assert.equal(ReporteModel.create.mock.callCount(), 0);
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('normalizeReporteIA expone IA normalizada y no JSON crudo', () => {
+  const reporte = normalizeReporteIA({
+    id_reporte: 1,
+    ia_etiquetas: '["agua","rio"]',
+    ia_confianza: '0.75',
+    ia_procesado: 1,
+  });
+
+  assert.deepEqual(reporte.ia_etiquetas, ['agua', 'rio']);
+  assert.equal(reporte.ia_confianza, 0.75);
+  assert.equal(reporte.ia_procesado, true);
+
+  const invalid = normalizeReporteIA({
+    id_reporte: 2,
+    ia_etiquetas: 'json roto',
+    ia_confianza: null,
+    ia_procesado: 0,
+  });
+
+  assert.deepEqual(invalid.ia_etiquetas, []);
+  assert.equal(invalid.ia_confianza, null);
+  assert.equal(invalid.ia_procesado, false);
+});


### PR DESCRIPTION
# Closes #203 

## Descripción

Se agregó la clasificación previa de imágenes y la persistencia de campos IA en reportes.
Ahora `POST /reportes/analizar-imagen` recibe una imagen, devuelve una clasificación con categoría, confianza, subcategoría, severidad y etiquetas, y elimina el archivo temporal después del análisis.
También se actualizó `POST /reportes` para guardar la IA aceptada por el usuario mediante `ia_etiquetas`, `ia_confianza` e `ia_procesado`, manteniendo las validaciones actuales de categoría, severidad y datos del reporte.
Además, los reportes ahora exponen los campos IA normalizados al leerse, evitando devolver JSON crudo o valores inconsistentes. Se agregaron tests para imagen faltante, clasificación, fallback, payload IA válido/inválido y normalización.


<img width="773" height="824" alt="image" src="https://github.com/user-attachments/assets/b33185c7-af12-434b-a79c-c4407359029f" />
