### PR TITLE
Issue 204 Agregar prediccion de zonas de riesgo y alertas

### DIFF
--- a/migrations/011_add_prediction_indexes.sql
+++ b/migrations/011_add_prediction_indexes.sql
@@ -1,0 +1,9 @@
+-- Migracion: indices para prediccion de zonas de riesgo y alertas
+CREATE INDEX idx_reportes_estado_created_at
+  ON reportes (estado, created_at);
+
+CREATE INDEX idx_reportes_tipo_created_at
+  ON reportes (tipo_contaminacion, created_at);
+
+CREATE INDEX idx_reportes_latitud_longitud
+  ON reportes (latitud, longitud);

--- a/routes/reporte.routes.js
+++ b/routes/reporte.routes.js
@@ -11,8 +11,6 @@ import {
   getStatsTimeline,
   getHeatmapPoints,
   getStatsIA,
-  getZonasRiesgo,
-  getAlertasPredictivas,
   getTrendingReportes,
   toggleLikeReporte,
   analizarImagen,
@@ -24,6 +22,10 @@ import {
   addEvidenciaReporte,
   deleteEvidenciaReporte,
 } from '../src/controllers/reporte.controller.js';
+import {
+  getAlertasPredictivas,
+  getZonasRiesgo,
+} from '../src/controllers/prediccion.controller.js';
  
 
 const reporteRouter = Router();
@@ -34,7 +36,7 @@ reporteRouter.get('/stats/timeline', getStatsTimeline);
 reporteRouter.get('/stats/heatmap', getHeatmapPoints);
 reporteRouter.get('/stats/ia', verifyToken, requireRoles('admin', 'moderador'), getStatsIA);
 reporteRouter.get('/zonas-riesgo', verifyToken, requireRoles('admin', 'moderador'), getZonasRiesgo);
-reporteRouter.get('/alertas-predictivas', getAlertasPredictivas);
+reporteRouter.get('/alertas-predictivas', optionalAuth, getAlertasPredictivas);
 reporteRouter.get('/trending', optionalAuth, getTrendingReportes);
 reporteRouter.get('/export', verifyToken, requireRoles('admin', 'moderador'), exportReportes);
 reporteRouter.get('/mis-reportes', verifyToken, getMisReportes);

--- a/src/controllers/prediccion.controller.js
+++ b/src/controllers/prediccion.controller.js
@@ -1,0 +1,27 @@
+import {
+  calcularAlertasPredictivas,
+  calcularZonasRiesgo,
+  parseAlertasParams,
+  parseZonasParams,
+} from '../services/prediccion.service.js';
+import { successResponse } from '../utils/response.js';
+
+export const getZonasRiesgo = async (req, res, next) => {
+  try {
+    const payload = await calcularZonasRiesgo(parseZonasParams(req.query));
+    return successResponse(res, payload, 'Zonas de riesgo obtenidas correctamente.');
+  } catch (error) {
+    return next(error);
+  }
+};
+
+// Publico para que el frontend pueda mostrar alertas preventivas sin sesion.
+// No expone autores, usuarios ni IDs personales; solo agregados por zona.
+export const getAlertasPredictivas = async (req, res, next) => {
+  try {
+    const payload = await calcularAlertasPredictivas(parseAlertasParams(req.query));
+    return successResponse(res, payload, 'Alertas predictivas obtenidas correctamente.');
+  } catch (error) {
+    return next(error);
+  }
+};

--- a/src/controllers/reporte.controller.js
+++ b/src/controllers/reporte.controller.js
@@ -11,6 +11,7 @@ import { EvidenciaModel } from '../models/evidencia.model.js';
 import { LikeModel } from '../models/like.model.js';
 import { analyzeReporte } from '../services/ia.service.js';
 import { clasificarImagen } from '../services/clasificacion.service.js';
+import { invalidatePrediccionCache } from '../services/prediccion.service.js';
 import { errorResponse, successResponse } from '../utils/response.js';
 
 const ANONYMOUS_VIEW_THROTTLE_MS = 5 * 60 * 1000;
@@ -324,6 +325,7 @@ export const createReporte = async (req, res, next) => {
       });
     }
 
