### PR TITLE
205 chatbot conversacional compatible

### DIFF
--- a/migrations/011_add_prediction_indexes.sql
+++ b/migrations/011_add_prediction_indexes.sql
@@ -1,0 +1,9 @@
+-- Migracion: indices para prediccion de zonas de riesgo y alertas
+CREATE INDEX idx_reportes_estado_created_at
+  ON reportes (estado, created_at);
+
+CREATE INDEX idx_reportes_tipo_created_at
+  ON reportes (tipo_contaminacion, created_at);
+
+CREATE INDEX idx_reportes_latitud_longitud
+  ON reportes (latitud, longitud);

--- a/routes/reporte.routes.js
+++ b/routes/reporte.routes.js
@@ -11,8 +11,6 @@ import {
   getStatsTimeline,
   getHeatmapPoints,
   getStatsIA,
-  getZonasRiesgo,
-  getAlertasPredictivas,
   getTrendingReportes,
   toggleLikeReporte,
   analizarImagen,
@@ -24,6 +22,10 @@ import {
   addEvidenciaReporte,
   deleteEvidenciaReporte,
 } from '../src/controllers/reporte.controller.js';
+import {
+  getAlertasPredictivas,
+  getZonasRiesgo,
+} from '../src/controllers/prediccion.controller.js';
  
 
 const reporteRouter = Router();
@@ -34,7 +36,7 @@ reporteRouter.get('/stats/timeline', getStatsTimeline);
 reporteRouter.get('/stats/heatmap', getHeatmapPoints);
 reporteRouter.get('/stats/ia', verifyToken, requireRoles('admin', 'moderador'), getStatsIA);
 reporteRouter.get('/zonas-riesgo', verifyToken, requireRoles('admin', 'moderador'), getZonasRiesgo);
-reporteRouter.get('/alertas-predictivas', getAlertasPredictivas);
+reporteRouter.get('/alertas-predictivas', optionalAuth, getAlertasPredictivas);
 reporteRouter.get('/trending', optionalAuth, getTrendingReportes);
 reporteRouter.get('/export', verifyToken, requireRoles('admin', 'moderador'), exportReportes);
 reporteRouter.get('/mis-reportes', verifyToken, getMisReportes);

--- a/src/controllers/chatbot.controller.js
+++ b/src/controllers/chatbot.controller.js
@@ -1,129 +1,70 @@
-import { ReporteModel } from '../models/reporte.model.js';
+import { generarRespuestaChatbot } from '../services/chatbot.service.js';
+import { FAQ_GROUPS } from '../services/chatbot-offline.js';
 import { successResponse, errorResponse } from '../utils/response.js';
 
-const FAQ_GROUPS = [
-  {
-    titulo: 'Reportes',
-    items: [
-      {
-        pregunta: 'Como crear un reporte ambiental?',
-        prompt: 'Como creo un reporte ambiental?',
-      },
-      {
-        pregunta: 'Que evidencia puedo adjuntar?',
-        prompt: 'Que evidencia puedo adjuntar a un reporte?',
-      },
-      {
-        pregunta: 'Como reviso el estado de mi reporte?',
-        prompt: 'Como reviso el estado de mi reporte?',
-      },
-    ],
-  },
-  {
-    titulo: 'Alertas',
-    items: [
-      {
-        pregunta: 'Que son las zonas de riesgo?',
-        prompt: 'Que son las zonas de riesgo predictivas?',
-      },
-      {
-        pregunta: 'Como activar alertas en mi zona?',
-        prompt: 'Como activo alertas en mi zona?',
-      },
-    ],
-  },
-  {
-    titulo: 'Cuenta',
-    items: [
-      {
-        pregunta: 'Como verifico mi correo?',
-        prompt: 'Como verifico mi correo electronico?',
-      },
-      {
-        pregunta: 'Como recupero mi contrasena?',
-        prompt: 'Como recupero mi contrasena?',
-      },
-    ],
-  },
-];
+const MAX_MESSAGE_LENGTH = 500;
+const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const RATE_LIMIT_MAX = 20;
+const rateLimitStore = new Map();
 
-const detectIntent = (mensaje) => {
-  const text = String(mensaje || '').toLowerCase();
-  if (/reporte|denuncia|evidencia|foto|crear|enviar/.test(text)) return 'reportes';
-  if (/alerta|riesgo|zona|mapa|predic/.test(text)) return 'alertas';
-  if (/correo|verific|otp|codigo/.test(text)) return 'verificacion';
-  if (/contrase|password|recuper/.test(text)) return 'recuperacion';
-  if (/estado|seguimiento|moderacion|revision/.test(text)) return 'seguimiento';
-  return 'fallback';
+export const clearChatbotRateLimit = () => {
+  rateLimitStore.clear();
 };
 
-const buildRespuesta = (intent, stats) => {
-  const totalReportes = Number(stats?.total_reportes) || 0;
-  const municipios = Number(stats?.municipios_activos) || 0;
+const getRateLimitKey = (req, sessionId) => (
+  sessionId || req.ip || req.socket?.remoteAddress || 'anonymous'
+);
 
-  const responses = {
-    reportes: `Para crear un reporte entra a "Nuevo reporte", selecciona la categoria, severidad, descripcion, ubicacion y adjunta evidencias si las tienes. La plataforma registra el reporte y lo deja en estado pendiente para revision.`,
-    alertas: `Las zonas de riesgo se calculan con reportes recientes, severidad y concentracion geografica. Actualmente hay ${totalReportes} reportes registrados en ${municipios} municipio(s) activo(s).`,
-    verificacion: 'Despues del registro enviamos un codigo de 6 digitos al correo. En la pantalla "Verifica tu correo" puedes ingresarlo o solicitar un nuevo codigo cuando termine el contador.',
-    recuperacion: 'Para recuperar tu contrasena usa "Olvidaste tu contrasena", escribe tu correo y abre el enlace recibido. El enlace expira por seguridad.',
-    seguimiento: 'Puedes revisar el estado en "Mis reportes". Los moderadores pueden cambiar un reporte entre pendiente, en revision, verificado, en proceso, resuelto o rechazado.',
-    fallback: 'Puedo ayudarte con reportes ambientales, verificacion de correo, recuperacion de contrasena, alertas de riesgo y seguimiento de reportes.',
-  };
+const isRateLimited = (key) => {
+  const now = Date.now();
+  const entry = rateLimitStore.get(key);
 
-  return responses[intent] || responses.fallback;
-};
-
-const buildSuggestions = (intent) => {
-  const common = [
-    'Como crear un reporte ambiental?',
-    'Como verifico mi correo?',
-    'Que son las zonas de riesgo?',
-  ];
-
-  if (intent === 'reportes') {
-    return ['Que evidencia puedo adjuntar?', 'Como edito un reporte?', 'Como veo mis reportes?'];
+  if (!entry || entry.resetAt <= now) {
+    rateLimitStore.set(key, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return false;
   }
 
-  if (intent === 'alertas') {
-    return ['Como activar alertas en mi zona?', 'Que significa riesgo critico?', 'Como se calcula el mapa?'];
-  }
-
-  return common;
+  entry.count += 1;
+  return entry.count > RATE_LIMIT_MAX;
 };
 
 export const enviarMensajeChatbot = async (req, res, next) => {
   const startedAt = Date.now();
+
   try {
-    const { mensaje, sessionId } = req.body ?? {};
+    const { mensaje, sessionId, lat, lng } = req.body ?? {};
     const cleanMessage = typeof mensaje === 'string' ? mensaje.trim() : '';
 
     if (!cleanMessage) {
       return errorResponse(res, 'El mensaje es requerido.', 400);
     }
 
-    const [stats, zonas] = await Promise.all([
-      ReporteModel.getStats(),
-      ReporteModel.getAlertasPredictivas({ limite: 3, nivel_min: 'medio' }).catch(() => []),
-    ]);
-    const intent = detectIntent(cleanMessage);
+    if (cleanMessage.length > MAX_MESSAGE_LENGTH) {
+      return errorResponse(res, 'El mensaje no puede superar 500 caracteres.', 400);
+    }
+
+    if (isRateLimited(getRateLimitKey(req, sessionId))) {
+      return errorResponse(res, 'Demasiados mensajes. Intenta nuevamente en un minuto.', 429);
+    }
+
+    const result = await generarRespuestaChatbot({
+      mensaje: cleanMessage,
+      sessionId,
+      user: req.user,
+      lat,
+      lng,
+    });
 
     return successResponse(
       res,
       {
         sessionId,
-        respuesta: buildRespuesta(intent, stats),
-        sugerencias: buildSuggestions(intent),
-        cards: zonas.map((zona) => ({
-          titulo: `${zona.municipio || 'Zona'} - riesgo ${zona.nivel}`,
-          descripcion: `${zona.n_reportes} reporte(s), categoria ${zona.tipo_dominante}`,
-          tipo: 'alerta',
-          data: zona,
-        })),
-        estadoAmbiental: zonas.some((zona) => zona.nivel === 'critico' || zona.nivel === 'alto')
-          ? 'alerta'
-          : 'optimo',
-        fuente: 'backend',
-        intent,
+        respuesta: result.respuesta,
+        intent: result.intent,
+        fuente: result.fuente,
+        sugerencias: result.sugerencias,
+        cards: result.cards,
+        estadoAmbiental: result.estadoAmbiental,
         latencia_ms: Date.now() - startedAt,
       },
       'Respuesta generada correctamente.'

--- a/src/controllers/prediccion.controller.js
+++ b/src/controllers/prediccion.controller.js
@@ -1,0 +1,27 @@
+import {
+  calcularAlertasPredictivas,
+  calcularZonasRiesgo,
+  parseAlertasParams,
+  parseZonasParams,
+} from '../services/prediccion.service.js';
+import { successResponse } from '../utils/response.js';
+
+export const getZonasRiesgo = async (req, res, next) => {
+  try {
+    const payload = await calcularZonasRiesgo(parseZonasParams(req.query));
+    return successResponse(res, payload, 'Zonas de riesgo obtenidas correctamente.');
+  } catch (error) {
+    return next(error);
+  }
+};
+
+// Publico para que el frontend pueda mostrar alertas preventivas sin sesion.
+// No expone autores, usuarios ni IDs personales; solo agregados por zona.
+export const getAlertasPredictivas = async (req, res, next) => {
+  try {
+    const payload = await calcularAlertasPredictivas(parseAlertasParams(req.query));
+    return successResponse(res, payload, 'Alertas predictivas obtenidas correctamente.');
+  } catch (error) {
+    return next(error);
+  }
+};

--- a/src/controllers/reporte.controller.js
+++ b/src/controllers/reporte.controller.js
@@ -11,6 +11,7 @@ import { EvidenciaModel } from '../models/evidencia.model.js';
 import { LikeModel } from '../models/like.model.js';
 import { analyzeReporte } from '../services/ia.service.js';
 import { clasificarImagen } from '../services/clasificacion.service.js';
+import { invalidatePrediccionCache } from '../services/prediccion.service.js';
 import { errorResponse, successResponse } from '../utils/response.js';
 
 const ANONYMOUS_VIEW_THROTTLE_MS = 5 * 60 * 1000;
@@ -324,6 +325,7 @@ export const createReporte = async (req, res, next) => {
       });
     }
 
+    invalidatePrediccionCache();
     return successResponse(res, { reporte }, 'Reporte creado correctamente.', 201);
   } catch (error) {
     return next(error);
@@ -687,6 +689,12 @@ export const updateReporte = async (req, res, next) => {
     }
 
     await ReporteModel.update(id, campos);
+    if (
+      Object.prototype.hasOwnProperty.call(campos, 'estado') ||
+      Object.prototype.hasOwnProperty.call(campos, 'nivel_severidad')
+    ) {
+      invalidatePrediccionCache();
+    }
     const updated = await ReporteModel.findById(id);
     return successResponse(res, { reporte: updated }, 'Reporte actualizado.');
   } catch (error) {
@@ -718,6 +726,7 @@ export const deleteReporte = async (req, res, next) => {
     }
 
     await ReporteModel.remove(id);
+    invalidatePrediccionCache();
     return successResponse(res, null, 'Reporte eliminado.');
   } catch (error) {
     return next(error);

--- a/src/models/reporte.model.js
+++ b/src/models/reporte.model.js
@@ -550,6 +550,46 @@ export const ReporteModel = {
     return rows;
   },
 
+  findParaPrediccion: async ({ desde, tipo } = {}) => {
+    const conditions = [
+      'r.deleted_at IS NULL',
+      'r.latitud IS NOT NULL',
+      'r.longitud IS NOT NULL',
+      "r.estado IN ('verificado', 'en_proceso', 'resuelto')",
+    ];
+    const params = [];
+
+    if (desde) {
+      conditions.push('r.created_at >= ?');
+      params.push(desde);
+    }
+
+    if (tipo) {
+      conditions.push('r.tipo_contaminacion = ?');
+      params.push(tipo);
+    }
+
+    const [rows] = await pool.execute(
+      `SELECT
+         r.id_reporte,
+         r.tipo_contaminacion,
+         r.subcategoria,
+         r.estado,
+         r.nivel_severidad,
+         r.latitud,
+         r.longitud,
+         r.municipio,
+         r.departamento,
+         r.created_at
+       FROM reportes r
+       WHERE ${conditions.join(' AND ')}
+       ORDER BY r.created_at DESC`,
+      params
+    );
+
+    return rows;
+  },
+
   findTrending: async ({ limit = 12 } = {}) => {
     const safeLimit = Math.max(1, Math.min(50, parseInt(limit, 10) || 12));
     const [rows] = await pool.execute(

--- a/src/services/chatbot-context.js
+++ b/src/services/chatbot-context.js
@@ -1,0 +1,40 @@
+import { ReporteModel } from '../models/reporte.model.js';
+import {
+  calcularAlertasPredictivas,
+  parseAlertasParams,
+} from './prediccion.service.js';
+
+const toNumber = (value) => {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+};
+
+export const construirContextoChatbot = async ({ user, lat, lng } = {}) => {
+  const userId = user?.sub;
+  const latitude = toNumber(lat);
+  const longitude = toNumber(lng);
+
+  const [global, usuario, alertasPayload] = await Promise.all([
+    ReporteModel.getStats().catch(() => ({})),
+    userId
+      ? Promise.all([
+        ReporteModel.findByUsuario(userId, { limit: 5, offset: 0 }).catch(() => []),
+        ReporteModel.countByUsuario(userId).catch(() => 0),
+      ]).then(([reportes, total]) => ({ reportes, total_reportes: Number(total) || 0 }))
+      : Promise.resolve(null),
+    calcularAlertasPredictivas(parseAlertasParams({
+      lat: latitude ?? undefined,
+      lng: longitude ?? undefined,
+      radio_km: latitude !== null && longitude !== null ? 25 : undefined,
+      limite: 3,
+      min_score: 0,
+      nivel_min: 'medio',
+    })).catch(() => ({ alertas: [] })),
+  ]);
+
+  return {
+    global,
+    usuario,
+    alertasZona: alertasPayload.alertas || [],
+  };
+};

--- a/src/services/chatbot-offline.js
+++ b/src/services/chatbot-offline.js
@@ -1,0 +1,108 @@
+export const FAQ_GROUPS = [
+  {
+    titulo: 'Reportes',
+    items: [
+      { pregunta: 'Como crear un reporte ambiental?', prompt: 'Como creo un reporte ambiental?' },
+      { pregunta: 'Que evidencia puedo adjuntar?', prompt: 'Que evidencia puedo adjuntar a un reporte?' },
+      { pregunta: 'Como reviso el estado de mi reporte?', prompt: 'Como reviso el estado de mi reporte?' },
+    ],
+  },
+  {
+    titulo: 'Alertas',
+    items: [
+      { pregunta: 'Que son las zonas de riesgo?', prompt: 'Que son las zonas de riesgo predictivas?' },
+      { pregunta: 'Como activar alertas en mi zona?', prompt: 'Como activo alertas en mi zona?' },
+    ],
+  },
+  {
+    titulo: 'Cuenta',
+    items: [
+      { pregunta: 'Como verifico mi correo?', prompt: 'Como verifico mi correo electronico?' },
+      { pregunta: 'Como recupero mi contrasena?', prompt: 'Como recupero mi contrasena?' },
+    ],
+  },
+];
+
+const normalizeText = (value) => (
+  String(value || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+);
+
+export const detectIntent = (mensaje) => {
+  const text = normalizeText(mensaje);
+
+  if (/mis reportes|mis denuncias|cuantos reportes|estado de mi|seguimiento/.test(text)) {
+    return 'mis_reportes';
+  }
+  if (/reporte|denuncia|evidencia|foto|crear|enviar|adjuntar/.test(text)) return 'reportes';
+  if (/alerta|riesgo|zona|mapa|predic|cerca|ubicacion/.test(text)) return 'alertas';
+  if (/correo|verific|otp|codigo/.test(text)) return 'verificacion';
+  if (/contrase|password|recuper/.test(text)) return 'recuperacion';
+  if (/estado|moderacion|revision/.test(text)) return 'seguimiento';
+  return 'fallback';
+};
+
+export const buildSuggestions = (intent) => {
+  if (intent === 'reportes') {
+    return ['Que evidencia puedo adjuntar?', 'Como edito un reporte?', 'Como veo mis reportes?'];
+  }
+
+  if (intent === 'alertas') {
+    return ['Como activar alertas en mi zona?', 'Que significa riesgo critico?', 'Como se calcula el mapa?'];
+  }
+
+  if (intent === 'mis_reportes') {
+    return ['Como reviso el estado?', 'Puedo editar un reporte?', 'Como agrego evidencias?'];
+  }
+
+  return [
+    'Como crear un reporte ambiental?',
+    'Como verifico mi correo?',
+    'Que son las zonas de riesgo?',
+  ];
+};
+
+export const buildCards = (contexto = {}) => (
+  (contexto.alertasZona || []).slice(0, 3).map((alerta) => ({
+    titulo: `${alerta.tipo_dominante || 'Zona'} - riesgo ${alerta.nivel}`,
+    descripcion: `${alerta.n_reportes || 0} reporte(s), score ${alerta.score || 0}`,
+    tipo: 'alerta',
+    data: alerta,
+  }))
+);
+
+export const buildOfflineResponse = ({ mensaje, contexto = {} }) => {
+  const intent = detectIntent(mensaje);
+  const stats = contexto.global || {};
+  const usuario = contexto.usuario || null;
+  const totalReportes = Number(stats.total_reportes) || 0;
+  const municipios = Number(stats.municipios_activos) || 0;
+  const reportesUsuario = usuario?.total_reportes ?? usuario?.reportes?.length ?? 0;
+
+  const responses = {
+    reportes: 'Para crear un reporte entra a Nuevo reporte, selecciona categoria y severidad, describe el problema, agrega ubicacion y adjunta evidencias si las tienes.',
+    alertas: `Las zonas de riesgo se calculan con reportes recientes, severidad y concentracion geografica. Hay ${totalReportes} reportes registrados en ${municipios} municipio(s) activo(s).`,
+    verificacion: 'Despues del registro enviamos un codigo de 6 digitos al correo. Puedes ingresarlo en la pantalla de verificacion o solicitar uno nuevo cuando termine el contador.',
+    recuperacion: 'Para recuperar tu contrasena usa Olvidaste tu contrasena, escribe tu correo y abre el enlace recibido. El enlace expira por seguridad.',
+    seguimiento: 'Puedes revisar el estado en Mis reportes. Los moderadores pueden cambiar un reporte entre pendiente, en revision, verificado, en proceso, resuelto o rechazado.',
+    mis_reportes: usuario
+      ? `Tienes ${reportesUsuario} reporte(s) registrados. Revisa Mis reportes para ver estado, evidencias y comentarios de moderacion.`
+      : 'Para consultar tus reportes necesito que inicies sesion. Sin sesion puedo ayudarte con reportes, alertas y verificacion.',
+    fallback: 'Puedo ayudarte con reportes ambientales, verificacion de correo, recuperacion de contrasena, alertas de riesgo y seguimiento de reportes.',
+  };
+
+  const cards = buildCards(contexto);
+
+  return {
+    respuesta: responses[intent] || responses.fallback,
+    intent,
+    fuente: 'offline',
+    sugerencias: buildSuggestions(intent),
+    cards,
+    estadoAmbiental: cards.some((card) => ['critico', 'alto'].includes(card.data?.nivel))
+      ? 'alerta'
+      : 'optimo',
+  };
+};

--- a/src/services/chatbot.service.js
+++ b/src/services/chatbot.service.js
@@ -1,0 +1,115 @@
+import { buildOfflineResponse } from './chatbot-offline.js';
+import { construirContextoChatbot } from './chatbot-context.js';
+
+const CACHE_TTL_MS = 30 * 1000;
+const cache = new Map();
+
+const getCacheKey = ({ mensaje, sessionId, user, lat, lng }) => JSON.stringify({
+  mensaje: String(mensaje || '').trim().toLowerCase(),
+  sessionId: sessionId || null,
+  userId: user?.sub || null,
+  lat: lat || null,
+  lng: lng || null,
+});
+
+const getCached = (key) => {
+  const entry = cache.get(key);
+  if (!entry || entry.expiresAt <= Date.now()) {
+    cache.delete(key);
+    return null;
+  }
+
+  return entry.value;
+};
+
+const setCached = (key, value) => {
+  cache.set(key, {
+    value,
+    expiresAt: Date.now() + CACHE_TTL_MS,
+  });
+  return value;
+};
+
+export const clearChatbotCache = () => {
+  cache.clear();
+};
+
+export const getChatbotCacheSize = () => cache.size;
+
+const fetchJson = async (url, options) => {
+  const response = await fetch(url, {
+    ...options,
+    signal: AbortSignal.timeout(4000),
+  });
+
+  if (!response.ok) return null;
+  return response.json();
+};
+
+const tryGroq = async ({ mensaje, contexto }) => {
+  if (!process.env.GROQ_API_KEY) return null;
+
+  const json = await fetchJson('https://api.groq.com/openai/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.GROQ_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: process.env.GROQ_MODEL || 'llama-3.1-8b-instant',
+      messages: [
+        { role: 'system', content: 'Responde como asistente ambiental de Green Alert. Mantén formato breve y accionable.' },
+        { role: 'user', content: JSON.stringify({ mensaje, contexto }) },
+      ],
+      temperature: 0.2,
+    }),
+  }).catch(() => null);
+
+  const respuesta = json?.choices?.[0]?.message?.content?.trim();
+  return respuesta ? { respuesta, fuente: 'groq' } : null;
+};
+
+const tryGemini = async ({ mensaje, contexto }) => {
+  if (!process.env.GEMINI_API_KEY) return null;
+
+  const model = process.env.GEMINI_MODEL || 'gemini-1.5-flash';
+  const json = await fetchJson(
+    `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${process.env.GEMINI_API_KEY}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contents: [{
+          parts: [{ text: JSON.stringify({ mensaje, contexto }) }],
+        }],
+      }),
+    }
+  ).catch(() => null);
+
+  const respuesta = json?.candidates?.[0]?.content?.parts?.[0]?.text?.trim();
+  return respuesta ? { respuesta, fuente: 'gemini' } : null;
+};
+
+export const generarRespuestaChatbot = async ({ mensaje, sessionId, user, lat, lng }) => {
+  const key = getCacheKey({ mensaje, sessionId, user, lat, lng });
+  const cached = getCached(key);
+  if (cached) {
+    return {
+      ...cached,
+      cache: true,
+    };
+  }
+
+  const contexto = await construirContextoChatbot({ user, lat, lng });
+  const offline = buildOfflineResponse({ mensaje, contexto });
+  const external = await tryGroq({ mensaje, contexto })
+    || await tryGemini({ mensaje, contexto });
+
+  const result = {
+    ...offline,
+    ...(external ? { respuesta: external.respuesta, fuente: external.fuente } : {}),
+    cache: false,
+  };
+
+  return setCached(key, result);
+};

--- a/src/services/prediccion.service.js
+++ b/src/services/prediccion.service.js
@@ -1,0 +1,268 @@
+import { ReporteModel } from '../models/reporte.model.js';
+
+export const PREDICCION_CACHE_TTL_MS = 5 * 60 * 1000;
+export const DEFAULT_CELDA_GRADOS = 0.05;
+
+const cache = new Map();
+const NIVEL_RANK = { bajo: 1, medio: 2, alto: 3, critico: 4 };
+const SCORE_NIVEL = [
+  { min: 80, nivel: 'critico' },
+  { min: 60, nivel: 'alto' },
+  { min: 35, nivel: 'medio' },
+  { min: 0, nivel: 'bajo' },
+];
+
+const toNumber = (value) => {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+};
+
+const validationError = (message) => {
+  const error = new Error(message);
+  error.statusCode = 400;
+  return error;
+};
+
+const clampInt = (value, { fallback, min, max }) => {
+  if (value === undefined || value === null || value === '') return fallback;
+  const parsed = parseInt(value, 10);
+  if (!Number.isFinite(parsed)) {
+    throw validationError(`El parametro debe ser un entero entre ${min} y ${max}.`);
+  }
+  return Math.max(min, Math.min(max, parsed));
+};
+
+const parseDateDesde = (dias) => {
+  const safeDias = clampInt(dias, { fallback: 30, min: 1, max: 365 });
+  const desde = new Date();
+  desde.setDate(desde.getDate() - safeDias);
+  return { safeDias, desde };
+};
+
+const cacheKey = (name, params) => `${name}:${JSON.stringify(params)}`;
+
+const getCached = (key) => {
+  const entry = cache.get(key);
+  if (!entry || entry.expiresAt <= Date.now()) {
+    cache.delete(key);
+    return null;
+  }
+
+  return entry.value;
+};
+
+const setCached = (key, value) => {
+  cache.set(key, {
+    value,
+    expiresAt: Date.now() + PREDICCION_CACHE_TTL_MS,
+  });
+  return value;
+};
+
+export const invalidatePrediccionCache = () => {
+  cache.clear();
+};
+
+export const getPrediccionCacheSize = () => cache.size;
+
+const validateTipo = (tipo) => (
+  typeof tipo === 'string' && tipo.trim() ? tipo.trim().toLowerCase() : null
+);
+
+export const parseZonasParams = (query = {}) => {
+  const { safeDias, desde } = parseDateDesde(query.dias);
+  const minScore = query.min_score === undefined || query.min_score === ''
+    ? 30
+    : Number(query.min_score);
+
+  if (!Number.isFinite(minScore) || minScore < 0 || minScore > 100) {
+    throw validationError('min_score debe ser un numero entre 0 y 100.');
+  }
+
+  return {
+    dias: safeDias,
+    desde,
+    tipo: validateTipo(query.tipo),
+    min_score: minScore,
+  };
+};
+
+export const parseAlertasParams = (query = {}) => {
+  const zonasParams = parseZonasParams(query);
+  const limite = clampInt(query.limite, { fallback: 10, min: 1, max: 50 });
+  const nivel_min = query.nivel_min === undefined || query.nivel_min === ''
+    ? 'medio'
+    : String(query.nivel_min).toLowerCase();
+  if (!NIVEL_RANK[nivel_min]) {
+    throw validationError('nivel_min debe ser uno de: bajo, medio, alto, critico.');
+  }
+  const lat = toNumber(query.lat);
+  const lng = toNumber(query.lng);
+  const radio_km = toNumber(query.radio_km);
+
+  if (query.lat !== undefined && (lat === null || lat < -90 || lat > 90)) {
+    throw validationError('lat debe ser un numero entre -90 y 90.');
+  }
+  if (query.lng !== undefined && (lng === null || lng < -180 || lng > 180)) {
+    throw validationError('lng debe ser un numero entre -180 y 180.');
+  }
+  if (query.radio_km !== undefined && (radio_km === null || radio_km <= 0 || radio_km > 500)) {
+    throw validationError('radio_km debe ser un numero mayor a 0 y menor o igual a 500.');
+  }
+
+  return {
+    ...zonasParams,
+    limite,
+    nivel_min,
+    lat: lat !== null && lat >= -90 && lat <= 90 ? lat : null,
+    lng: lng !== null && lng >= -180 && lng <= 180 ? lng : null,
+    radio_km: radio_km !== null && radio_km > 0 ? Math.min(radio_km, 500) : null,
+  };
+};
+
+const gridKeyFor = (lat, lng, cellSize = DEFAULT_CELDA_GRADOS) => {
+  const latCell = Math.floor(Number(lat) / cellSize) * cellSize;
+  const lngCell = Math.floor(Number(lng) / cellSize) * cellSize;
+  return `${latCell.toFixed(4)}:${lngCell.toFixed(4)}`;
+};
+
+const scoreZona = (reportes) => {
+  const severidadPromedio = reportes.reduce(
+    (sum, reporte) => sum + (NIVEL_RANK[reporte.nivel_severidad] || 1),
+    0
+  ) / Math.max(1, reportes.length);
+  const recencia = reportes.reduce((sum, reporte) => {
+    const createdAt = new Date(reporte.created_at).getTime();
+    const days = Number.isFinite(createdAt)
+      ? Math.max(0, (Date.now() - createdAt) / 86400000)
+      : 365;
+    return sum + Math.max(0, 30 - days);
+  }, 0) / Math.max(1, reportes.length);
+  const score = Math.min(100, Math.round((reportes.length * 16) + (severidadPromedio * 14) + recencia));
+  const nivel = SCORE_NIVEL.find((item) => score >= item.min)?.nivel || 'bajo';
+
+  return { score, nivel, severidadPromedio };
+};
+
+const buildZonas = (reportes, { min_score }) => {
+  const grouped = new Map();
+
+  for (const reporte of reportes) {
+    const lat = Number(reporte.latitud);
+    const lng = Number(reporte.longitud);
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) continue;
+
+    const key = gridKeyFor(lat, lng);
+    grouped.set(key, [...(grouped.get(key) || []), reporte]);
+  }
+
+  return [...grouped.entries()]
+    .map(([key, items]) => {
+      const [latCell, lngCell] = key.split(':').map(Number);
+      const { score, nivel, severidadPromedio } = scoreZona(items);
+      const tipoCounts = new Map();
+      let latest = null;
+
+      for (const item of items) {
+        tipoCounts.set(item.tipo_contaminacion, (tipoCounts.get(item.tipo_contaminacion) || 0) + 1);
+        const itemDate = new Date(item.created_at).getTime();
+        if (!latest || itemDate > new Date(latest).getTime()) latest = item.created_at;
+      }
+
+      const [tipoDominante] = [...tipoCounts.entries()].sort((a, b) => b[1] - a[1])[0] || ['otro'];
+
+      return {
+        id: key,
+        zona_id: key,
+        centro: {
+          lat: Number((latCell + (DEFAULT_CELDA_GRADOS / 2)).toFixed(6)),
+          lng: Number((lngCell + (DEFAULT_CELDA_GRADOS / 2)).toFixed(6)),
+        },
+        tipo_dominante: tipoDominante,
+        n_reportes: items.length,
+        severidad_promedio: Number(severidadPromedio.toFixed(2)),
+        ultimo_reporte: latest,
+        score,
+        nivel,
+      };
+    })
+    .filter((zona) => zona.score >= min_score)
+    .sort((a, b) => b.score - a.score || b.n_reportes - a.n_reportes);
+};
+
+const distanceKm = (a, b) => {
+  const radius = 6371;
+  const dLat = ((b.lat - a.lat) * Math.PI) / 180;
+  const dLng = ((b.lng - a.lng) * Math.PI) / 180;
+  const lat1 = (a.lat * Math.PI) / 180;
+  const lat2 = (b.lat * Math.PI) / 180;
+  const h = Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) ** 2;
+  return 2 * radius * Math.asin(Math.sqrt(h));
+};
+
+export const calcularZonasRiesgo = async (params) => {
+  const key = cacheKey('zonas', {
+    dias: params.dias,
+    tipo: params.tipo,
+    min_score: params.min_score,
+  });
+  const cached = getCached(key);
+  if (cached) return cached;
+
+  const reportes = await ReporteModel.findParaPrediccion({
+    desde: params.desde,
+    tipo: params.tipo,
+  });
+  const payload = {
+    actualizado_en: new Date().toISOString(),
+    celda_grados: DEFAULT_CELDA_GRADOS,
+    zonas: buildZonas(reportes, params),
+  };
+
+  return setCached(key, payload);
+};
+
+export const calcularAlertasPredictivas = async (params) => {
+  const key = cacheKey('alertas', {
+    dias: params.dias,
+    tipo: params.tipo,
+    min_score: params.min_score,
+    limite: params.limite,
+    nivel_min: params.nivel_min,
+    lat: params.lat,
+    lng: params.lng,
+    radio_km: params.radio_km,
+  });
+  const cached = getCached(key);
+  if (cached) return cached;
+
+  const zonasPayload = await calcularZonasRiesgo({ ...params, min_score: params.min_score ?? 0 });
+  const minRank = NIVEL_RANK[params.nivel_min] || NIVEL_RANK.medio;
+  const origin = params.lat !== null && params.lng !== null ? { lat: params.lat, lng: params.lng } : null;
+
+  const alertas = zonasPayload.zonas
+    .filter((zona) => (NIVEL_RANK[zona.nivel] || 1) >= minRank)
+    .filter((zona) => !params.tipo || zona.tipo_dominante === params.tipo)
+    .map((zona) => ({
+      id: zona.id,
+      zona_id: zona.zona_id,
+      centro: zona.centro,
+      tipo_dominante: zona.tipo_dominante,
+      n_reportes: zona.n_reportes,
+      score: zona.score,
+      nivel: zona.nivel,
+      ultimo_reporte: zona.ultimo_reporte,
+      distancia_km: origin ? Number(distanceKm(origin, zona.centro).toFixed(2)) : null,
+    }))
+    .filter((alerta) => !origin || !params.radio_km || alerta.distancia_km <= params.radio_km)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, params.limite);
+
+  const payload = {
+    generado_en: new Date().toISOString(),
+    alertas,
+  };
+
+  return setCached(key, payload);
+};

--- a/tests/unit/chatbot-conversacional.test.js
+++ b/tests/unit/chatbot-conversacional.test.js
@@ -1,0 +1,147 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { enviarMensajeChatbot, clearChatbotRateLimit } from '../../src/controllers/chatbot.controller.js';
+import { detectIntent, buildOfflineResponse } from '../../src/services/chatbot-offline.js';
+import {
+  clearChatbotCache,
+  generarRespuestaChatbot,
+  getChatbotCacheSize,
+} from '../../src/services/chatbot.service.js';
+import { ReporteModel } from '../../src/models/reporte.model.js';
+
+const createResponse = () => ({
+  statusCode: null,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+});
+
+const mockContextQueries = (t) => {
+  t.mock.method(ReporteModel, 'getStats', async () => ({
+    total_reportes: 12,
+    municipios_activos: 3,
+  }));
+  t.mock.method(ReporteModel, 'findByUsuario', async () => ([
+    { id_reporte: 1, estado: 'pendiente', titulo: 'Reporte propio' },
+  ]));
+  t.mock.method(ReporteModel, 'countByUsuario', async () => 1);
+  t.mock.method(ReporteModel, 'findParaPrediccion', async () => []);
+};
+
+test('detectIntent reconoce intents principales', () => {
+  assert.equal(detectIntent('Quiero crear un reporte con foto'), 'reportes');
+  assert.equal(detectIntent('Hay alertas cerca de mi ubicacion?'), 'alertas');
+  assert.equal(detectIntent('Cuantos reportes tengo?'), 'mis_reportes');
+  assert.equal(detectIntent('Como verifico mi correo?'), 'verificacion');
+  assert.equal(detectIntent('Recuperar password'), 'recuperacion');
+});
+
+test('motor offline responde con contexto de usuario cuando hay JWT', () => {
+  const result = buildOfflineResponse({
+    mensaje: 'cuantos reportes tengo?',
+    contexto: {
+      global: { total_reportes: 12, municipios_activos: 3 },
+      usuario: { total_reportes: 2, reportes: [] },
+      alertasZona: [],
+    },
+  });
+
+  assert.equal(result.intent, 'mis_reportes');
+  assert.match(result.respuesta, /Tienes 2 reporte/);
+  assert.equal(result.fuente, 'offline');
+  assert.deepEqual(result.cards, []);
+});
+
+test('generarRespuestaChatbot funciona offline y usa cache', async (t) => {
+  clearChatbotCache();
+  mockContextQueries(t);
+
+  const first = await generarRespuestaChatbot({
+    mensaje: 'Que son las zonas de riesgo?',
+    sessionId: 's1',
+    user: { sub: 7 },
+  });
+  const second = await generarRespuestaChatbot({
+    mensaje: 'Que son las zonas de riesgo?',
+    sessionId: 's1',
+    user: { sub: 7 },
+  });
+
+  assert.equal(first.fuente, 'offline');
+  assert.equal(first.cache, false);
+  assert.equal(second.cache, true);
+  assert.equal(getChatbotCacheSize(), 1);
+  assert.equal(ReporteModel.getStats.mock.callCount(), 1);
+});
+
+test('enviarMensajeChatbot valida mensaje requerido y maximo 500 caracteres', async (t) => {
+  clearChatbotRateLimit();
+
+  const missingRes = createResponse();
+  await enviarMensajeChatbot({ body: {}, ip: '1.1.1.1' }, missingRes, t.mock.fn());
+
+  assert.equal(missingRes.statusCode, 400);
+  assert.equal(missingRes.body.message, 'El mensaje es requerido.');
+
+  const longRes = createResponse();
+  await enviarMensajeChatbot({
+    body: { mensaje: 'a'.repeat(501) },
+    ip: '1.1.1.2',
+  }, longRes, t.mock.fn());
+
+  assert.equal(longRes.statusCode, 400);
+  assert.equal(longRes.body.message, 'El mensaje no puede superar 500 caracteres.');
+});
+
+test('enviarMensajeChatbot aplica rate limit por sessionId', async (t) => {
+  clearChatbotCache();
+  clearChatbotRateLimit();
+  mockContextQueries(t);
+
+  for (let index = 0; index < 20; index += 1) {
+    const res = createResponse();
+    await enviarMensajeChatbot({
+      body: { mensaje: `Hola ${index}`, sessionId: 'limit-session' },
+      ip: '2.2.2.2',
+    }, res, t.mock.fn());
+    assert.notEqual(res.statusCode, 429);
+  }
+
+  const limited = createResponse();
+  await enviarMensajeChatbot({
+    body: { mensaje: 'mensaje final', sessionId: 'limit-session' },
+    ip: '2.2.2.2',
+  }, limited, t.mock.fn());
+
+  assert.equal(limited.statusCode, 429);
+  assert.equal(limited.body.message, 'Demasiados mensajes. Intenta nuevamente en un minuto.');
+});
+
+test('enviarMensajeChatbot conserva formato esperado por frontend', async (t) => {
+  clearChatbotCache();
+  clearChatbotRateLimit();
+  mockContextQueries(t);
+
+  const res = createResponse();
+  await enviarMensajeChatbot({
+    body: { mensaje: 'Como crear un reporte?', sessionId: 'fmt' },
+    user: { sub: 7 },
+    ip: '3.3.3.3',
+  }, res, t.mock.fn());
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.data.sessionId, 'fmt');
+  assert.equal(typeof res.body.data.respuesta, 'string');
+  assert.equal(res.body.data.intent, 'reportes');
+  assert.equal(res.body.data.fuente, 'offline');
+  assert.ok(Array.isArray(res.body.data.sugerencias));
+  assert.ok(Array.isArray(res.body.data.cards));
+  assert.ok(['optimo', 'alerta'].includes(res.body.data.estadoAmbiental));
+  assert.equal(typeof res.body.data.latencia_ms, 'number');
+});

--- a/tests/unit/prediccion-service.test.js
+++ b/tests/unit/prediccion-service.test.js
@@ -1,0 +1,129 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  calcularAlertasPredictivas,
+  calcularZonasRiesgo,
+  getPrediccionCacheSize,
+  invalidatePrediccionCache,
+  parseAlertasParams,
+  parseZonasParams,
+} from '../../src/services/prediccion.service.js';
+import { ReporteModel } from '../../src/models/reporte.model.js';
+
+const reportesBase = [
+  {
+    id_reporte: 1,
+    tipo_contaminacion: 'agua',
+    subcategoria: 'vertimiento',
+    estado: 'verificado',
+    nivel_severidad: 'alto',
+    latitud: 10.401,
+    longitud: -73.201,
+    municipio: 'Valledupar',
+    departamento: 'Cesar',
+    created_at: new Date().toISOString(),
+  },
+  {
+    id_reporte: 2,
+    tipo_contaminacion: 'agua',
+    subcategoria: 'vertimiento',
+    estado: 'resuelto',
+    nivel_severidad: 'critico',
+    latitud: 10.402,
+    longitud: -73.202,
+    municipio: 'Valledupar',
+    departamento: 'Cesar',
+    created_at: new Date().toISOString(),
+  },
+  {
+    id_reporte: 3,
+    tipo_contaminacion: 'aire',
+    subcategoria: 'humo',
+    estado: 'en_proceso',
+    nivel_severidad: 'medio',
+    latitud: 11.1,
+    longitud: -74.1,
+    municipio: 'Santa Marta',
+    departamento: 'Magdalena',
+    created_at: new Date().toISOString(),
+  },
+];
+
+test('calcularZonasRiesgo agrupa por grilla y no expone datos personales', async (t) => {
+  invalidatePrediccionCache();
+  t.mock.method(ReporteModel, 'findParaPrediccion', async () => reportesBase);
+
+  const result = await calcularZonasRiesgo(parseZonasParams({ min_score: '0' }));
+
+  assert.equal(result.celda_grados, 0.05);
+  assert.ok(result.actualizado_en);
+  assert.equal(result.zonas.length, 2);
+  assert.equal(result.zonas[0].tipo_dominante, 'agua');
+  assert.equal(result.zonas[0].n_reportes, 2);
+  assert.equal(Object.hasOwn(result.zonas[0], 'id_usuario'), false);
+  assert.equal(Object.hasOwn(result.zonas[0], 'autor_nombre'), false);
+});
+
+test('calcularAlertasPredictivas filtra por nivel, tipo, distancia y limite', async (t) => {
+  invalidatePrediccionCache();
+  t.mock.method(ReporteModel, 'findParaPrediccion', async () => reportesBase);
+
+  const result = await calcularAlertasPredictivas(parseAlertasParams({
+    min_score: '0',
+    nivel_min: 'alto',
+    tipo: 'agua',
+    limite: '1',
+    lat: '10.40',
+    lng: '-73.20',
+    radio_km: '20',
+  }));
+
+  assert.ok(result.generado_en);
+  assert.equal(result.alertas.length, 1);
+  assert.equal(result.alertas[0].tipo_dominante, 'agua');
+  assert.equal(result.alertas[0].nivel === 'alto' || result.alertas[0].nivel === 'critico', true);
+  assert.equal(Object.hasOwn(result.alertas[0], 'id_usuario'), false);
+});
+
+test('prediccion responde listas vacias sin datos', async (t) => {
+  invalidatePrediccionCache();
+  t.mock.method(ReporteModel, 'findParaPrediccion', async () => []);
+
+  const zonas = await calcularZonasRiesgo(parseZonasParams({}));
+  const alertas = await calcularAlertasPredictivas(parseAlertasParams({}));
+
+  assert.deepEqual(zonas.zonas, []);
+  assert.deepEqual(alertas.alertas, []);
+});
+
+test('prediccion usa cache TTL hasta invalidar', async (t) => {
+  invalidatePrediccionCache();
+  t.mock.method(ReporteModel, 'findParaPrediccion', async () => reportesBase);
+
+  await calcularZonasRiesgo(parseZonasParams({ min_score: '0' }));
+  await calcularZonasRiesgo(parseZonasParams({ min_score: '0' }));
+
+  assert.equal(ReporteModel.findParaPrediccion.mock.callCount(), 1);
+  assert.equal(getPrediccionCacheSize() > 0, true);
+
+  invalidatePrediccionCache();
+  assert.equal(getPrediccionCacheSize(), 0);
+
+  await calcularZonasRiesgo(parseZonasParams({ min_score: '0' }));
+  assert.equal(ReporteModel.findParaPrediccion.mock.callCount(), 2);
+});
+
+test('parseAlertasParams valida parametros geograficos y nivel', () => {
+  assert.throws(
+    () => parseAlertasParams({ lat: '91' }),
+    /lat debe ser un numero entre -90 y 90/
+  );
+  assert.throws(
+    () => parseAlertasParams({ nivel_min: 'urgente' }),
+    /nivel_min debe ser uno de/
+  );
+  assert.throws(
+    () => parseZonasParams({ min_score: '101' }),
+    /min_score debe ser un numero entre 0 y 100/
+  );
+});


### PR DESCRIPTION
# Closes #205 

## Descripción

Se reemplazó el chatbot simple por un flujo conversacional compatible con el frontend. Ahora `POST /chatbot/mensaje` usa `optionalAuth`, valida el mensaje, aplica rate limit por sesión o IP, y responde con `respuesta`, `intent`, `fuente`, `sugerencias`, `cards`, `latencia_ms` y `estadoAmbiental`.
También se agregó motor offline con intents y FAQs, contexto dinámico con estadísticas, reportes del usuario y alertas por ubicación, cache de respuestas y fallback opcional a Groq/Gemini si hay API keys configuradas. `GET /chatbot/faqs` se mantiene funcionando.

<img width="785" height="821" alt="image" src="https://github.com/user-attachments/assets/0d412e7d-f1ba-4e6e-9803-47fa2ba45c36" />
