### PR TITLE
Issue 208 regression tests paridad

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,8 @@ DB_PASSWORD=
 DB_NAME=green-alert
 
 # JWT Configuration
-JWT_SECRET=jwt_toke.+n
-JWT_EXPIRES_IN=15m
+JWT_SECRET=cambia_esto_por_un_secreto_seguro
+JWT_EXPIRES_IN=1h
 REFRESH_TOKEN_EXPIRES_DAYS=7
 OAUTH_CALLBACK_CODE_TTL_SECONDS=120
 RATE_LIMIT_LOGIN_MAX=5
@@ -23,12 +23,20 @@ UPLOAD_DIR=./uploads
 MAX_FILE_SIZE=10485760
 
 # Email Configuration
-EMAIL_HOST=smtp.mailtrap.io
+APP_NAME=GreenAlert
+EMAIL_HOST=smtp.gmail.com
 EMAIL_PORT=587
-EMAIL_USER=your_email@mailtrap.io
-EMAIL_PASS=your_password
-EMAIL_FROM=noreply@greenalert.com
-EMAIL_TEST_TO=test@greenalert.local
+EMAIL_USER=tu_correo@gmail.com
+EMAIL_PASS=xxxx xxxx xxxx xxxx
+EMAIL_FROM=GreenAlert <tu_correo@gmail.com>
+EMAIL_TEST_TO=tu_correo@gmail.com
+
+# SMTP aliases
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USER=tu_correo@gmail.com
+SMTP_PASS=xxxx xxxx xxxx xxxx
+SMTP_FROM=GreenAlert <tu_correo@gmail.com>
 
 # Logging
 LOG_LEVEL=info
@@ -56,3 +64,25 @@ FACEBOOK_CALLBACK_RESPONSE=json
 # API Configuration
 API_PREFIX=
 API_PUBLIC_URL=http://localhost:3000
+
+# Hugging Face API
+# Token con scope "Inference Providers" en https://huggingface.co/settings/tokens
+HF_API_KEY=hf_xxxxxxxxxxxxxxxxxxxxxxxx
+# Modelo VLM usado via HF Router. Default: zai-org/GLM-4.5V
+HF_IMAGE_MODEL=zai-org/GLM-4.5V
+
+# Chatbot NLP - Groq
+GROQ_API_KEY=gsk_xxxxxxxxxxxxxxxxxxxxxxxx
+# Opciones: llama-3.1-8b-instant, llama-3.3-70b-versatile
+GROQ_MODEL=llama-3.1-8b-instant
+
+# Chatbot NLP - Gemini fallback
+GEMINI_API_KEY=AIzaxxxxxxxxxxxxxxxxxxxxxxxx
+# Opciones: gemini-2.0-flash-exp, gemini-1.5-flash
+GEMINI_MODEL=gemini-2.0-flash-exp
+
+# Firebase Admin SDK
+# Obtener de Firebase Console > Project Settings > Service Accounts > Generate new private key
+FIREBASE_PROJECT_ID=green-alert-1
+FIREBASE_CLIENT_EMAIL=firebase-adminsdk-fbsvc@green-alert-1.iam.gserviceaccount.com
+FIREBASE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"

--- a/DATABASE_SCHEMA_COMPLETE.sql
+++ b/DATABASE_SCHEMA_COMPLETE.sql
@@ -3,10 +3,14 @@
 -- ============================================================================
 -- This schema reflects the actual field usage in the codebase
 -- Generated from: models, controllers, and migration files
--- Date: April 18, 2026
+-- Date: May 18, 2026
 -- ============================================================================
 
 -- Drop existing tables (use with caution!)
+-- DROP TABLE IF EXISTS notificaciones;
+-- DROP TABLE IF EXISTS reporte_vistas;
+-- DROP TABLE IF EXISTS reporte_likes;
+-- DROP TABLE IF EXISTS refresh_tokens;
 -- DROP TABLE IF EXISTS evidencias;
 -- DROP TABLE IF EXISTS reportes;
 -- DROP TABLE IF EXISTS categorias_riesgo;