+    invalidatePrediccionCache();
     return successResponse(res, { reporte }, 'Reporte creado correctamente.', 201);
   } catch (error) {
     return next(error);
@@ -687,6 +689,12 @@ export const updateReporte = async (req, res, next) => {
     }
 
     await ReporteModel.update(id, campos);
+    if (
+      Object.prototype.hasOwnProperty.call(campos, 'estado') ||
+      Object.prototype.hasOwnProperty.call(campos, 'nivel_severidad')
+    ) {
+      invalidatePrediccionCache();
+    }
     const updated = await ReporteModel.findById(id);
     return successResponse(res, { reporte: updated }, 'Reporte actualizado.');
   } catch (error) {
@@ -718,6 +726,7 @@ export const deleteReporte = async (req, res, next) => {
     }
 
     await ReporteModel.remove(id);
+    invalidatePrediccionCache();
     return successResponse(res, null, 'Reporte eliminado.');
   } catch (error) {
     return next(error);

--- a/src/models/reporte.model.js
+++ b/src/models/reporte.model.js
@@ -550,6 +550,46 @@ export const ReporteModel = {
     return rows;
   },
 
+  findParaPrediccion: async ({ desde, tipo } = {}) => {
+    const conditions = [
+      'r.deleted_at IS NULL',
+      'r.latitud IS NOT NULL',
+      'r.longitud IS NOT NULL',
+      "r.estado IN ('verificado', 'en_proceso', 'resuelto')",
+    ];
+    const params = [];
+
+    if (desde) {
+      conditions.push('r.created_at >= ?');
+      params.push(desde);
+    }
+
+    if (tipo) {
+      conditions.push('r.tipo_contaminacion = ?');
+      params.push(tipo);
+    }
+
+    const [rows] = await pool.execute(
+      `SELECT
+         r.id_reporte,
+         r.tipo_contaminacion,
+         r.subcategoria,
+         r.estado,
+         r.nivel_severidad,
+         r.latitud,
+         r.longitud,
+         r.municipio,
+         r.departamento,
+         r.created_at
+       FROM reportes r
+       WHERE ${conditions.join(' AND ')}
+       ORDER BY r.created_at DESC`,
+      params
+    );
+
+    return rows;
+  },
+
   findTrending: async ({ limit = 12 } = {}) => {
     const safeLimit = Math.max(1, Math.min(50, parseInt(limit, 10) || 12));
     const [rows] = await pool.execute(

--- a/src/services/prediccion.service.js
+++ b/src/services/prediccion.service.js
@@ -1,0 +1,268 @@
+import { ReporteModel } from '../models/reporte.model.js';
+
+export const PREDICCION_CACHE_TTL_MS = 5 * 60 * 1000;
+export const DEFAULT_CELDA_GRADOS = 0.05;
+
+const cache = new Map();
+const NIVEL_RANK = { bajo: 1, medio: 2, alto: 3, critico: 4 };
+const SCORE_NIVEL = [
+  { min: 80, nivel: 'critico' },
+  { min: 60, nivel: 'alto' },
+  { min: 35, nivel: 'medio' },
+  { min: 0, nivel: 'bajo' },
+];
+
+const toNumber = (value) => {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+};
+
+const validationError = (message) => {
+  const error = new Error(message);
+  error.statusCode = 400;
+  return error;
+};
+
+const clampInt = (value, { fallback, min, max }) => {
+  if (value === undefined || value === null || value === '') return fallback;
+  const parsed = parseInt(value, 10);
+  if (!Number.isFinite(parsed)) {
+    throw validationError(`El parametro debe ser un entero entre ${min} y ${max}.`);
+  }
+  return Math.max(min, Math.min(max, parsed));
+};
+
+const parseDateDesde = (dias) => {
+  const safeDias = clampInt(dias, { fallback: 30, min: 1, max: 365 });
+  const desde = new Date();
+  desde.setDate(desde.getDate() - safeDias);
+  return { safeDias, desde };
+};
+
+const cacheKey = (name, params) => `${name}:${JSON.stringify(params)}`;
+
+const getCached = (key) => {
+  const entry = cache.get(key);
+  if (!entry || entry.expiresAt <= Date.now()) {
+    cache.delete(key);
+    return null;
+  }
+
+  return entry.value;
+};
+
+const setCached = (key, value) => {
+  cache.set(key, {
+    value,
+    expiresAt: Date.now() + PREDICCION_CACHE_TTL_MS,
+  });
+  return value;
+};
+
+export const invalidatePrediccionCache = () => {
+  cache.clear();
+};
+
+export const getPrediccionCacheSize = () => cache.size;
+
+const validateTipo = (tipo) => (
+  typeof tipo === 'string' && tipo.trim() ? tipo.trim().toLowerCase() : null
+);
+
+export const parseZonasParams = (query = {}) => {
+  const { safeDias, desde } = parseDateDesde(query.dias);
+  const minScore = query.min_score === undefined || query.min_score === ''
+    ? 30
+    : Number(query.min_score);
+
+  if (!Number.isFinite(minScore) || minScore < 0 || minScore > 100) {
+    throw validationError('min_score debe ser un numero entre 0 y 100.');
+  }
+
+  return {
+    dias: safeDias,
+    desde,
+    tipo: validateTipo(query.tipo),
+    min_score: minScore,
+  };
+};
+
+export const parseAlertasParams = (query = {}) => {
+  const zonasParams = parseZonasParams(query);
+  const limite = clampInt(query.limite, { fallback: 10, min: 1, max: 50 });
+  const nivel_min = query.nivel_min === undefined || query.nivel_min === ''
+    ? 'medio'
+    : String(query.nivel_min).toLowerCase();
+  if (!NIVEL_RANK[nivel_min]) {
+    throw validationError('nivel_min debe ser uno de: bajo, medio, alto, critico.');
+  }
+  const lat = toNumber(query.lat);
+  const lng = toNumber(query.lng);
+  const radio_km = toNumber(query.radio_km);
+
+  if (query.lat !== undefined && (lat === null || lat < -90 || lat > 90)) {
+    throw validationError('lat debe ser un numero entre -90 y 90.');
+  }
+  if (query.lng !== undefined && (lng === null || lng < -180 || lng > 180)) {
+    throw validationError('lng debe ser un numero entre -180 y 180.');
+  }
+  if (query.radio_km !== undefined && (radio_km === null || radio_km <= 0 || radio_km > 500)) {
+    throw validationError('radio_km debe ser un numero mayor a 0 y menor o igual a 500.');
+  }
+
+  return {
+    ...zonasParams,
+    limite,
+    nivel_min,
+    lat: lat !== null && lat >= -90 && lat <= 90 ? lat : null,
+    lng: lng !== null && lng >= -180 && lng <= 180 ? lng : null,
+    radio_km: radio_km !== null && radio_km > 0 ? Math.min(radio_km, 500) : null,
+  };
+};
+
+const gridKeyFor = (lat, lng, cellSize = DEFAULT_CELDA_GRADOS) => {
+  const latCell = Math.floor(Number(lat) / cellSize) * cellSize;
+  const lngCell = Math.floor(Number(lng) / cellSize) * cellSize;
+  return `${latCell.toFixed(4)}:${lngCell.toFixed(4)}`;
+};
+
+const scoreZona = (reportes) => {
+  const severidadPromedio = reportes.reduce(
+    (sum, reporte) => sum + (NIVEL_RANK[reporte.nivel_severidad] || 1),
+    0
+  ) / Math.max(1, reportes.length);
+  const recencia = reportes.reduce((sum, reporte) => {
+    const createdAt = new Date(reporte.created_at).getTime();
+    const days = Number.isFinite(createdAt)
+      ? Math.max(0, (Date.now() - createdAt) / 86400000)
+      : 365;
+    return sum + Math.max(0, 30 - days);
+  }, 0) / Math.max(1, reportes.length);
+  const score = Math.min(100, Math.round((reportes.length * 16) + (severidadPromedio * 14) + recencia));
+  const nivel = SCORE_NIVEL.find((item) => score >= item.min)?.nivel || 'bajo';
+
+  return { score, nivel, severidadPromedio };
+};
+
+const buildZonas = (reportes, { min_score }) => {
+  const grouped = new Map();
+
+  for (const reporte of reportes) {
+    const lat = Number(reporte.latitud);
+    const lng = Number(reporte.longitud);
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) continue;
+
+    const key = gridKeyFor(lat, lng);
+    grouped.set(key, [...(grouped.get(key) || []), reporte]);
+  }
+
+  return [...grouped.entries()]
+    .map(([key, items]) => {
+      const [latCell, lngCell] = key.split(':').map(Number);
+      const { score, nivel, severidadPromedio } = scoreZona(items);
+      const tipoCounts = new Map();
+      let latest = null;
+
+      for (const item of items) {
+        tipoCounts.set(item.tipo_contaminacion, (tipoCounts.get(item.tipo_contaminacion) || 0) + 1);
+        const itemDate = new Date(item.created_at).getTime();
+        if (!latest || itemDate > new Date(latest).getTime()) latest = item.created_at;
+      }
+
+      const [tipoDominante] = [...tipoCounts.entries()].sort((a, b) => b[1] - a[1])[0] || ['otro'];
+
+      return {
+        id: key,
+        zona_id: key,
+        centro: {
+          lat: Number((latCell + (DEFAULT_CELDA_GRADOS / 2)).toFixed(6)),
+          lng: Number((lngCell + (DEFAULT_CELDA_GRADOS / 2)).toFixed(6)),
+        },
+        tipo_dominante: tipoDominante,
+        n_reportes: items.length,
+        severidad_promedio: Number(severidadPromedio.toFixed(2)),
+        ultimo_reporte: latest,
+        score,
+        nivel,
+      };
+    })
+    .filter((zona) => zona.score >= min_score)
+    .sort((a, b) => b.score - a.score || b.n_reportes - a.n_reportes);
+};
+
+const distanceKm = (a, b) => {
+  const radius = 6371;
+  const dLat = ((b.lat - a.lat) * Math.PI) / 180;
+  const dLng = ((b.lng - a.lng) * Math.PI) / 180;
+  const lat1 = (a.lat * Math.PI) / 180;
+  const lat2 = (b.lat * Math.PI) / 180;
+  const h = Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) ** 2;
+  return 2 * radius * Math.asin(Math.sqrt(h));
+};
+
+export const calcularZonasRiesgo = async (params) => {
+  const key = cacheKey('zonas', {
+    dias: params.dias,
+    tipo: params.tipo,
+    min_score: params.min_score,
+  });
+  const cached = getCached(key);
+  if (cached) return cached;
+
+  const reportes = await ReporteModel.findParaPrediccion({
+    desde: params.desde,
+    tipo: params.tipo,
+  });
+  const payload = {
+    actualizado_en: new Date().toISOString(),
+    celda_grados: DEFAULT_CELDA_GRADOS,
+    zonas: buildZonas(reportes, params),
+  };
+
+  return setCached(key, payload);
+};
+
+export const calcularAlertasPredictivas = async (params) => {
+  const key = cacheKey('alertas', {
+    dias: params.dias,
+    tipo: params.tipo,
+    min_score: params.min_score,
+    limite: params.limite,
+    nivel_min: params.nivel_min,
+    lat: params.lat,
+    lng: params.lng,
+    radio_km: params.radio_km,
+  });
+  const cached = getCached(key);
+  if (cached) return cached;
+
+  const zonasPayload = await calcularZonasRiesgo({ ...params, min_score: params.min_score ?? 0 });
+  const minRank = NIVEL_RANK[params.nivel_min] || NIVEL_RANK.medio;
+  const origin = params.lat !== null && params.lng !== null ? { lat: params.lat, lng: params.lng } : null;
+
+  const alertas = zonasPayload.zonas
+    .filter((zona) => (NIVEL_RANK[zona.nivel] || 1) >= minRank)
+    .filter((zona) => !params.tipo || zona.tipo_dominante === params.tipo)
+    .map((zona) => ({
+      id: zona.id,
+      zona_id: zona.zona_id,
+      centro: zona.centro,
+      tipo_dominante: zona.tipo_dominante,
+      n_reportes: zona.n_reportes,
+      score: zona.score,
+      nivel: zona.nivel,
+      ultimo_reporte: zona.ultimo_reporte,
+      distancia_km: origin ? Number(distanceKm(origin, zona.centro).toFixed(2)) : null,
+    }))
+    .filter((alerta) => !origin || !params.radio_km || alerta.distancia_km <= params.radio_km)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, params.limite);
+
+  const payload = {
+    generado_en: new Date().toISOString(),
+    alertas,
+  };
+
+  return setCached(key, payload);
+};