@@ -82,24 +86,25 @@ CREATE TABLE IF NOT EXISTS categorias_riesgo (
 -- TABLE: reportes
 -- ============================================================================
 CREATE TABLE IF NOT EXISTS reportes (
-  id_reporte INT AUTO_INCREMENT PRIMARY KEY,
+  id_reporte BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   uuid VARCHAR(36) UNIQUE NOT NULL,
   id_usuario BIGINT UNSIGNED NOT NULL,
   tipo_contaminacion VARCHAR(50) NOT NULL,
+  subcategoria VARCHAR(100) NULL,
   estado ENUM('pendiente', 'en_revision', 'verificado', 'en_proceso', 'rechazado', 'resuelto') DEFAULT 'pendiente',
   nivel_severidad ENUM('bajo', 'medio', 'alto', 'critico') DEFAULT 'medio',
   titulo VARCHAR(255) NOT NULL,
   descripcion TEXT NULL,
   latitud DECIMAL(10, 8) NULL,
   longitud DECIMAL(11, 8) NULL,
-  punto_geo GEOMETRY(POINT, 4326) NULL,
+  punto_geo POINT SRID 4326 NULL,
   direccion VARCHAR(255) NULL,
   municipio VARCHAR(100) NULL,
   departamento VARCHAR(100) NULL,
   votos_relevancia INT DEFAULT 0,
   vistas INT DEFAULT 0,
-  ia_etiquetas TEXT NULL,
-  ia_confianza DECIMAL(3, 2) NULL,
+  ia_etiquetas JSON NULL,
+  ia_confianza DECIMAL(5, 2) NULL,
   ia_procesado BOOLEAN DEFAULT FALSE,
   comentario_moderacion TEXT NULL,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -120,6 +125,9 @@ CREATE TABLE IF NOT EXISTS reportes (
   INDEX idx_created_at (created_at),
   INDEX idx_comentario_moderacion (comentario_moderacion(100)),
   INDEX idx_deleted_at (deleted_at),
+  INDEX idx_reportes_estado_created_at (estado, created_at),
+  INDEX idx_reportes_tipo_created_at (tipo_contaminacion, created_at),
+  INDEX idx_reportes_latitud_longitud (latitud, longitud),
   SPATIAL INDEX idx_punto_geo (punto_geo)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
@@ -127,9 +135,9 @@ CREATE TABLE IF NOT EXISTS reportes (
 -- TABLE: evidencias
 -- ============================================================================
 CREATE TABLE IF NOT EXISTS evidencias (
-  id_evidencia INT AUTO_INCREMENT PRIMARY KEY,
+  id_evidencia BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   uuid VARCHAR(36) UNIQUE NOT NULL,
-  id_reporte INT NOT NULL,
+  id_reporte BIGINT UNSIGNED NOT NULL,
   id_usuario BIGINT UNSIGNED NOT NULL,
   tipo_archivo VARCHAR(50) NULL,
   url_archivo VARCHAR(255) NOT NULL,
@@ -165,7 +173,7 @@ CREATE TABLE IF NOT EXISTS evidencias (
 -- TABLE: refresh_tokens
 -- ============================================================================
 CREATE TABLE IF NOT EXISTS refresh_tokens (
-  id_refresh_token INT AUTO_INCREMENT PRIMARY KEY,
+  id_refresh_token BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   id_usuario BIGINT UNSIGNED NOT NULL,
   token_hash VARCHAR(64) NOT NULL UNIQUE,
   expires_at DATETIME NOT NULL,
@@ -181,6 +189,69 @@ CREATE TABLE IF NOT EXISTS refresh_tokens (
   INDEX idx_refresh_usuario (id_usuario),
   INDEX idx_refresh_expires_at (expires_at),
   INDEX idx_refresh_revoked_at (revoked_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ============================================================================
+-- TABLE: reporte_likes
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS reporte_likes (
+  id_like BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  id_reporte BIGINT UNSIGNED NOT NULL,
+  id_usuario BIGINT UNSIGNED NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT fk_reporte_likes_reporte FOREIGN KEY (id_reporte)
+    REFERENCES reportes(id_reporte) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT fk_reporte_likes_usuario FOREIGN KEY (id_usuario)
+    REFERENCES usuarios(id_usuario) ON DELETE CASCADE ON UPDATE CASCADE,
+
+  UNIQUE KEY uk_reporte_likes_reporte_usuario (id_reporte, id_usuario),
+  INDEX idx_reporte_likes_usuario (id_usuario),
+  INDEX idx_reporte_likes_created_at (created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ============================================================================
+-- TABLE: reporte_vistas
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS reporte_vistas (
+  id_vista BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  id_reporte BIGINT UNSIGNED NOT NULL,
+  id_usuario BIGINT UNSIGNED NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT fk_reporte_vistas_reporte FOREIGN KEY (id_reporte)
+    REFERENCES reportes(id_reporte) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT fk_reporte_vistas_usuario FOREIGN KEY (id_usuario)
+    REFERENCES usuarios(id_usuario) ON DELETE CASCADE ON UPDATE CASCADE,
+
+  UNIQUE KEY uk_reporte_vistas_reporte_usuario (id_reporte, id_usuario),
+  INDEX idx_reporte_vistas_usuario (id_usuario),
+  INDEX idx_reporte_vistas_created_at (created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ============================================================================
+-- TABLE: notificaciones
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS notificaciones (
+  id_notificacion BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  uuid VARCHAR(36) UNIQUE NOT NULL,
+  id_usuario BIGINT UNSIGNED NOT NULL,
+  tipo ENUM('reporte_estado', 'reporte_comentario', 'reporte_creado', 'alerta_zona', 'sistema') NOT NULL,
+  titulo VARCHAR(150) NOT NULL,
+  mensaje TEXT NOT NULL,
+  referencia_tipo VARCHAR(30) NULL,
+  referencia_uuid VARCHAR(36) NULL,
+  link VARCHAR(255) NULL,
+  leida BOOLEAN DEFAULT FALSE,
+  leida_at DATETIME NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT fk_notificaciones_usuario FOREIGN KEY (id_usuario)
+    REFERENCES usuarios(id_usuario) ON DELETE CASCADE ON UPDATE CASCADE,
+
+  INDEX idx_notificaciones_usuario_leida (id_usuario, leida, created_at),
+  INDEX idx_notificaciones_uuid (uuid),
+  INDEX idx_notificaciones_referencia (referencia_tipo, referencia_uuid)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- ============================================================================
@@ -216,7 +287,7 @@ SELECT
 FROM reportes r
 LEFT JOIN evidencias e ON e.id_reporte = r.id_reporte AND e.deleted_at IS NULL
 WHERE r.deleted_at IS NULL
-GROUP BY r.id_reporte;
+GROUP BY r.id_reporte, r.uuid, r.titulo, r.estado, r.municipio;
 
 -- ============================================================================
 -- SEED DATA (Sample categories)
@@ -239,7 +310,7 @@ VALUES
 
 -- Get reports by geographic radius
 DELIMITER //
-CREATE PROCEDURE IF NOT EXISTS sp_reportes_por_radio(
+CREATE PROCEDURE sp_reportes_por_radio(
   IN p_latitude DECIMAL(10, 8),
   IN p_longitude DECIMAL(11, 8),
   IN p_radio_km INT
@@ -270,7 +341,7 @@ DELIMITER ;
 
 -- Get user statistics
 DELIMITER //
-CREATE PROCEDURE IF NOT EXISTS sp_estadisticas_usuarios()
+CREATE PROCEDURE sp_estadisticas_usuarios()
 BEGIN
   SELECT 
     COUNT(*) AS total,

--- a/docs/regression-parity-208.md
+++ b/docs/regression-parity-208.md
@@ -1,0 +1,90 @@
+# Regression tests y paridad interna
+
+## Estado inicial
+
+Antes de agregar artefactos para esta tarea se ejecuto:
+
+```bash
+npm run test:unit
+```
+
+Resultado: verde, `112/112`.
+
+## Cobertura automatizada
+
+- Rutas publicas sin `/api`: `tests/unit/route-prefix.test.js`.
+- `optionalAuth`: `tests/unit/optional-auth.test.js`.
+- Likes, vistas y trending: `tests/unit/likes-vistas-trending.test.js`.
+- IA y upload multiple: `tests/unit/clasificacion-ia.test.js`, `tests/unit/ia-service.test.js`, `tests/unit/reporte-upload-evidencias.test.js`.
+- Prediccion: `tests/unit/prediccion-service.test.js`.
+- Chatbot: `tests/unit/chatbot-conversacional.test.js`.
+- Notificaciones: `tests/unit/notificacion.controller.test.js`.
+- Contrato de endpoints usados por el frontend: `tests/unit/frontend-api-contract.test.js`.
+
+## Checklist de endpoints frontend
+
+El frontend consume `/api` como base URL. En desarrollo, Vite reescribe `/api` hacia el backend sin prefijo interno; por eso el backend debe responder rutas como `/reportes`, `/auth`, `/chatbot`, etc. cuando `API_PREFIX` esta vacio.
+
+Endpoints principales cubiertos por el contrato:
+
+- `GET /health`
+- `POST /auth/login`
+- `POST /auth/register`
+- `POST /auth/google`
+- `POST /auth/facebook`
+- `GET /categorias`
+- `GET /categorias/:codigo`
+- `GET /reportes`
+- `POST /reportes`
+- `GET /reportes/:id`
+- `PATCH /reportes/:id`
+- `DELETE /reportes/:id`
+- `POST /reportes/:id/like`
+- `GET /reportes/trending`
+- `GET /reportes/stats`
+- `GET /reportes/stats/categoria`
+- `GET /reportes/stats/timeline`
+- `GET /reportes/stats/heatmap`
+- `GET /reportes/stats/ia`
+- `POST /reportes/analizar-imagen`
+- `GET /reportes/export`
+- `GET /reportes/mis-reportes`
+- `GET /reportes/zonas-riesgo`
+- `GET /reportes/alertas-predictivas`
+- `GET /auth/perfil`
+- `PATCH /auth/perfil`
+- `PATCH /auth/avatar`
+- `PATCH /auth/cambiar-contrasena`
+- `PATCH /auth/notificaciones`
+- `POST /auth/forgot-password`
+- `POST /auth/reset-password`
+- `POST /auth/enviar-verificacion`
+- `POST /auth/verificar-email`
+- `GET /admin/usuarios/stats`
+- `GET /admin/usuarios`
+- `GET /admin/usuarios/:id`
+- `PATCH /admin/usuarios/:id/rol`
+- `PATCH /admin/usuarios/:id/estado`
+- `DELETE /admin/usuarios/:id`
+- `POST /chatbot/mensaje`
+- `GET /chatbot/faqs`
+- `GET /notificaciones`
+- `GET /notificaciones/contador`
+- `PATCH /notificaciones/:uuid/leida`
+- `PATCH /notificaciones/marcar-todas`
+- `DELETE /notificaciones/:uuid`
+
+## Diagnostico manual
+
+Para listar el contrato exportado por el frontend:
+
+```bash
+node tests/diagnose-frontend-contract.js
+```
+
+Para diagnosticar rutas contra un servidor levantado, usar `tests/diagnose-routes.js` ajustando `BASE_URL` si hace falta.
+
+## Diferencias intencionales
+
+- El backend no fuerza `/api` internamente por defecto. Esto permite que el proxy de Vite quite `/api` y mantenga compatibilidad local.
+- `API_PREFIX=/api` sigue disponible para despliegues que quieran montar el backend con prefijo real.

--- a/migrations/003_add_google_oauth_support.sql
+++ b/migrations/003_add_google_oauth_support.sql
@@ -1,11 +1,8 @@
--- Migración: Agregar soporte para Google OAuth
+-- Migracion: Agregar soporte para Google OAuth
 -- Fecha: 2026-04-26
--- Descripción: Agrega columna google_id a tabla usuarios para almacenar ID de Google
+-- Descripcion: Agrega columna google_id a usuarios para vincular cuentas de Google.
 
-ALTER TABLE usuarios ADD COLUMN google_id VARCHAR(255) UNIQUE DEFAULT NULL AFTER uuid;
+ALTER TABLE usuarios
+  ADD COLUMN IF NOT EXISTS google_id VARCHAR(255) UNIQUE NULL AFTER uuid;
 
--- Crear índice para búsquedas rápidas por google_id
-CREATE INDEX idx_google_id ON usuarios(google_id);
-
--- Comentario de columna
--- ALTER TABLE usuarios MODIFY COLUMN google_id VARCHAR(255) COMMENT 'Google user ID (sub claim)' UNIQUE;
+CREATE INDEX IF NOT EXISTS idx_google_id ON usuarios(google_id);

--- a/migrations/009_create_reporte_likes.sql
+++ b/migrations/009_create_reporte_likes.sql
@@ -1,8 +1,8 @@
 -- Migracion: likes persistentes por usuario y reporte
 CREATE TABLE IF NOT EXISTS reporte_likes (
   id_like BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-  id_reporte INT NOT NULL,
-  id_usuario INT NOT NULL,
+  id_reporte BIGINT UNSIGNED NOT NULL,
+  id_usuario BIGINT UNSIGNED NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (id_like),
   UNIQUE KEY uk_reporte_likes_reporte_usuario (id_reporte, id_usuario),
@@ -13,4 +13,4 @@ CREATE TABLE IF NOT EXISTS reporte_likes (
   CONSTRAINT fk_reporte_likes_usuario
     FOREIGN KEY (id_usuario) REFERENCES usuarios(id_usuario)
     ON DELETE CASCADE ON UPDATE CASCADE
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/migrations/010_create_reporte_vistas.sql
+++ b/migrations/010_create_reporte_vistas.sql
@@ -1,8 +1,8 @@
 -- Migracion: vistas unicas persistentes para usuarios autenticados
 CREATE TABLE IF NOT EXISTS reporte_vistas (
   id_vista BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-  id_reporte INT NOT NULL,
-  id_usuario INT NOT NULL,
+  id_reporte BIGINT UNSIGNED NOT NULL,
+  id_usuario BIGINT UNSIGNED NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (id_vista),
   UNIQUE KEY uk_reporte_vistas_reporte_usuario (id_reporte, id_usuario),
@@ -13,4 +13,4 @@ CREATE TABLE IF NOT EXISTS reporte_vistas (
   CONSTRAINT fk_reporte_vistas_usuario
     FOREIGN KEY (id_usuario) REFERENCES usuarios(id_usuario)
     ON DELETE CASCADE ON UPDATE CASCADE
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/migrations/011_add_prediction_indexes.sql
+++ b/migrations/011_add_prediction_indexes.sql
@@ -1,9 +1,52 @@
--- Migracion: indices para prediccion de zonas de riesgo y alertas
-CREATE INDEX idx_reportes_estado_created_at
-  ON reportes (estado, created_at);
+-- Migracion: indices para prediccion de zonas de riesgo y alertas.
+-- Idempotente para poder aplicarse en bases existentes sin borrar datos.
 
-CREATE INDEX idx_reportes_tipo_created_at
-  ON reportes (tipo_contaminacion, created_at);
+SET @schema_name = DATABASE();
 
-CREATE INDEX idx_reportes_latitud_longitud
-  ON reportes (latitud, longitud);
+SET @index_exists = (
+  SELECT COUNT(*)
+  FROM information_schema.statistics
+  WHERE table_schema = @schema_name
+    AND table_name = 'reportes'
+    AND index_name = 'idx_reportes_estado_created_at'
+);
+SET @sql = IF(
+  @index_exists = 0,
+  'CREATE INDEX idx_reportes_estado_created_at ON reportes (estado, created_at)',
+  'SELECT ''idx_reportes_estado_created_at ya existe'' AS info'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @index_exists = (
+  SELECT COUNT(*)
+  FROM information_schema.statistics
+  WHERE table_schema = @schema_name
+    AND table_name = 'reportes'
+    AND index_name = 'idx_reportes_tipo_created_at'
+);
+SET @sql = IF(
+  @index_exists = 0,
+  'CREATE INDEX idx_reportes_tipo_created_at ON reportes (tipo_contaminacion, created_at)',
+  'SELECT ''idx_reportes_tipo_created_at ya existe'' AS info'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @index_exists = (
+  SELECT COUNT(*)
+  FROM information_schema.statistics
+  WHERE table_schema = @schema_name
+    AND table_name = 'reportes'
+    AND index_name = 'idx_reportes_latitud_longitud'
+);
+SET @sql = IF(
+  @index_exists = 0,
+  'CREATE INDEX idx_reportes_latitud_longitud ON reportes (latitud, longitud)',
+  'SELECT ''idx_reportes_latitud_longitud ya existe'' AS info'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/migrations/012_create_notificaciones.sql
+++ b/migrations/012_create_notificaciones.sql
@@ -1,3 +1,4 @@
+-- Migracion: notificaciones in-app por usuario
 CREATE TABLE IF NOT EXISTS notificaciones (
   id_notificacion BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   uuid VARCHAR(36) UNIQUE NOT NULL,

--- a/migrations/create_notificaciones.sql
+++ b/migrations/create_notificaciones.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS notificaciones (
+  id_notificacion BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  uuid VARCHAR(36) UNIQUE NOT NULL,
+  id_usuario BIGINT UNSIGNED NOT NULL,
+  tipo ENUM('reporte_estado', 'reporte_comentario', 'reporte_creado', 'alerta_zona', 'sistema') NOT NULL,
+  titulo VARCHAR(150) NOT NULL,
+  mensaje TEXT NOT NULL,
+  referencia_tipo VARCHAR(30) NULL,
+  referencia_uuid VARCHAR(36) NULL,
+  link VARCHAR(255) NULL,
+  leida BOOLEAN DEFAULT FALSE,
+  leida_at DATETIME NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT fk_notificaciones_usuario
+    FOREIGN KEY (id_usuario)
+    REFERENCES usuarios(id_usuario)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE,
+
+  INDEX idx_notificaciones_usuario_leida (id_usuario, leida, created_at),
+  INDEX idx_notificaciones_uuid (uuid),
+  INDEX idx_notificaciones_referencia (referencia_tipo, referencia_uuid)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/routes/notificacion.routes.js
+++ b/routes/notificacion.routes.js
@@ -1,0 +1,21 @@
+import { Router } from 'express';
+import { verifyToken } from '../middlewares/auth.middleware.js';
+import {
+  contadorNotificaciones,
+  eliminarNotificacion,
+  listarNotificaciones,
+  marcarLeida,
+  marcarTodasLeidas,
+} from '../src/controllers/notificacion.controller.js';
+
+const notificacionRouter = Router();
+
+notificacionRouter.use(verifyToken);
+
+notificacionRouter.get('/contador', contadorNotificaciones);
+notificacionRouter.patch('/marcar-todas', marcarTodasLeidas);
+notificacionRouter.get('/', listarNotificaciones);
+notificacionRouter.patch('/:uuid/leida', marcarLeida);
+notificacionRouter.delete('/:uuid', eliminarNotificacion);
+
+export default notificacionRouter;

--- a/scripts/sql/00_create_database.sql
+++ b/scripts/sql/00_create_database.sql
@@ -1,0 +1,5 @@
+CREATE DATABASE IF NOT EXISTS `green-alert`
+  DEFAULT CHARACTER SET utf8mb4
+  COLLATE utf8mb4_unicode_ci;
+
+USE `green-alert`;

--- a/scripts/sql/verify_schema.sql
+++ b/scripts/sql/verify_schema.sql
@@ -1,0 +1,52 @@
+-- Ejecutar despues de DATABASE_SCHEMA_COMPLETE.sql o de las migraciones.
+-- Devuelve las tablas y columnas criticas esperadas por el backend.
+
+SELECT table_name
+FROM information_schema.tables
+WHERE table_schema = DATABASE()
+  AND table_name IN (
+    'usuarios',
+    'categorias_riesgo',
+    'reportes',
+    'evidencias',
+    'refresh_tokens',
+    'reporte_likes',
+    'reporte_vistas',
+    'notificaciones'
+  )
+ORDER BY table_name;
+
+SELECT table_name, column_name, column_type, is_nullable
+FROM information_schema.columns
+WHERE table_schema = DATABASE()
+  AND (
+    (table_name = 'usuarios' AND column_name IN (
+      'google_id',
+      'facebook_id',
+      'notification_preferences',
+      'avatar_url',
+      'email_verificado',
+      'email_verification_token',
+      'otp_code_hash'
+    ))
+    OR (table_name = 'reportes' AND column_name IN (
+      'subcategoria',
+      'estado',
+      'comentario_moderacion',
+      'ia_etiquetas',
+      'ia_confianza',
+      'ia_procesado'
+    ))
+  )
+ORDER BY table_name, column_name;
+
+SELECT table_name, index_name
+FROM information_schema.statistics
+WHERE table_schema = DATABASE()
+  AND table_name = 'reportes'
+  AND index_name IN (
+    'idx_reportes_estado_created_at',
+    'idx_reportes_tipo_created_at',
+    'idx_reportes_latitud_longitud'
+  )
+ORDER BY table_name, index_name;

--- a/src/app.js
+++ b/src/app.js
@@ -8,6 +8,7 @@ import reporteRouter from '../routes/reporte.routes.js';
 import categoriaRouter from '../routes/categoria-riesgo.routes.js';
 import adminRouter from '../routes/admin.routes.js';
 import chatbotRouter from '../routes/chatbot.routes.js';
+import notificacionRouter from '../routes/notificacion.routes.js';
 import { getCorsOptions, getHelmetOptions } from './config/security.config.js';
 import { getUploadDir } from './config/upload.config.js';
 import { getApiPrefix } from './config/api-prefix.config.js';
@@ -31,6 +32,7 @@ app.use(`${apiPrefix}/reportes`, reporteRouter);
 app.use(`${apiPrefix}/categorias`, categoriaRouter);
 app.use(`${apiPrefix}/admin`, adminRouter);
 app.use(`${apiPrefix}/chatbot`, chatbotRouter);
+app.use(`${apiPrefix}/notificaciones`, notificacionRouter);
 
  
 app.use(notFoundHandler);

--- a/src/controllers/chatbot.controller.js
+++ b/src/controllers/chatbot.controller.js
@@ -1,129 +1,70 @@
-import { ReporteModel } from '../models/reporte.model.js';
+import { generarRespuestaChatbot } from '../services/chatbot.service.js';
+import { FAQ_GROUPS } from '../services/chatbot-offline.js';
 import { successResponse, errorResponse } from '../utils/response.js';
 
-const FAQ_GROUPS = [
-  {
-    titulo: 'Reportes',
-    items: [
-      {
-        pregunta: 'Como crear un reporte ambiental?',
-        prompt: 'Como creo un reporte ambiental?',
-      },
-      {
-        pregunta: 'Que evidencia puedo adjuntar?',
-        prompt: 'Que evidencia puedo adjuntar a un reporte?',
-      },
-      {
-        pregunta: 'Como reviso el estado de mi reporte?',
-        prompt: 'Como reviso el estado de mi reporte?',
-      },
-    ],
-  },
-  {
-    titulo: 'Alertas',
-    items: [
-      {
-        pregunta: 'Que son las zonas de riesgo?',
-        prompt: 'Que son las zonas de riesgo predictivas?',
-      },
-      {
-        pregunta: 'Como activar alertas en mi zona?',
-        prompt: 'Como activo alertas en mi zona?',
-      },
-    ],
-  },
-  {
-    titulo: 'Cuenta',
-    items: [
-      {
-        pregunta: 'Como verifico mi correo?',
-        prompt: 'Como verifico mi correo electronico?',
-      },
-      {
-        pregunta: 'Como recupero mi contrasena?',
-        prompt: 'Como recupero mi contrasena?',
-      },
-    ],
-  },
-];
+const MAX_MESSAGE_LENGTH = 500;
+const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const RATE_LIMIT_MAX = 20;
+const rateLimitStore = new Map();
 
-const detectIntent = (mensaje) => {
-  const text = String(mensaje || '').toLowerCase();
-  if (/reporte|denuncia|evidencia|foto|crear|enviar/.test(text)) return 'reportes';
-  if (/alerta|riesgo|zona|mapa|predic/.test(text)) return 'alertas';
-  if (/correo|verific|otp|codigo/.test(text)) return 'verificacion';
-  if (/contrase|password|recuper/.test(text)) return 'recuperacion';
-  if (/estado|seguimiento|moderacion|revision/.test(text)) return 'seguimiento';
-  return 'fallback';
+export const clearChatbotRateLimit = () => {
+  rateLimitStore.clear();
 };
 
-const buildRespuesta = (intent, stats) => {
-  const totalReportes = Number(stats?.total_reportes) || 0;
-  const municipios = Number(stats?.municipios_activos) || 0;
+const getRateLimitKey = (req, sessionId) => (
+  sessionId || req.ip || req.socket?.remoteAddress || 'anonymous'
+);
 
-  const responses = {
-    reportes: `Para crear un reporte entra a "Nuevo reporte", selecciona la categoria, severidad, descripcion, ubicacion y adjunta evidencias si las tienes. La plataforma registra el reporte y lo deja en estado pendiente para revision.`,
-    alertas: `Las zonas de riesgo se calculan con reportes recientes, severidad y concentracion geografica. Actualmente hay ${totalReportes} reportes registrados en ${municipios} municipio(s) activo(s).`,
-    verificacion: 'Despues del registro enviamos un codigo de 6 digitos al correo. En la pantalla "Verifica tu correo" puedes ingresarlo o solicitar un nuevo codigo cuando termine el contador.',
-    recuperacion: 'Para recuperar tu contrasena usa "Olvidaste tu contrasena", escribe tu correo y abre el enlace recibido. El enlace expira por seguridad.',
-    seguimiento: 'Puedes revisar el estado en "Mis reportes". Los moderadores pueden cambiar un reporte entre pendiente, en revision, verificado, en proceso, resuelto o rechazado.',
-    fallback: 'Puedo ayudarte con reportes ambientales, verificacion de correo, recuperacion de contrasena, alertas de riesgo y seguimiento de reportes.',
-  };
+const isRateLimited = (key) => {
+  const now = Date.now();
+  const entry = rateLimitStore.get(key);
 
-  return responses[intent] || responses.fallback;
-};
-
-const buildSuggestions = (intent) => {
-  const common = [
-    'Como crear un reporte ambiental?',
-    'Como verifico mi correo?',
-    'Que son las zonas de riesgo?',
-  ];
-
-  if (intent === 'reportes') {
-    return ['Que evidencia puedo adjuntar?', 'Como edito un reporte?', 'Como veo mis reportes?'];
+  if (!entry || entry.resetAt <= now) {
+    rateLimitStore.set(key, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return false;
   }
 
-  if (intent === 'alertas') {
-    return ['Como activar alertas en mi zona?', 'Que significa riesgo critico?', 'Como se calcula el mapa?'];
-  }
-
-  return common;
+  entry.count += 1;
+  return entry.count > RATE_LIMIT_MAX;
 };
 
 export const enviarMensajeChatbot = async (req, res, next) => {
   const startedAt = Date.now();
+
   try {
-    const { mensaje, sessionId } = req.body ?? {};
+    const { mensaje, sessionId, lat, lng } = req.body ?? {};
     const cleanMessage = typeof mensaje === 'string' ? mensaje.trim() : '';
 
     if (!cleanMessage) {
       return errorResponse(res, 'El mensaje es requerido.', 400);
     }
 
-    const [stats, zonas] = await Promise.all([
-      ReporteModel.getStats(),
-      ReporteModel.getAlertasPredictivas({ limite: 3, nivel_min: 'medio' }).catch(() => []),
-    ]);
-    const intent = detectIntent(cleanMessage);
+    if (cleanMessage.length > MAX_MESSAGE_LENGTH) {
+      return errorResponse(res, 'El mensaje no puede superar 500 caracteres.', 400);
+    }
+
+    if (isRateLimited(getRateLimitKey(req, sessionId))) {
+      return errorResponse(res, 'Demasiados mensajes. Intenta nuevamente en un minuto.', 429);
+    }
+
+    const result = await generarRespuestaChatbot({
+      mensaje: cleanMessage,
+      sessionId,
+      user: req.user,
+      lat,
+      lng,
+    });
 
     return successResponse(
       res,
       {
         sessionId,
-        respuesta: buildRespuesta(intent, stats),
-        sugerencias: buildSuggestions(intent),
-        cards: zonas.map((zona) => ({
-          titulo: `${zona.municipio || 'Zona'} - riesgo ${zona.nivel}`,
-          descripcion: `${zona.n_reportes} reporte(s), categoria ${zona.tipo_dominante}`,
-          tipo: 'alerta',
-          data: zona,
-        })),
-        estadoAmbiental: zonas.some((zona) => zona.nivel === 'critico' || zona.nivel === 'alto')
-          ? 'alerta'
-          : 'optimo',
-        fuente: 'backend',
-        intent,
+        respuesta: result.respuesta,
+        intent: result.intent,
+        fuente: result.fuente,
+        sugerencias: result.sugerencias,
+        cards: result.cards,
+        estadoAmbiental: result.estadoAmbiental,
         latencia_ms: Date.now() - startedAt,
       },
       'Respuesta generada correctamente.'

--- a/src/controllers/notificacion.controller.js
+++ b/src/controllers/notificacion.controller.js
@@ -1,0 +1,100 @@
+import { NotificacionModel } from '../models/notificacion.model.js';
+import { errorResponse, successResponse } from '../utils/response.js';
+
+export const crearNotificacion = async (payload) => {
+  try {
+    return await NotificacionModel.create(payload);
+  } catch (error) {
+    console.error('[notificaciones] error al crear:', error.message);
+    return null;
+  }
+};
+
+export const listarNotificaciones = async (req, res, next) => {
+  try {
+    const idUsuario = req.user?.sub;
+    if (!idUsuario) return errorResponse(res, 'No autorizado.', 401);
+
+    const filtroLeida = req.query?.leida === 'true'
+      ? true
+      : req.query?.leida === 'false'
+        ? false
+        : undefined;
+
+    const data = await NotificacionModel.findByUsuario(idUsuario, {
+      leida: filtroLeida,
+      limit: req.query?.limit,
+      offset: req.query?.offset,
+    });
+
+    res.setHeader('Cache-Control', 'no-store');
+    return successResponse(res, data, 'Notificaciones obtenidas.');
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const contadorNotificaciones = async (req, res, next) => {
+  try {
+    const idUsuario = req.user?.sub;
+    if (!idUsuario) return errorResponse(res, 'No autorizado.', 401);
+
+    const no_leidas = await NotificacionModel.contarNoLeidas(idUsuario);
+
+    res.setHeader('Cache-Control', 'no-store');
+    return successResponse(res, { no_leidas }, 'ok');
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const marcarLeida = async (req, res, next) => {
+  try {
+    const idUsuario = req.user?.sub;
+    if (!idUsuario) return errorResponse(res, 'No autorizado.', 401);
+
+    const { uuid } = req.params;
+    if (!uuid) return errorResponse(res, 'UUID requerido.', 400);
+
+    const ok = await NotificacionModel.marcarLeida(uuid, idUsuario);
+    if (!ok) return errorResponse(res, 'Notificacion no encontrada.', 404);
+
+    return successResponse(res, { uuid }, 'Notificacion marcada como leida.');
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const marcarTodasLeidas = async (req, res, next) => {
+  try {
+    const idUsuario = req.user?.sub;
+    if (!idUsuario) return errorResponse(res, 'No autorizado.', 401);
+
+    const actualizadas = await NotificacionModel.marcarTodasLeidas(idUsuario);
+
+    return successResponse(
+      res,
+      { actualizadas },
+      'Notificaciones marcadas como leidas.'
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const eliminarNotificacion = async (req, res, next) => {
+  try {
+    const idUsuario = req.user?.sub;
+    if (!idUsuario) return errorResponse(res, 'No autorizado.', 401);
+
+    const { uuid } = req.params;
+    if (!uuid) return errorResponse(res, 'UUID requerido.', 400);
+
+    const ok = await NotificacionModel.eliminar(uuid, idUsuario);
+    if (!ok) return errorResponse(res, 'Notificacion no encontrada.', 404);
+
+    return successResponse(res, { uuid }, 'Notificacion eliminada.');
+  } catch (error) {
+    return next(error);
+  }
+};

--- a/src/controllers/reporte.controller.js
+++ b/src/controllers/reporte.controller.js
@@ -13,6 +13,7 @@ import { analyzeReporte } from '../services/ia.service.js';
 import { clasificarImagen } from '../services/clasificacion.service.js';
 import { invalidatePrediccionCache } from '../services/prediccion.service.js';
 import { errorResponse, successResponse } from '../utils/response.js';
+import { crearNotificacion } from './notificacion.controller.js';
 
 const ANONYMOUS_VIEW_THROTTLE_MS = 5 * 60 * 1000;
 const anonymousViewThrottle = new Map();
@@ -46,6 +47,8 @@ const normalizeEnumValue = (value) => (
 const buildAllowedValuesMessage = (field, allowedValues) => (
   `${field} debe ser uno de: ${allowedValues.join(', ')}.`
 );
+
+const buildReporteLink = (reporte) => `/reports/${reporte.uuid ?? reporte.id_reporte}`;
 
 const canManageReporteEvidence = (reporte, user) => {
   if (!reporte || !user) {
@@ -696,6 +699,43 @@ export const updateReporte = async (req, res, next) => {
       invalidatePrediccionCache();
     }
     const updated = await ReporteModel.findById(id);
+
+    if (isMod && reporte.id_usuario && Number(reporte.id_usuario) !== Number(sub)) {
+      const cambioEstado = (
+        Object.prototype.hasOwnProperty.call(campos, 'estado') &&
+        campos.estado !== reporte.estado
+      );
+      const nuevoComentario = (
+        Object.prototype.hasOwnProperty.call(campos, 'comentario_moderacion') &&
+        String(campos.comentario_moderacion ?? '').trim().length > 0 &&
+        campos.comentario_moderacion !== reporte.comentario_moderacion
+      );
+
+      if (cambioEstado) {
+        crearNotificacion({
+          id_usuario: reporte.id_usuario,
+          tipo: 'reporte_estado',
+          titulo: `Tu reporte cambio a "${campos.estado}"`,
+          mensaje: `El reporte "${reporte.titulo}" ahora esta en estado: ${campos.estado}.`,
+          referencia_tipo: 'reporte',
+          referencia_uuid: reporte.uuid,
+          link: buildReporteLink(reporte),
+        });
+      }
+
+      if (nuevoComentario) {
+        crearNotificacion({
+          id_usuario: reporte.id_usuario,
+          tipo: 'reporte_comentario',
+          titulo: 'Comentario de moderacion en tu reporte',
+          mensaje: String(campos.comentario_moderacion).slice(0, 240),
+          referencia_tipo: 'reporte',
+          referencia_uuid: reporte.uuid,
+          link: buildReporteLink(reporte),
+        });
+      }
+    }
+
     return successResponse(res, { reporte: updated }, 'Reporte actualizado.');
   } catch (error) {
     return next(error);

--- a/src/models/notificacion.model.js
+++ b/src/models/notificacion.model.js
@@ -1,0 +1,136 @@
+import { randomUUID } from 'crypto';
+import pool from '../config/database.js';
+
+export const NotificacionModel = {
+  create: async ({
+    id_usuario,
+    tipo,
+    titulo,
+    mensaje,
+    referencia_tipo = null,
+    referencia_uuid = null,
+    link = null,
+  }) => {
+    const uuid = randomUUID();
+    const [result] = await pool.execute(
+      `INSERT INTO notificaciones
+         (uuid, id_usuario, tipo, titulo, mensaje, referencia_tipo, referencia_uuid, link)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        uuid,
+        id_usuario,
+        tipo,
+        titulo,
+        mensaje,
+        referencia_tipo,
+        referencia_uuid,
+        link,
+      ]
+    );
+
+    return { id_notificacion: result.insertId, uuid };
+  },
+
+  findByUsuario: async (id_usuario, { leida, limit = 20, offset = 0 } = {}) => {
+    const where = ['id_usuario = ?'];
+    const params = [id_usuario];
+
+    if (leida === true || leida === false) {
+      where.push('leida = ?');
+      params.push(leida ? 1 : 0);
+    }
+
+    const safeLimit = Math.max(1, Math.min(100, parseInt(limit, 10) || 20));
+    const safeOffset = Math.max(0, parseInt(offset, 10) || 0);
+
+    const [rows] = await pool.execute(
+      `SELECT id_notificacion, uuid, tipo, titulo, mensaje,
+              referencia_tipo, referencia_uuid, link,
+              leida, leida_at, created_at
+       FROM notificaciones
+       WHERE ${where.join(' AND ')}
+       ORDER BY created_at DESC
+       LIMIT ${safeLimit} OFFSET ${safeOffset}`,
+      params
+    );
+
+    const [[meta]] = await pool.execute(
+      `SELECT
+         COUNT(*) AS total,
+         SUM(CASE WHEN leida = 0 THEN 1 ELSE 0 END) AS no_leidas
+       FROM notificaciones
+       WHERE id_usuario = ?`,
+      [id_usuario]
+    );
+
+    return {
+      items: rows.map((row) => ({
+        ...row,
+        leida: Boolean(row.leida),
+      })),
+      meta: {
+        total: Number(meta?.total) || 0,
+        no_leidas: Number(meta?.no_leidas) || 0,
+        limit: safeLimit,
+        offset: safeOffset,
+      },
+    };
+  },
+
+  contarNoLeidas: async (id_usuario) => {
+    const [[row]] = await pool.execute(
+      `SELECT COUNT(*) AS total
+       FROM notificaciones
+       WHERE id_usuario = ? AND leida = 0`,
+      [id_usuario]
+    );
+
+    return Number(row?.total) || 0;
+  },
+
+  marcarLeida: async (uuid, id_usuario) => {
+    const [result] = await pool.execute(
+      `UPDATE notificaciones
+       SET leida = 1, leida_at = COALESCE(leida_at, NOW())
+       WHERE uuid = ? AND id_usuario = ? AND leida = 0`,
+      [uuid, id_usuario]
+    );
+
+    if (result.affectedRows > 0) {
+      return true;
+    }
+
+    const [rows] = await pool.execute(
+      `SELECT 1
+       FROM notificaciones
+       WHERE uuid = ? AND id_usuario = ?
+       LIMIT 1`,
+      [uuid, id_usuario]
+    );
+
+    return rows.length > 0;
+  },
+
+  marcarTodasLeidas: async (id_usuario) => {
+    const [result] = await pool.execute(
+      `UPDATE notificaciones
+       SET leida = 1, leida_at = COALESCE(leida_at, NOW())
+       WHERE id_usuario = ? AND leida = 0`,
+      [id_usuario]
+    );
+
+    return result.affectedRows;
+  },
+
+  eliminar: async (uuid, id_usuario) => {
+    const [result] = await pool.execute(
+      `DELETE FROM notificaciones
+       WHERE uuid = ? AND id_usuario = ?`,
+      [uuid, id_usuario]
+    );
+
+    return result.affectedRows > 0;
+  },
+};
+
+export default NotificacionModel;

--- a/src/services/chatbot-context.js
+++ b/src/services/chatbot-context.js
@@ -1,0 +1,40 @@
+import { ReporteModel } from '../models/reporte.model.js';
+import {
+  calcularAlertasPredictivas,
+  parseAlertasParams,
+} from './prediccion.service.js';
+
+const toNumber = (value) => {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+};
+
+export const construirContextoChatbot = async ({ user, lat, lng } = {}) => {
+  const userId = user?.sub;
+  const latitude = toNumber(lat);
+  const longitude = toNumber(lng);
+
+  const [global, usuario, alertasPayload] = await Promise.all([
+    ReporteModel.getStats().catch(() => ({})),
+    userId
+      ? Promise.all([
+        ReporteModel.findByUsuario(userId, { limit: 5, offset: 0 }).catch(() => []),
+        ReporteModel.countByUsuario(userId).catch(() => 0),
+      ]).then(([reportes, total]) => ({ reportes, total_reportes: Number(total) || 0 }))
+      : Promise.resolve(null),
+    calcularAlertasPredictivas(parseAlertasParams({
+      lat: latitude ?? undefined,
+      lng: longitude ?? undefined,
+      radio_km: latitude !== null && longitude !== null ? 25 : undefined,
+      limite: 3,
+      min_score: 0,
+      nivel_min: 'medio',
+    })).catch(() => ({ alertas: [] })),
+  ]);
+
+  return {
+    global,
+    usuario,
+    alertasZona: alertasPayload.alertas || [],
+  };
+};

--- a/src/services/chatbot-context.js
+++ b/src/services/chatbot-context.js
@@ -13,6 +13,7 @@ export const construirContextoChatbot = async ({ user, lat, lng } = {}) => {
   const userId = user?.sub;
   const latitude = toNumber(lat);
   const longitude = toNumber(lng);
+  const hasLocation = latitude !== null && longitude !== null;
 
   const [global, usuario, alertasPayload] = await Promise.all([
     ReporteModel.getStats().catch(() => ({})),
@@ -22,14 +23,16 @@ export const construirContextoChatbot = async ({ user, lat, lng } = {}) => {
         ReporteModel.countByUsuario(userId).catch(() => 0),
       ]).then(([reportes, total]) => ({ reportes, total_reportes: Number(total) || 0 }))
       : Promise.resolve(null),
-    calcularAlertasPredictivas(parseAlertasParams({
-      lat: latitude ?? undefined,
-      lng: longitude ?? undefined,
-      radio_km: latitude !== null && longitude !== null ? 25 : undefined,
-      limite: 3,
-      min_score: 0,
-      nivel_min: 'medio',
-    })).catch(() => ({ alertas: [] })),
+    hasLocation
+      ? calcularAlertasPredictivas(parseAlertasParams({
+        lat: latitude,
+        lng: longitude,
+        radio_km: 25,
+        limite: 3,
+        min_score: 0,
+        nivel_min: 'medio',
+      })).catch(() => ({ alertas: [] }))
+      : Promise.resolve({ alertas: [] }),
   ]);
 
   return {

--- a/src/services/chatbot-offline.js
+++ b/src/services/chatbot-offline.js
@@ -1,0 +1,108 @@
+export const FAQ_GROUPS = [
+  {
+    titulo: 'Reportes',
+    items: [
+      { pregunta: 'Como crear un reporte ambiental?', prompt: 'Como creo un reporte ambiental?' },
+      { pregunta: 'Que evidencia puedo adjuntar?', prompt: 'Que evidencia puedo adjuntar a un reporte?' },
+      { pregunta: 'Como reviso el estado de mi reporte?', prompt: 'Como reviso el estado de mi reporte?' },
+    ],
+  },
+  {
+    titulo: 'Alertas',
+    items: [
+      { pregunta: 'Que son las zonas de riesgo?', prompt: 'Que son las zonas de riesgo predictivas?' },
+      { pregunta: 'Como activar alertas en mi zona?', prompt: 'Como activo alertas en mi zona?' },
+    ],
+  },
+  {
+    titulo: 'Cuenta',
+    items: [
+      { pregunta: 'Como verifico mi correo?', prompt: 'Como verifico mi correo electronico?' },
+      { pregunta: 'Como recupero mi contrasena?', prompt: 'Como recupero mi contrasena?' },
+    ],
+  },
+];
+
+const normalizeText = (value) => (
+  String(value || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+);
+
+export const detectIntent = (mensaje) => {
+  const text = normalizeText(mensaje);
+
+  if (/mis reportes|mis denuncias|cuantos reportes|estado de mi|seguimiento/.test(text)) {
+    return 'mis_reportes';
+  }
+  if (/reporte|denuncia|evidencia|foto|crear|enviar|adjuntar/.test(text)) return 'reportes';
+  if (/alerta|riesgo|zona|mapa|predic|cerca|ubicacion/.test(text)) return 'alertas';
+  if (/correo|verific|otp|codigo/.test(text)) return 'verificacion';
+  if (/contrase|password|recuper/.test(text)) return 'recuperacion';
+  if (/estado|moderacion|revision/.test(text)) return 'seguimiento';
+  return 'fallback';
+};
+
+export const buildSuggestions = (intent) => {
+  if (intent === 'reportes') {
+    return ['Que evidencia puedo adjuntar?', 'Como edito un reporte?', 'Como veo mis reportes?'];
+  }
+
+  if (intent === 'alertas') {
+    return ['Como activar alertas en mi zona?', 'Que significa riesgo critico?', 'Como se calcula el mapa?'];
+  }
+
+  if (intent === 'mis_reportes') {
+    return ['Como reviso el estado?', 'Puedo editar un reporte?', 'Como agrego evidencias?'];
+  }
+
+  return [
+    'Como crear un reporte ambiental?',
+    'Como verifico mi correo?',
+    'Que son las zonas de riesgo?',
+  ];
+};
+
+export const buildCards = (contexto = {}) => (
+  (contexto.alertasZona || []).slice(0, 3).map((alerta) => ({
+    titulo: `${alerta.tipo_dominante || 'Zona'} - riesgo ${alerta.nivel}`,
+    descripcion: `${alerta.n_reportes || 0} reporte(s), score ${alerta.score || 0}`,
+    tipo: 'alerta',
+    data: alerta,
+  }))
+);
+
+export const buildOfflineResponse = ({ mensaje, contexto = {} }) => {
+  const intent = detectIntent(mensaje);
+  const stats = contexto.global || {};
+  const usuario = contexto.usuario || null;
+  const totalReportes = Number(stats.total_reportes) || 0;
+  const municipios = Number(stats.municipios_activos) || 0;
+  const reportesUsuario = usuario?.total_reportes ?? usuario?.reportes?.length ?? 0;
+
+  const responses = {
+    reportes: 'Para crear un reporte entra a Nuevo reporte, selecciona categoria y severidad, describe el problema, agrega ubicacion y adjunta evidencias si las tienes.',
+    alertas: `Las zonas de riesgo se calculan con reportes recientes, severidad y concentracion geografica. Hay ${totalReportes} reportes registrados en ${municipios} municipio(s) activo(s).`,
+    verificacion: 'Despues del registro enviamos un codigo de 6 digitos al correo. Puedes ingresarlo en la pantalla de verificacion o solicitar uno nuevo cuando termine el contador.',
+    recuperacion: 'Para recuperar tu contrasena usa Olvidaste tu contrasena, escribe tu correo y abre el enlace recibido. El enlace expira por seguridad.',
+    seguimiento: 'Puedes revisar el estado en Mis reportes. Los moderadores pueden cambiar un reporte entre pendiente, en revision, verificado, en proceso, resuelto o rechazado.',
+    mis_reportes: usuario
+      ? `Tienes ${reportesUsuario} reporte(s) registrados. Revisa Mis reportes para ver estado, evidencias y comentarios de moderacion.`
+      : 'Para consultar tus reportes necesito que inicies sesion. Sin sesion puedo ayudarte con reportes, alertas y verificacion.',
+    fallback: 'Puedo ayudarte con reportes ambientales, verificacion de correo, recuperacion de contrasena, alertas de riesgo y seguimiento de reportes.',
+  };
+
+  const cards = buildCards(contexto);
+
+  return {
+    respuesta: responses[intent] || responses.fallback,
+    intent,
+    fuente: 'offline',
+    sugerencias: buildSuggestions(intent),
+    cards,
+    estadoAmbiental: cards.some((card) => ['critico', 'alto'].includes(card.data?.nivel))
+      ? 'alerta'
+      : 'optimo',
+  };
+};

--- a/src/services/chatbot.service.js
+++ b/src/services/chatbot.service.js
@@ -1,0 +1,115 @@
+import { buildOfflineResponse } from './chatbot-offline.js';
+import { construirContextoChatbot } from './chatbot-context.js';
+
+const CACHE_TTL_MS = 30 * 1000;
+const cache = new Map();
+
+const getCacheKey = ({ mensaje, sessionId, user, lat, lng }) => JSON.stringify({
+  mensaje: String(mensaje || '').trim().toLowerCase(),
+  sessionId: sessionId || null,
+  userId: user?.sub || null,
+  lat: lat || null,
+  lng: lng || null,
+});
+
+const getCached = (key) => {
+  const entry = cache.get(key);
+  if (!entry || entry.expiresAt <= Date.now()) {
+    cache.delete(key);
+    return null;
+  }
+
+  return entry.value;
+};
+
+const setCached = (key, value) => {
+  cache.set(key, {
+    value,
+    expiresAt: Date.now() + CACHE_TTL_MS,
+  });
+  return value;
+};
+
+export const clearChatbotCache = () => {
+  cache.clear();
+};
+
+export const getChatbotCacheSize = () => cache.size;
+
+const fetchJson = async (url, options) => {
+  const response = await fetch(url, {
+    ...options,
+    signal: AbortSignal.timeout(4000),
+  });
+
+  if (!response.ok) return null;
+  return response.json();
+};
+
+const tryGroq = async ({ mensaje, contexto }) => {
+  if (!process.env.GROQ_API_KEY) return null;
+
+  const json = await fetchJson('https://api.groq.com/openai/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.GROQ_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: process.env.GROQ_MODEL || 'llama-3.1-8b-instant',
+      messages: [
+        { role: 'system', content: 'Responde como asistente ambiental de Green Alert. Mantén formato breve y accionable.' },
+        { role: 'user', content: JSON.stringify({ mensaje, contexto }) },
+      ],
+      temperature: 0.2,
+    }),
+  }).catch(() => null);
+
+  const respuesta = json?.choices?.[0]?.message?.content?.trim();
+  return respuesta ? { respuesta, fuente: 'groq' } : null;
+};
+
+const tryGemini = async ({ mensaje, contexto }) => {
+  if (!process.env.GEMINI_API_KEY) return null;
+
+  const model = process.env.GEMINI_MODEL || 'gemini-1.5-flash';
+  const json = await fetchJson(
+    `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${process.env.GEMINI_API_KEY}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contents: [{
+          parts: [{ text: JSON.stringify({ mensaje, contexto }) }],
+        }],
+      }),
+    }
+  ).catch(() => null);
+
+  const respuesta = json?.candidates?.[0]?.content?.parts?.[0]?.text?.trim();
+  return respuesta ? { respuesta, fuente: 'gemini' } : null;
+};
+
+export const generarRespuestaChatbot = async ({ mensaje, sessionId, user, lat, lng }) => {
+  const key = getCacheKey({ mensaje, sessionId, user, lat, lng });
+  const cached = getCached(key);
+  if (cached) {
+    return {
+      ...cached,
+      cache: true,
+    };
+  }
+
+  const contexto = await construirContextoChatbot({ user, lat, lng });
+  const offline = buildOfflineResponse({ mensaje, contexto });
+  const external = await tryGroq({ mensaje, contexto })
+    || await tryGemini({ mensaje, contexto });
+
+  const result = {
+    ...offline,
+    ...(external ? { respuesta: external.respuesta, fuente: external.fuente } : {}),
+    cache: false,
+  };
+
+  return setCached(key, result);
+};

--- a/tests/diagnose-frontend-contract.js
+++ b/tests/diagnose-frontend-contract.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const backendDir = path.resolve(path.dirname(__filename), '..');
+const repoDir = path.resolve(backendDir, '..');
+const frontendApiPath = path.join(repoDir, 'Frontend', 'src', 'services', 'api.js');
+
+const source = await fs.readFile(frontendApiPath, 'utf8');
+const regex = /export const (\w+)\s*=.*?api\.(get|post|patch|delete)\((`[^`]+`|'[^']+'|"[^"]+")/gs;
+
+console.log('Contrato consumido por Frontend/src/services/api.js\n');
+let total = 0;
+for (const match of source.matchAll(regex)) {
+  const [, name, method, rawPath] = match;
+  const endpoint = rawPath.slice(1, -1);
+  console.log(`${method.toUpperCase().padEnd(6)} ${endpoint.padEnd(42)} ${name}`);
+  total += 1;
+}
+
+console.log(`\nTotal endpoints exportados: ${total}`);
+console.log('Nota: el frontend usa baseURL /api y Vite reescribe /api hacia el backend sin prefijo interno.');

--- a/tests/unit/chatbot-conversacional.test.js
+++ b/tests/unit/chatbot-conversacional.test.js
@@ -1,0 +1,147 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { enviarMensajeChatbot, clearChatbotRateLimit } from '../../src/controllers/chatbot.controller.js';
+import { detectIntent, buildOfflineResponse } from '../../src/services/chatbot-offline.js';
+import {
+  clearChatbotCache,
+  generarRespuestaChatbot,
+  getChatbotCacheSize,
+} from '../../src/services/chatbot.service.js';
+import { ReporteModel } from '../../src/models/reporte.model.js';
+
+const createResponse = () => ({
+  statusCode: null,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+});
+
+const mockContextQueries = (t) => {
+  t.mock.method(ReporteModel, 'getStats', async () => ({
+    total_reportes: 12,
+    municipios_activos: 3,
+  }));
+  t.mock.method(ReporteModel, 'findByUsuario', async () => ([
+    { id_reporte: 1, estado: 'pendiente', titulo: 'Reporte propio' },
+  ]));
+  t.mock.method(ReporteModel, 'countByUsuario', async () => 1);
+  t.mock.method(ReporteModel, 'findParaPrediccion', async () => []);
+};
+
+test('detectIntent reconoce intents principales', () => {
+  assert.equal(detectIntent('Quiero crear un reporte con foto'), 'reportes');
+  assert.equal(detectIntent('Hay alertas cerca de mi ubicacion?'), 'alertas');
+  assert.equal(detectIntent('Cuantos reportes tengo?'), 'mis_reportes');
+  assert.equal(detectIntent('Como verifico mi correo?'), 'verificacion');
+  assert.equal(detectIntent('Recuperar password'), 'recuperacion');
+});
+
+test('motor offline responde con contexto de usuario cuando hay JWT', () => {
+  const result = buildOfflineResponse({
+    mensaje: 'cuantos reportes tengo?',
+    contexto: {
+      global: { total_reportes: 12, municipios_activos: 3 },
+      usuario: { total_reportes: 2, reportes: [] },
+      alertasZona: [],
+    },
+  });
+
+  assert.equal(result.intent, 'mis_reportes');
+  assert.match(result.respuesta, /Tienes 2 reporte/);
+  assert.equal(result.fuente, 'offline');
+  assert.deepEqual(result.cards, []);
+});
+
+test('generarRespuestaChatbot funciona offline y usa cache', async (t) => {
+  clearChatbotCache();
+  mockContextQueries(t);
+
+  const first = await generarRespuestaChatbot({
+    mensaje: 'Que son las zonas de riesgo?',
+    sessionId: 's1',
+    user: { sub: 7 },
+  });
+  const second = await generarRespuestaChatbot({
+    mensaje: 'Que son las zonas de riesgo?',
+    sessionId: 's1',
+    user: { sub: 7 },
+  });
+
+  assert.equal(first.fuente, 'offline');
+  assert.equal(first.cache, false);
+  assert.equal(second.cache, true);
+  assert.equal(getChatbotCacheSize(), 1);
+  assert.equal(ReporteModel.getStats.mock.callCount(), 1);
+});
+
+test('enviarMensajeChatbot valida mensaje requerido y maximo 500 caracteres', async (t) => {
+  clearChatbotRateLimit();
+
+  const missingRes = createResponse();
+  await enviarMensajeChatbot({ body: {}, ip: '1.1.1.1' }, missingRes, t.mock.fn());
+
+  assert.equal(missingRes.statusCode, 400);
+  assert.equal(missingRes.body.message, 'El mensaje es requerido.');
+
+  const longRes = createResponse();
+  await enviarMensajeChatbot({
+    body: { mensaje: 'a'.repeat(501) },
+    ip: '1.1.1.2',
+  }, longRes, t.mock.fn());
+
+  assert.equal(longRes.statusCode, 400);
+  assert.equal(longRes.body.message, 'El mensaje no puede superar 500 caracteres.');
+});
+
+test('enviarMensajeChatbot aplica rate limit por sessionId', async (t) => {
+  clearChatbotCache();
+  clearChatbotRateLimit();
+  mockContextQueries(t);
+
+  for (let index = 0; index < 20; index += 1) {
+    const res = createResponse();
+    await enviarMensajeChatbot({
+      body: { mensaje: `Hola ${index}`, sessionId: 'limit-session' },
+      ip: '2.2.2.2',
+    }, res, t.mock.fn());
+    assert.notEqual(res.statusCode, 429);
+  }
+
+  const limited = createResponse();
+  await enviarMensajeChatbot({
+    body: { mensaje: 'mensaje final', sessionId: 'limit-session' },
+    ip: '2.2.2.2',
+  }, limited, t.mock.fn());
+
+  assert.equal(limited.statusCode, 429);
+  assert.equal(limited.body.message, 'Demasiados mensajes. Intenta nuevamente en un minuto.');
+});
+
+test('enviarMensajeChatbot conserva formato esperado por frontend', async (t) => {
+  clearChatbotCache();
+  clearChatbotRateLimit();
+  mockContextQueries(t);
+
+  const res = createResponse();
+  await enviarMensajeChatbot({
+    body: { mensaje: 'Como crear un reporte?', sessionId: 'fmt' },
+    user: { sub: 7 },
+    ip: '3.3.3.3',
+  }, res, t.mock.fn());
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.data.sessionId, 'fmt');
+  assert.equal(typeof res.body.data.respuesta, 'string');
+  assert.equal(res.body.data.intent, 'reportes');
+  assert.equal(res.body.data.fuente, 'offline');
+  assert.ok(Array.isArray(res.body.data.sugerencias));
+  assert.ok(Array.isArray(res.body.data.cards));
+  assert.ok(['optimo', 'alerta'].includes(res.body.data.estadoAmbiental));
+  assert.equal(typeof res.body.data.latencia_ms, 'number');
+});

--- a/tests/unit/database-schema.test.js
+++ b/tests/unit/database-schema.test.js
@@ -1,0 +1,72 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const backendDir = path.resolve(path.dirname(__filename), '../..');
+
+const readSchema = () => fs.readFile(
+  path.join(backendDir, 'DATABASE_SCHEMA_COMPLETE.sql'),
+  'utf8'
+);
+
+test('schema completo incluye tablas de soporte requeridas por el backend', async () => {
+  const schema = await readSchema();
+
+  for (const table of [
+    'usuarios',
+    'categorias_riesgo',
+    'reportes',
+    'evidencias',
+    'refresh_tokens',
+    'reporte_likes',
+    'reporte_vistas',
+    'notificaciones',
+  ]) {
+    assert.match(schema, new RegExp(`CREATE TABLE IF NOT EXISTS ${table} \\(`));
+  }
+});
+
+test('schema completo conserva columnas actuales de auth, IA y moderacion', async () => {
+  const schema = await readSchema();
+
+  for (const column of [
+    'google_id VARCHAR(255) UNIQUE NULL',
+    'facebook_id VARCHAR(255) UNIQUE NULL',
+    'notification_preferences JSON NULL',
+    'avatar_url VARCHAR(255) NULL',
+    'email_verificado BOOLEAN DEFAULT FALSE',
+    'email_verification_token VARCHAR(64) NULL',
+    'subcategoria VARCHAR(100) NULL',
+    "estado ENUM('pendiente', 'en_revision', 'verificado', 'en_proceso', 'rechazado', 'resuelto')",
+    'comentario_moderacion TEXT NULL',
+    'ia_etiquetas JSON NULL',
+    'ia_confianza DECIMAL(5, 2) NULL',
+    'ia_procesado BOOLEAN DEFAULT FALSE',
+  ]) {
+    assert.ok(schema.includes(column), column);
+  }
+});
+
+test('schema completo incluye indices de prediccion', async () => {
+  const schema = await readSchema();
+
+  assert.ok(schema.includes('INDEX idx_reportes_estado_created_at (estado, created_at)'));
+  assert.ok(schema.includes('INDEX idx_reportes_tipo_created_at (tipo_contaminacion, created_at)'));
+  assert.ok(schema.includes('INDEX idx_reportes_latitud_longitud (latitud, longitud)'));
+});
+
+test('migraciones no tienen numeracion duplicada ni scripts sueltos de notificaciones', async () => {
+  const migrationsDir = path.join(backendDir, 'migrations');
+  const files = await fs.readdir(migrationsDir);
+  const numbered = files
+    .map((file) => file.match(/^(\d{3})_/)?.[1])
+    .filter(Boolean);
+  const duplicateNumbers = numbered.filter((number, index) => numbered.indexOf(number) !== index);
+
+  assert.deepEqual(duplicateNumbers, []);
+  assert.equal(files.includes('create_notificaciones.sql'), false);
+  assert.equal(files.includes('012_create_notificaciones.sql'), true);
+});

--- a/tests/unit/frontend-api-contract.test.js
+++ b/tests/unit/frontend-api-contract.test.js
@@ -1,0 +1,113 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const backendDir = path.resolve(path.dirname(__filename), '../..');
+const repoDir = path.resolve(backendDir, '..');
+const frontendApiPath = path.join(repoDir, 'Frontend', 'src', 'services', 'api.js');
+
+const expectedFrontendContracts = [
+  { method: 'get', path: '/health' },
+  { method: 'post', path: '/auth/login' },
+  { method: 'post', path: '/auth/register' },
+  { method: 'post', path: '/auth/google' },
+  { method: 'post', path: '/auth/facebook' },
+  { method: 'get', path: '/categorias' },
+  { method: 'get', path: '/categorias/${codigo}' },
+  { method: 'get', path: '/reportes/stats' },
+  { method: 'get', path: '/reportes/stats/categoria' },
+  { method: 'get', path: '/reportes/stats/timeline' },
+  { method: 'get', path: '/reportes/stats/heatmap' },
+  { method: 'get', path: '/reportes/stats/ia' },
+  { method: 'post', path: '/reportes' },
+  { method: 'get', path: '/reportes' },
+  { method: 'get', path: '/reportes/${id}' },
+  { method: 'post', path: '/reportes/analizar-imagen' },
+  { method: 'patch', path: '/reportes/${id}' },
+  { method: 'delete', path: '/reportes/${id}' },
+  { method: 'get', path: '/reportes/export' },
+  { method: 'post', path: '/reportes/${id}/like' },
+  { method: 'get', path: '/reportes/trending' },
+  { method: 'get', path: '/reportes/zonas-riesgo' },
+  { method: 'get', path: '/reportes/alertas-predictivas' },
+  { method: 'get', path: '/auth/perfil' },
+  { method: 'patch', path: '/auth/perfil' },
+  { method: 'patch', path: '/auth/avatar' },
+  { method: 'patch', path: '/auth/cambiar-contrasena' },
+  { method: 'patch', path: '/auth/notificaciones' },
+  { method: 'get', path: '/reportes/mis-reportes' },
+  { method: 'post', path: '/auth/forgot-password' },
+  { method: 'post', path: '/auth/reset-password' },
+  { method: 'post', path: '/auth/enviar-verificacion' },
+  { method: 'post', path: '/auth/verificar-email' },
+  { method: 'get', path: '/admin/usuarios/stats' },
+  { method: 'get', path: '/admin/usuarios' },
+  { method: 'get', path: '/admin/usuarios/${id}' },
+  { method: 'patch', path: '/admin/usuarios/${id}/rol' },
+  { method: 'patch', path: '/admin/usuarios/${id}/estado' },
+  { method: 'delete', path: '/admin/usuarios/${id}' },
+  { method: 'post', path: '/chatbot/mensaje' },
+  { method: 'get', path: '/chatbot/faqs' },
+  { method: 'get', path: '/notificaciones' },
+  { method: 'get', path: '/notificaciones/contador' },
+  { method: 'patch', path: '/notificaciones/${uuid}/leida' },
+  { method: 'patch', path: '/notificaciones/marcar-todas' },
+  { method: 'delete', path: '/notificaciones/${uuid}' },
+];
+
+const normalizeTemplate = (value) => value
+  .replace(/\$\{uuid\}/g, '__UUID__')
+  .replace(/\$\{codigo\}/g, '__CODIGO__')
+  .replace(/\$\{[^}]+\}/g, '${id}')
+  .replace(/__UUID__/g, '${uuid}')
+  .replace(/__CODIGO__/g, '${codigo}');
+
+const extractContracts = (source) => {
+  const contracts = [];
+  const regex = /api\.(get|post|patch|delete)\((`[^`]+`|'[^']+'|"[^"]+")/g;
+  let match;
+
+  while ((match = regex.exec(source)) !== null) {
+    contracts.push({
+      method: match[1],
+      path: normalizeTemplate(match[2].slice(1, -1)),
+    });
+  }
+
+  return contracts;
+};
+
+test('frontend usa baseURL /api para que Vite haga proxy al backend sin prefijo interno', async () => {
+  const source = await fs.readFile(frontendApiPath, 'utf8');
+
+  assert.match(source, /baseURL:\s*'\/api'/);
+});
+
+test('endpoints consumidos por Frontend/src/services/api.js estan registrados en el contrato esperado', async () => {
+  const source = await fs.readFile(frontendApiPath, 'utf8');
+  const actual = extractContracts(source);
+  const expectedKeys = new Set(expectedFrontendContracts.map((item) => `${item.method} ${item.path}`));
+  const actualKeys = actual.map((item) => `${item.method} ${item.path}`);
+  const missingFromExpected = actualKeys.filter((key) => !expectedKeys.has(key));
+  const notUsedByFrontend = [...expectedKeys].filter((key) => !actualKeys.includes(key));
+
+  assert.deepEqual(missingFromExpected, []);
+  assert.deepEqual(notUsedByFrontend, []);
+});
+
+test('contrato de frontend cubre modulos principales verificados por la suite', () => {
+  const prefixes = new Set(expectedFrontendContracts.map(({ path: routePath }) => routePath.split('/')[1]));
+
+  assert.deepEqual([...prefixes].sort(), [
+    'admin',
+    'auth',
+    'categorias',
+    'chatbot',
+    'health',
+    'notificaciones',
+    'reportes',
+  ]);
+});

--- a/tests/unit/notificacion.controller.test.js
+++ b/tests/unit/notificacion.controller.test.js
@@ -1,0 +1,328 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import http from 'node:http';
+import notificacionRouter from '../../routes/notificacion.routes.js';
+import {
+  contadorNotificaciones,
+  eliminarNotificacion,
+  listarNotificaciones,
+  marcarLeida,
+  marcarTodasLeidas,
+} from '../../src/controllers/notificacion.controller.js';
+import { updateReporte } from '../../src/controllers/reporte.controller.js';
+import { NotificacionModel } from '../../src/models/notificacion.model.js';
+import { ReporteModel } from '../../src/models/reporte.model.js';
+
+const createResponse = () => ({
+  statusCode: null,
+  body: null,
+  headers: {},
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+  setHeader(key, value) {
+    this.headers[key] = value;
+  },
+});
+
+const createMemoryStore = () => {
+  let nextId = 1;
+  const rows = [];
+
+  const create = async (data) => {
+    const row = {
+      id_notificacion: nextId,
+      uuid: `notif-${nextId}`,
+      leida: false,
+      leida_at: null,
+      created_at: new Date(nextId * 1000),
+      referencia_tipo: null,
+      referencia_uuid: null,
+      link: null,
+      ...data,
+    };
+    nextId += 1;
+    rows.push(row);
+    return { id_notificacion: row.id_notificacion, uuid: row.uuid };
+  };
+
+  return {
+    rows,
+    create,
+    findByUsuario: async (id_usuario, { leida, limit = 20, offset = 0 } = {}) => {
+      let items = rows.filter((row) => Number(row.id_usuario) === Number(id_usuario));
+      if (leida === true || leida === false) {
+        items = items.filter((row) => row.leida === leida);
+      }
+      items = items.sort((a, b) => b.id_notificacion - a.id_notificacion);
+
+      const ownRows = rows.filter((row) => Number(row.id_usuario) === Number(id_usuario));
+      return {
+        items: items.slice(Number(offset) || 0, (Number(offset) || 0) + (Number(limit) || 20)),
+        meta: {
+          total: ownRows.length,
+          no_leidas: ownRows.filter((row) => !row.leida).length,
+          limit: Number(limit) || 20,
+          offset: Number(offset) || 0,
+        },
+      };
+    },
+    contarNoLeidas: async (id_usuario) => (
+      rows.filter((row) => Number(row.id_usuario) === Number(id_usuario) && !row.leida).length
+    ),
+    marcarLeida: async (uuid, id_usuario) => {
+      const row = rows.find((item) => item.uuid === uuid && Number(item.id_usuario) === Number(id_usuario));
+      if (!row) return false;
+      row.leida = true;
+      row.leida_at = new Date();
+      return true;
+    },
+    marcarTodasLeidas: async (id_usuario) => {
+      let count = 0;
+      for (const row of rows) {
+        if (Number(row.id_usuario) === Number(id_usuario) && !row.leida) {
+          row.leida = true;
+          row.leida_at = new Date();
+          count += 1;
+        }
+      }
+      return count;
+    },
+    eliminar: async (uuid, id_usuario) => {
+      const index = rows.findIndex((row) => row.uuid === uuid && Number(row.id_usuario) === Number(id_usuario));
+      if (index === -1) return false;
+      rows.splice(index, 1);
+      return true;
+    },
+  };
+};
+
+const mockNotificationModel = (t, store) => {
+  t.mock.method(NotificacionModel, 'create', store.create);
+  t.mock.method(NotificacionModel, 'findByUsuario', store.findByUsuario);
+  t.mock.method(NotificacionModel, 'contarNoLeidas', store.contarNoLeidas);
+  t.mock.method(NotificacionModel, 'marcarLeida', store.marcarLeida);
+  t.mock.method(NotificacionModel, 'marcarTodasLeidas', store.marcarTodasLeidas);
+  t.mock.method(NotificacionModel, 'eliminar', store.eliminar);
+};
+
+test('contador devuelve no leidas y aisla por usuario', async (t) => {
+  const store = createMemoryStore();
+  mockNotificationModel(t, store);
+  await store.create({ id_usuario: 1, tipo: 'sistema', titulo: 'A', mensaje: 'Uno' });
+  await store.create({ id_usuario: 1, tipo: 'sistema', titulo: 'B', mensaje: 'Dos' });
+  await store.create({ id_usuario: 2, tipo: 'sistema', titulo: 'C', mensaje: 'Tres' });
+
+  const res = createResponse();
+  await contadorNotificaciones({ user: { sub: 1 } }, res, t.mock.fn());
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.data.no_leidas, 2);
+  assert.equal(res.headers['Cache-Control'], 'no-store');
+});
+
+test('listado devuelve solo notificaciones del usuario autenticado', async (t) => {
+  const store = createMemoryStore();
+  mockNotificationModel(t, store);
+  await store.create({ id_usuario: 1, tipo: 'sistema', titulo: 'A', mensaje: 'Uno' });
+  await store.create({ id_usuario: 2, tipo: 'sistema', titulo: 'B', mensaje: 'Dos' });
+
+  const res = createResponse();
+  await listarNotificaciones({ user: { sub: 1 }, query: {} }, res, t.mock.fn());
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.data.items.length, 1);
+  assert.equal(res.body.data.items[0].id_usuario, 1);
+  assert.equal(res.body.data.meta.total, 1);
+});
+
+test('marcar leida solo modifica notificaciones propias', async (t) => {
+  const store = createMemoryStore();
+  mockNotificationModel(t, store);
+  const own = await store.create({ id_usuario: 1, tipo: 'sistema', titulo: 'A', mensaje: 'Uno' });
+  const other = await store.create({ id_usuario: 2, tipo: 'sistema', titulo: 'B', mensaje: 'Dos' });
+
+  const ownRes = createResponse();
+  await marcarLeida(
+    { user: { sub: 1 }, params: { uuid: own.uuid } },
+    ownRes,
+    t.mock.fn()
+  );
+  assert.equal(ownRes.statusCode, 200);
+  assert.equal(store.rows.find((row) => row.uuid === own.uuid).leida, true);
+
+  const otherRes = createResponse();
+  await marcarLeida(
+    { user: { sub: 1 }, params: { uuid: other.uuid } },
+    otherRes,
+    t.mock.fn()
+  );
+  assert.equal(otherRes.statusCode, 404);
+  assert.equal(store.rows.find((row) => row.uuid === other.uuid).leida, false);
+});
+
+test('marcar todas solo afecta al usuario actual', async (t) => {
+  const store = createMemoryStore();
+  mockNotificationModel(t, store);
+  await store.create({ id_usuario: 1, tipo: 'sistema', titulo: 'A', mensaje: 'Uno' });
+  await store.create({ id_usuario: 1, tipo: 'sistema', titulo: 'B', mensaje: 'Dos' });
+  await store.create({ id_usuario: 2, tipo: 'sistema', titulo: 'C', mensaje: 'Tres' });
+
+  const res = createResponse();
+  await marcarTodasLeidas({ user: { sub: 1 } }, res, t.mock.fn());
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.data.actualizadas, 2);
+  assert.equal(store.rows.filter((row) => row.id_usuario === 1 && !row.leida).length, 0);
+  assert.equal(store.rows.filter((row) => row.id_usuario === 2 && !row.leida).length, 1);
+});
+
+test('eliminar solo borra notificaciones propias', async (t) => {
+  const store = createMemoryStore();
+  mockNotificationModel(t, store);
+  const own = await store.create({ id_usuario: 1, tipo: 'sistema', titulo: 'A', mensaje: 'Uno' });
+  const other = await store.create({ id_usuario: 2, tipo: 'sistema', titulo: 'B', mensaje: 'Dos' });
+
+  const forbidden = createResponse();
+  await eliminarNotificacion(
+    { user: { sub: 1 }, params: { uuid: other.uuid } },
+    forbidden,
+    t.mock.fn()
+  );
+  assert.equal(forbidden.statusCode, 404);
+
+  const ok = createResponse();
+  await eliminarNotificacion(
+    { user: { sub: 1 }, params: { uuid: own.uuid } },
+    ok,
+    t.mock.fn()
+  );
+  assert.equal(ok.statusCode, 200);
+  assert.equal(store.rows.some((row) => row.uuid === own.uuid), false);
+  assert.equal(store.rows.some((row) => row.uuid === other.uuid), true);
+});
+
+test('sin JWT todas las rutas de notificaciones responden 401', async () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/notificaciones', notificacionRouter);
+  const server = await new Promise((resolve) => {
+    const instance = http.createServer(app);
+    instance.listen(0, () => resolve(instance));
+  });
+
+  try {
+    const { port } = server.address();
+    const cases = [
+      ['GET', '/notificaciones'],
+      ['GET', '/notificaciones/contador'],
+      ['PATCH', '/notificaciones/marcar-todas'],
+      ['PATCH', '/notificaciones/notif-1/leida'],
+      ['DELETE', '/notificaciones/notif-1'],
+    ];
+
+    for (const [method, path] of cases) {
+      const response = await fetch(`http://127.0.0.1:${port}${path}`, { method });
+      assert.equal(response.status, 401, `${method} ${path}`);
+    }
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test('updateReporte genera notificacion al dueno cuando cambia estado o comentario', async (t) => {
+  const reportes = [
+    {
+      id_reporte: 10,
+      uuid: 'reporte-uuid',
+      id_usuario: 7,
+      estado: 'pendiente',
+      titulo: 'Rio contaminado',
+      comentario_moderacion: null,
+    },
+    {
+      id_reporte: 10,
+      uuid: 'reporte-uuid',
+      id_usuario: 7,
+      estado: 'verificado',
+      titulo: 'Rio contaminado',
+      comentario_moderacion: 'Se valido evidencia.',
+    },
+  ];
+
+  t.mock.method(ReporteModel, 'findById', async () => reportes.shift());
+  t.mock.method(ReporteModel, 'update', async () => true);
+  t.mock.method(NotificacionModel, 'create', async () => ({ id_notificacion: 1, uuid: 'notif-1' }));
+
+  const res = createResponse();
+  await updateReporte(
+    {
+      params: { id: '10' },
+      user: { sub: 99, rol: 'moderador' },
+      body: {
+        estado: 'verificado',
+        comentario_moderacion: 'Se valido evidencia.',
+      },
+    },
+    res,
+    t.mock.fn()
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(NotificacionModel.create.mock.callCount(), 2);
+  assert.equal(NotificacionModel.create.mock.calls[0].arguments[0].id_usuario, 7);
+  assert.equal(NotificacionModel.create.mock.calls[0].arguments[0].tipo, 'reporte_estado');
+  assert.equal(NotificacionModel.create.mock.calls[1].arguments[0].tipo, 'reporte_comentario');
+});
+
+test('fallo al crear notificacion no rompe updateReporte', async (t) => {
+  const reportes = [
+    {
+      id_reporte: 11,
+      uuid: 'reporte-uuid-2',
+      id_usuario: 7,
+      estado: 'pendiente',
+      titulo: 'Basura acumulada',
+      comentario_moderacion: null,
+    },
+    {
+      id_reporte: 11,
+      uuid: 'reporte-uuid-2',
+      id_usuario: 7,
+      estado: 'en_revision',
+      titulo: 'Basura acumulada',
+      comentario_moderacion: null,
+    },
+  ];
+
+  t.mock.method(ReporteModel, 'findById', async () => reportes.shift());
+  t.mock.method(ReporteModel, 'update', async () => true);
+  t.mock.method(NotificacionModel, 'create', async () => {
+    throw new Error('tabla no disponible');
+  });
+  t.mock.method(console, 'error', () => {});
+
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await updateReporte(
+    {
+      params: { id: '11' },
+      user: { sub: 99, rol: 'admin' },
+      body: { estado: 'en_revision' },
+    },
+    res,
+    next
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(next.mock.callCount(), 0);
+});

--- a/tests/unit/reporte-enum-validacion.test.js
+++ b/tests/unit/reporte-enum-validacion.test.js
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { updateReporte } from '../../src/controllers/reporte.controller.js';
+import { NotificacionModel } from '../../src/models/notificacion.model.js';
 import { ReporteModel } from '../../src/models/reporte.model.js';
 
 const createResponse = () => ({
@@ -29,6 +30,7 @@ test('updateReporte acepta estado y nivel_severidad validos normalizados', async
     estado: 'pendiente',
   }));
   t.mock.method(ReporteModel, 'update', async () => true);
+  t.mock.method(NotificacionModel, 'create', async () => ({ id_notificacion: 1, uuid: 'notif-1' }));
 
   const req = createModeratorRequest({
     estado: ' En_Revision ',


### PR DESCRIPTION
# Closes #208 

## Descripción

Se cerró la paridad funcional interna del backend mediante pruebas de regresión y verificación del contrato consumido por el frontend.
Se agregó una prueba que valida los endpoints exportados por `Frontend/src/services/api.js`, confirmando que el frontend usa `/api` como base y que las rutas principales están contempladas en el contrato esperado del backend.
También se añadió un script diagnóstico para listar los endpoints consumidos por el frontend y facilitar revisiones manuales. Además, se documentó el checklist de cobertura, endpoints principales, estado inicial de pruebas y diferencias intencionales del manejo de `/api`.
La suite unitaria quedó verde después de los cambios, pasando de `112` a `115` pruebas exitosas.
<img width="839" height="821" alt="image" src="https://github.com/user-attachments/assets/d35d7274-5e95-42cc-8bff-bb60bbb693de" />

<img width="954" height="918" alt="image" src="https://github.com/user-attachments/assets/0572a034-3ea0-4be0-bb5a-4e5ec9337b81" />