--- a/tests/unit/prediccion-service.test.js
+++ b/tests/unit/prediccion-service.test.js
@@ -1,0 +1,129 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  calcularAlertasPredictivas,
+  calcularZonasRiesgo,
+  getPrediccionCacheSize,
+  invalidatePrediccionCache,
+  parseAlertasParams,
+  parseZonasParams,
+} from '../../src/services/prediccion.service.js';
+import { ReporteModel } from '../../src/models/reporte.model.js';
+
+const reportesBase = [
+  {
+    id_reporte: 1,
+    tipo_contaminacion: 'agua',
+    subcategoria: 'vertimiento',
+    estado: 'verificado',
+    nivel_severidad: 'alto',
+    latitud: 10.401,
+    longitud: -73.201,
+    municipio: 'Valledupar',
+    departamento: 'Cesar',
+    created_at: new Date().toISOString(),
+  },
+  {
+    id_reporte: 2,
+    tipo_contaminacion: 'agua',
+    subcategoria: 'vertimiento',
+    estado: 'resuelto',
+    nivel_severidad: 'critico',
+    latitud: 10.402,
+    longitud: -73.202,
+    municipio: 'Valledupar',
+    departamento: 'Cesar',
+    created_at: new Date().toISOString(),
+  },
+  {
+    id_reporte: 3,
+    tipo_contaminacion: 'aire',
+    subcategoria: 'humo',
+    estado: 'en_proceso',
+    nivel_severidad: 'medio',
+    latitud: 11.1,
+    longitud: -74.1,
+    municipio: 'Santa Marta',
+    departamento: 'Magdalena',
+    created_at: new Date().toISOString(),
+  },
+];
+
+test('calcularZonasRiesgo agrupa por grilla y no expone datos personales', async (t) => {
+  invalidatePrediccionCache();
+  t.mock.method(ReporteModel, 'findParaPrediccion', async () => reportesBase);
+
+  const result = await calcularZonasRiesgo(parseZonasParams({ min_score: '0' }));
+
+  assert.equal(result.celda_grados, 0.05);
+  assert.ok(result.actualizado_en);
+  assert.equal(result.zonas.length, 2);
+  assert.equal(result.zonas[0].tipo_dominante, 'agua');
+  assert.equal(result.zonas[0].n_reportes, 2);
+  assert.equal(Object.hasOwn(result.zonas[0], 'id_usuario'), false);
+  assert.equal(Object.hasOwn(result.zonas[0], 'autor_nombre'), false);
+});
+
+test('calcularAlertasPredictivas filtra por nivel, tipo, distancia y limite', async (t) => {
+  invalidatePrediccionCache();
+  t.mock.method(ReporteModel, 'findParaPrediccion', async () => reportesBase);
+
+  const result = await calcularAlertasPredictivas(parseAlertasParams({
+    min_score: '0',
+    nivel_min: 'alto',
+    tipo: 'agua',
+    limite: '1',
+    lat: '10.40',
+    lng: '-73.20',
+    radio_km: '20',
+  }));
+
+  assert.ok(result.generado_en);
+  assert.equal(result.alertas.length, 1);
+  assert.equal(result.alertas[0].tipo_dominante, 'agua');
+  assert.equal(result.alertas[0].nivel === 'alto' || result.alertas[0].nivel === 'critico', true);
+  assert.equal(Object.hasOwn(result.alertas[0], 'id_usuario'), false);
+});
+
+test('prediccion responde listas vacias sin datos', async (t) => {
+  invalidatePrediccionCache();
+  t.mock.method(ReporteModel, 'findParaPrediccion', async () => []);
+
+  const zonas = await calcularZonasRiesgo(parseZonasParams({}));
+  const alertas = await calcularAlertasPredictivas(parseAlertasParams({}));
+
+  assert.deepEqual(zonas.zonas, []);
+  assert.deepEqual(alertas.alertas, []);
+});
+
+test('prediccion usa cache TTL hasta invalidar', async (t) => {
+  invalidatePrediccionCache();
+  t.mock.method(ReporteModel, 'findParaPrediccion', async () => reportesBase);
+
+  await calcularZonasRiesgo(parseZonasParams({ min_score: '0' }));
+  await calcularZonasRiesgo(parseZonasParams({ min_score: '0' }));
+
+  assert.equal(ReporteModel.findParaPrediccion.mock.callCount(), 1);
+  assert.equal(getPrediccionCacheSize() > 0, true);
+
+  invalidatePrediccionCache();
+  assert.equal(getPrediccionCacheSize(), 0);
+
+  await calcularZonasRiesgo(parseZonasParams({ min_score: '0' }));
+  assert.equal(ReporteModel.findParaPrediccion.mock.callCount(), 2);
+});
+
+test('parseAlertasParams valida parametros geograficos y nivel', () => {
+  assert.throws(
+    () => parseAlertasParams({ lat: '91' }),
+    /lat debe ser un numero entre -90 y 90/
+  );
+  assert.throws(
+    () => parseAlertasParams({ nivel_min: 'urgente' }),
+    /nivel_min debe ser uno de/
+  );
+  assert.throws(
+    () => parseZonasParams({ min_score: '101' }),
+    /min_score debe ser un numero entre 0 y 100/
+  );
+});


### PR DESCRIPTION
# Closes #204 

## Descripción

Se implementó el servicio de predicción para zonas de riesgo y alertas predictivas.
Ahora `GET /reportes/zonas-riesgo` calcula zonas por grilla geográfica y devuelve `actualizado_en`, `celda_grados` y `zonas`. Este endpoint se mantiene restringido a `admin/moderador`.
También se actualizó `GET /reportes/alertas-predictivas` para devolver `generado_en` y `alertas`, quedando público con `optionalAuth` porque solo expone datos agregados, sin información personal.
Se agregó cache con TTL para los cálculos, invalidación al crear, actualizar estado/severidad o eliminar reportes, validación de parámetros, `ReporteModel.findParaPrediccion`, una migración con índices para predicción y tests para cálculo, filtros, listas vacías, cache e invalidación.

<img width="787" height="817" alt="image" src="https://github.com/user-attachments/assets/05412bf0-026e-472d-b2e3-a37b2f4c9794" />
