### PR TITLE
Issues 219, 220, 221, 222, 223: Reforzamiento del backend de reportes y alertas

### DIFF
--- a/DATABASE_SCHEMA_COMPLETE.sql
+++ b/DATABASE_SCHEMA_COMPLETE.sql
@@ -255,6 +255,28 @@ CREATE TABLE IF NOT EXISTS notificaciones (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- ============================================================================
+-- TABLE: fcm_tokens
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS fcm_tokens (
+  id_fcm_token BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  id_usuario BIGINT UNSIGNED NOT NULL,
+  token TEXT NOT NULL,
+  token_hash CHAR(64) NOT NULL,
+  activo BOOLEAN DEFAULT TRUE,
+  user_agent VARCHAR(255) NULL,
+  last_seen_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+  CONSTRAINT fk_fcm_tokens_usuario FOREIGN KEY (id_usuario)
+    REFERENCES usuarios(id_usuario) ON DELETE CASCADE ON UPDATE CASCADE,
+
+  UNIQUE KEY uk_fcm_tokens_hash (token_hash),
+  INDEX idx_fcm_tokens_usuario_activo (id_usuario, activo),
+  INDEX idx_fcm_tokens_last_seen_at (last_seen_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ============================================================================
 -- VIEWS (Optional, for common queries)
 -- ============================================================================
 

--- a/docs/PREDICCION_ZONAS_RIESGO.md
+++ b/docs/PREDICCION_ZONAS_RIESGO.md
@@ -1,0 +1,60 @@
+# Prediccion de zonas de riesgo
+
+La prediccion usa reportes historicos moderados para agrupar eventos ambientales en celdas geograficas y producir zonas de riesgo consultables por el dashboard y las alertas.
+
+## Datos de entrada
+
+Solo se consideran reportes que cumplan estas condiciones:
+
+- `deleted_at IS NULL`
+- `latitud` y `longitud` no nulas
+- `estado IN ('verificado', 'en_proceso', 'resuelto')`
+- `created_at >= desde`, cuando se envia filtro por dias
+- `tipo_contaminacion = tipo`, cuando se envia filtro por tipo
+
+Los estados `pendiente`, `en_revision` y `rechazado` no alimentan la prediccion.
+
+## Agrupacion
+
+Cada reporte se asigna a una celda de `0.05` grados por latitud/longitud. La zona expone el centro de la celda, no coordenadas individuales de usuarios.
+
+## Score
+
+Para cada celda:
+
+```text
+score = min(100, round((cantidad_reportes * 16) + (severidad_promedio * 14) + recencia_promedio))
+```
+
+Donde:
+
+- `cantidad_reportes`: numero de reportes dentro de la celda.
+- `severidad_promedio`: promedio de severidad mapeada como `bajo=1`, `medio=2`, `alto=3`, `critico=4`.
+- `recencia_promedio`: promedio por reporte de `max(0, 30 - dias_desde_creacion)`.
+
+## Niveles
+
+- `critico`: score >= 80
+- `alto`: score >= 60
+- `medio`: score >= 35
+- `bajo`: score >= 0
+
+## Cache
+
+Las zonas y alertas se cachean por parametros durante 5 minutos. La cache se invalida al crear reportes, al eliminar reportes y cuando una actualizacion cambia `estado` o `nivel_severidad`.
+
+## Parametros
+
+`/reportes/zonas-riesgo`:
+
+- `dias`: entero entre 1 y 365. Default: 30.
+- `tipo`: categoria opcional.
+- `min_score`: numero entre 0 y 100. Default: 30.
+
+`/reportes/alertas-predictivas`:
+
+- Incluye los parametros anteriores.
+- `limite`: entero entre 1 y 50. Default: 10.
+- `nivel_min`: `bajo`, `medio`, `alto` o `critico`. Default: `medio`.
+- `lat` y `lng`: deben enviarse juntos.
+- `radio_km`: numero mayor a 0 y menor o igual a 500. Requiere `lat` y `lng`.

--- a/migrations/013_create_fcm_tokens.sql
+++ b/migrations/013_create_fcm_tokens.sql
@@ -1,0 +1,21 @@
+-- Migracion: tokens FCM por usuario
+-- Descripcion: Registra tokens de Firebase Cloud Messaging para notificaciones push.
+
+CREATE TABLE IF NOT EXISTS fcm_tokens (
+  id_fcm_token BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  id_usuario BIGINT UNSIGNED NOT NULL,
+  token TEXT NOT NULL,
+  token_hash CHAR(64) NOT NULL,
+  activo BOOLEAN DEFAULT TRUE,
+  user_agent VARCHAR(255) NULL,
+  last_seen_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+  CONSTRAINT fk_fcm_tokens_usuario FOREIGN KEY (id_usuario)
+    REFERENCES usuarios(id_usuario) ON DELETE CASCADE ON UPDATE CASCADE,
+
+  UNIQUE KEY uk_fcm_tokens_hash (token_hash),
+  INDEX idx_fcm_tokens_usuario_activo (id_usuario, activo),
+  INDEX idx_fcm_tokens_last_seen_at (last_seen_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/repomix-output.xml
+++ b/repomix-output.xml
@@ -1,0 +1,14967 @@
+This file is a merged representation of the entire codebase, combined into a single document by Repomix.
+
+<file_summary>
+This section contains a summary of this file.
+
+<purpose>
+This file contains a packed representation of the entire repository's contents.
+It is designed to be easily consumable by AI systems for analysis, code review,
+or other automated processes.
+</purpose>
+
+<file_format>
+The content is organized as follows:
+1. This summary section
+2. Repository information
+3. Directory structure
+4. Repository files (if enabled)
+5. Multiple file entries, each consisting of:
+  - File path as an attribute
+  - Full contents of the file
+</file_format>
+
+<usage_guidelines>
+- This file should be treated as read-only. Any changes should be made to the
+  original repository files, not this packed version.
+- When processing this file, use the file path to distinguish
+  between different files in the repository.
+- Be aware that this file may contain sensitive information. Handle it with
+  the same level of security as you would the original repository.
+- Pay special attention to the Repository Description. These contain important context and guidelines specific to this project.
+</usage_guidelines>
+
+<notes>
+- Some files may have been excluded based on .gitignore rules and Repomix's configuration
+- Binary files are not included in this packed representation. Please refer to the Repository Structure section for a complete list of file paths, including binary files
+- Files matching patterns in .gitignore are excluded
+- Files matching default ignore patterns are excluded
+- Files are sorted by Git change count (files with more changes are at the bottom)
+</notes>
+
+</file_summary>
+
+<user_provided_header>
+Responde en español. Resume en español.
+</user_provided_header>
+
+<directory_structure>
+.dockerignore
+.env.example
+.github/workflows/Maven.yml
+.gitignore
+DATABASE_SCHEMA_COMPLETE.sql
+Dockerfile
+docs/README.md
+docs/regression-parity-208.md
+middlewares/auth.middleware.js
+middlewares/errorHandler.js
+middlewares/rateLimit.middleware.js
+middlewares/upload.middleware.js
+middlewares/validate-id.middleware.js
+migrations/001_add_otp_columns_usuarios.sql
+migrations/002_add_comentario_moderacion_reportes.sql
+migrations/003_add_google_oauth_support.sql
+migrations/004_add_facebook_oauth_support.sql
+migrations/005_add_email_verification_token.sql
+migrations/006_create_refresh_tokens.sql
+migrations/007_set_reportes_estado_default_pendiente.sql
+migrations/008_add_notification_preferences_to_usuarios.sql
+migrations/009_create_reporte_likes.sql
+migrations/010_create_reporte_vistas.sql
+migrations/011_add_prediction_indexes.sql
+migrations/012_create_notificaciones.sql
+package.json
+README.md
+routes/admin.routes.js
+routes/auth.routes.js
+routes/categoria-riesgo.routes.js
+routes/chatbot.routes.js
+routes/health.routes.js
+routes/notificacion.routes.js
+routes/reporte.routes.js
+scripts/sql/00_create_database.sql
+scripts/sql/verify_schema.sql
+src/app.js
+src/config/api-prefix.config.js
+src/config/database.js
+src/config/email.config.js
+src/config/facebook.config.js
+src/config/google.config.js
+src/config/schema-compat.js
+src/config/security.config.js
+src/config/upload.config.js
+src/controllers/admin.controller.js
+src/controllers/auth.controller.js
+src/controllers/categoria-riesgo.controller.js
+src/controllers/chatbot.controller.js
+src/controllers/health.controller.js
+src/controllers/notificacion.controller.js
+src/controllers/prediccion.controller.js
+src/controllers/reporte.controller.js
+src/models/.gitkeep
+src/models/categoria-riesgo.model.js
+src/models/evidencia.model.js
+src/models/like.model.js
+src/models/notificacion.model.js
+src/models/refresh-token.model.js
+src/models/reporte.model.js
+src/models/usuario.model.js
+src/server.js
+src/services/.gitkeep
+src/services/chatbot-context.js
+src/services/chatbot-offline.js
+src/services/chatbot.service.js
+src/services/clasificacion.service.js
+src/services/email.service.js
+src/services/facebook-oauth.service.js
+src/services/google-oauth.service.js
+src/services/ia.service.js
+src/services/oauth-callback-code.service.js
+src/services/prediccion.service.js
+src/utils/constantes-validacion.js
+src/utils/response.js
+tests/auth/login.test.js
+tests/auth/password-reset.test.js
+tests/auth/refresh-flow.manual.ps1
+tests/auth/register.test.js
+tests/config/email-config.test.js
+tests/diagnose-frontend-contract.js
+tests/diagnose-routes.js
+tests/email/smtp-send.test.js
+tests/email/verification.test.js
+tests/email/welcome.test.js
+tests/integration-v2.test.js
+tests/integration.test.js
+tests/models/usuario.pagination.test.js
+tests/README.md
+tests/run-all.js
+tests/unit/categoria-admin-crud.test.js
+tests/unit/categoria-riesgo.test.js
+tests/unit/categoria-severidad-stats.test.js
+tests/unit/chatbot-conversacional.test.js
+tests/unit/clasificacion-ia.test.js
+tests/unit/database-schema.test.js
+tests/unit/email-template.test.js
+tests/unit/evidencia-soft-delete.test.js
+tests/unit/frontend-api-contract.test.js
+tests/unit/ia-service.test.js
+tests/unit/likes-vistas-trending.test.js
+tests/unit/logout-global-auth.test.js
+tests/unit/notificacion.controller.test.js
+tests/unit/notification-preferences.test.js
+tests/unit/oauth-callback-code.test.js
+tests/unit/optional-auth.test.js
+tests/unit/otp-generation.test.js
+tests/unit/password-refresh-revocation.test.js
+tests/unit/prediccion-service.test.js
+tests/unit/reporte-categoria-validacion.test.js
+tests/unit/reporte-enum-validacion.test.js
+tests/unit/reporte-estado-inicial.test.js
+tests/unit/reporte-evidencias-gestion.test.js
+tests/unit/reporte-pagination-total.test.js
+tests/unit/reporte-upload-evidencias.test.js
+tests/unit/response.test.js
+tests/unit/route-prefix.test.js
+tests/unit/security-middleware.test.js
+tests/unit/upload-config.test.js
+tests/unit/validaciones.test.js
+tests/unit/validate-id-middleware.test.js
+validate-facebook-credentials.js
+validate-google-credentials.js
+</directory_structure>
+
+<files>
+This section contains the contents of the repository's files.
+
+<file path=".gitignore">
+# Variables de entorno
+.env
+.env.local
+.env.*.local
+
+# Dependencias
+node_modules/
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+.pnpm-debug.log*
+
+# Runtime
+dist/
+build/
+
+# Archivos subidos por usuarios
+uploads/
+uploads/*
+!uploads/.gitkeep
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+.history
+.ionide
+
+# Testing
+coverage/
+.nyc_output/
+
+# Misc
+*.pem
+.cache/
+.output/
+
+# Directorio temporal
+tmp/
+temp/
+
+# Archivos del sistema
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# IDE específicos de Windows
+*.code-workspace
+
+# Archivos de backup
+*.bak
+*.backup
+*.old
+*~
+
+# SQLite (si se usa)
+*.db
+*.sqlite
+*.sqlite3
+</file>
+
+<file path="migrations/001_add_otp_columns_usuarios.sql">
+-- Migración: Agregar columnas OTP para verificación de email
+-- Descripción: Añade soporte para verificación de email mediante OTP de 6 dígitos
+
+ALTER TABLE usuarios
+ADD COLUMN otp_code_hash VARCHAR(64) NULL DEFAULT NULL COMMENT 'Hash SHA-256 del código OTP',
+ADD COLUMN otp_exp DATETIME NULL DEFAULT NULL COMMENT 'Fecha de expiración del OTP (10 minutos)',
+ADD COLUMN otp_attempts INT DEFAULT 0 COMMENT 'Contador de intentos fallidos',
+ADD COLUMN otp_last_request DATETIME NULL DEFAULT NULL COMMENT 'Timestamp del último reenvío solicitado';
+
+-- Crear índice para búsquedas rápidas de OTP
+CREATE INDEX idx_otp_code_hash ON usuarios(otp_code_hash);
+CREATE INDEX idx_otp_exp ON usuarios(otp_exp);
+</file>
+
+<file path="migrations/002_add_comentario_moderacion_reportes.sql">
+-- Migración: Agregar columna comentario_moderacion a tabla reportes
+-- Descripción: Permite a moderadores/admins adjuntar justificación al cambiar estado
+
+ALTER TABLE reportes
+ADD COLUMN comentario_moderacion TEXT NULL DEFAULT NULL COMMENT 'Comentario del moderador al cambiar estado (obligatorio para rechazo)' AFTER estado;
+
+-- Crear índice para búsquedas futuras
+CREATE INDEX idx_comentario_moderacion ON reportes(comentario_moderacion(100));
+</file>
+
+<file path="migrations/004_add_facebook_oauth_support.sql">
+-- Migracion: Agregar soporte para Facebook OAuth
+-- Descripcion: Agrega columna facebook_id a usuarios para vincular cuentas de Facebook.
+
+ALTER TABLE usuarios
+  ADD COLUMN IF NOT EXISTS facebook_id VARCHAR(255) UNIQUE NULL AFTER google_id;
+
+CREATE INDEX IF NOT EXISTS idx_facebook_id ON usuarios(facebook_id);
+</file>
+
+<file path="routes/health.routes.js">
+import { Router } from 'express';
+import { getHealth } from '../src/controllers/health.controller.js';
+
+const healthRouter = Router();
+
+healthRouter.get('/', getHealth);
+
+export default healthRouter;
+</file>
+
+<file path="src/config/database.js">
+import mysql from 'mysql2/promise';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+// pool de conexiones reutilizables
+const pool = mysql.createPool({
+  host:             process.env.DB_HOST,
+  port:             Number(process.env.DB_PORT),
+  user:             process.env.DB_USER,
+  password:         process.env.DB_PASSWORD,
+  database:         process.env.DB_NAME,
+  connectionLimit:  10,
+  waitForConnections: true,
+  queueLimit:       0,
+});
+
+// verifica la conexión al iniciar el servidor
+export const testConnection = async () => {
+  try {
+    const connection = await pool.getConnection();
+    console.log('conexión a mysql establecida.');
+    connection.release();
+  } catch (error) {
+    console.error('error al conectar con mysql:', error.message);
+    process.exit(1);
+  }
+};
+
+export default pool;
+</file>
+
+<file path="src/config/email.config.js">
+/**
+ * EMAIL CONFIGURATION
+ * Centraliza y valida todas las variables de entorno para el servicio de correo
+ * Nunca debe contener valores hardcodeados
+ */
+
+const validateEmailConfig = () => {
+  const config = {
+    host: process.env.EMAIL_HOST,
+    port: Number(process.env.EMAIL_PORT),
+    user: process.env.EMAIL_USER,
+    pass: process.env.EMAIL_PASS,
+    from: process.env.EMAIL_FROM,
+  };
+
+  // Validar que todas las variables estén definidas
+  const missingVars = [];
+  
+  if (!config.host) missingVars.push('EMAIL_HOST');
+  if (!config.port) missingVars.push('EMAIL_PORT');
+  if (!config.user) missingVars.push('EMAIL_USER');
+  if (!config.pass) missingVars.push('EMAIL_PASS');
+  if (!config.from) missingVars.push('EMAIL_FROM');
+
+  if (missingVars.length > 0) {
+    throw new Error(
+      `Variables de entorno para Email no configuradas: ${missingVars.join(', ')}\n` +
+      `Por favor, configura estas variables en el archivo .env\n` +
+      `Referencia: Backend/.env.example`
+    );
+  }
+
+  // Validar formato de puerto
+  if (isNaN(config.port) || config.port < 1 || config.port > 65535) {
+    throw new Error('EMAIL_PORT debe ser un número válido entre 1 y 65535');
+  }
+
+  // Validar formato de email en EMAIL_FROM
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailRegex.test(config.from)) {
+    throw new Error('EMAIL_FROM debe ser un correo electrónico válido');
+  }
+
+  return config;
+};
+
+// Cargar y validar configuración
+let emailConfig = null;
+
+export const getEmailConfig = () => {
+  if (!emailConfig) {
+    emailConfig = validateEmailConfig();
+  }
+  return emailConfig;
+};
+
+export default getEmailConfig;
+</file>
+
+<file path="src/controllers/admin.controller.js">
+import { UsuarioModel } from '../models/usuario.model.js';
+import { ReporteModel } from '../models/reporte.model.js';
+import { errorResponse, successResponse } from '../utils/response.js';
+
+const VALID_ROLES = ['ciudadano', 'moderador', 'admin'];
+
+const parseLimit = (value, fallback) => {
+  const parsed = Number(value);
+  if (Number.isNaN(parsed)) return fallback;
+  return Math.max(1, Math.min(100, parsed));
+};
+
+const parseOffset = (value, fallback) => {
+  const parsed = Number(value);
+  if (Number.isNaN(parsed)) return fallback;
+  return Math.max(0, parsed);
+};
+
+const parseActivo = (value) => {
+  if (value === undefined || value === null) return null;
+  if (typeof value === 'boolean') return value ? 1 : 0;
+  if (typeof value === 'number') return value === 1 ? 1 : value === 0 ? 0 : null;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'true' || normalized === '1') return 1;
+    if (normalized === 'false' || normalized === '0') return 0;
+  }
+  return null;
+};
+
+export const listarUsuarios = async (req, res, next) => {
+  try {
+    const { rol, activo, search } = req.query ?? {};
+    const limit = parseLimit(req.query?.limit, 20);
+    const offset = parseOffset(req.query?.offset, 0);
+    const activoValue = parseActivo(activo);
+
+    if (rol && !VALID_ROLES.includes(rol)) {
+      return errorResponse(res, 'Rol invalido.', 400);
+    }
+
+    const [usuarios, total] = await Promise.all([
+      UsuarioModel.findAll({
+        rol,
+        activo: activoValue,
+        search,
+        limit,
+        offset,
+      }),
+      UsuarioModel.countAll({
+        rol,
+        activo: activoValue,
+        search,
+      }),
+    ]);
+
+    return successResponse(
+      res,
+      { usuarios, total, limit, offset },
+      'Usuarios obtenidos correctamente.'
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const statsUsuarios = async (req, res, next) => {
+  try {
+    const [usuarios, reportes] = await Promise.all([
+      UsuarioModel.getStats(),
+      ReporteModel.getStats(),
+    ]);
+
+    return successResponse(
+      res,
+      { usuarios, reportes },
+      'Estadisticas obtenidas correctamente.'
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const obtenerUsuario = async (req, res, next) => {
+  try {
+    const id_usuario = Number(req.params.id);
+    if (!id_usuario) {
+      return errorResponse(res, 'Id de usuario invalido.', 400);
+    }
+
+    const usuario = await UsuarioModel.findByIdWithDetails(id_usuario);
+    if (!usuario) {
+      return errorResponse(res, 'Usuario no encontrado.', 404);
+    }
+
+    return successResponse(res, { usuario }, 'Usuario obtenido correctamente.');
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const cambiarRol = async (req, res, next) => {
+  try {
+    const id_usuario = Number(req.params.id);
+    const { rol } = req.body ?? {};
+    const currentUserId = req.user?.sub;
+
+    if (!id_usuario) {
+      return errorResponse(res, 'Id de usuario invalido.', 400);
+    }
+
+    if (!rol || !VALID_ROLES.includes(rol)) {
+      return errorResponse(res, 'Rol invalido.', 400);
+    }
+
+    if (currentUserId === id_usuario && rol !== 'admin') {
+      return errorResponse(res, 'No puedes cambiar tu propio rol.', 403);
+    }
+
+    const usuario = await UsuarioModel.updateRol(id_usuario, rol);
+    if (!usuario) {
+      return errorResponse(res, 'Usuario no encontrado.', 404);
+    }
+
+    return successResponse(res, { usuario }, 'Rol actualizado correctamente.');
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const cambiarEstado = async (req, res, next) => {
+  try {
+    const id_usuario = Number(req.params.id);
+    const { activo } = req.body ?? {};
+    const currentUserId = req.user?.sub;
+    const activoValue = parseActivo(activo);
+
+    if (!id_usuario) {
+      return errorResponse(res, 'Id de usuario invalido.', 400);
+    }
+
+    if (activoValue === null) {
+      return errorResponse(res, 'Estado activo invalido.', 400);
+    }
+
+    if (currentUserId === id_usuario && activoValue === 0) {
+      return errorResponse(res, 'No puedes desactivar tu propia cuenta.', 403);
+    }
+
+    const usuario = await UsuarioModel.updateActivo(id_usuario, activoValue);
+    if (!usuario) {
+      return errorResponse(res, 'Usuario no encontrado.', 404);
+    }
+
+    return successResponse(res, { usuario }, 'Estado actualizado correctamente.');
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const eliminarUsuario = async (req, res, next) => {
+  try {
+    const id_usuario = Number(req.params.id);
+    const currentUserId = req.user?.sub;
+
+    if (!id_usuario) {
+      return errorResponse(res, 'Id de usuario invalido.', 400);
+    }
+
+    if (currentUserId === id_usuario) {
+      return errorResponse(res, 'No puedes eliminar tu propia cuenta.', 403);
+    }
+
+    const removed = await UsuarioModel.remove(id_usuario);
+    if (!removed) {
+      return errorResponse(res, 'Usuario no encontrado.', 404);
+    }
+
+    return successResponse(res, null, 'Usuario eliminado correctamente.');
+  } catch (error) {
+    return next(error);
+  }
+};
+</file>
+
+<file path="src/controllers/health.controller.js">
+import pool from '../config/database.js';
+
+// verifica servidor y base de datos
+export const getHealth = async (req, res) => {
+  try {
+    await pool.query('SELECT 1');
+
+    res.status(200).json({
+      status: 'ok',
+      message: 'servidor funcionando correctamente',
+      database: 'conectada',
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    res.status(503).json({
+      status: 'error',
+      message: 'base de datos no responde',
+      database: 'desconectada',
+      timestamp: new Date().toISOString(),
+    });
+  }
+};
+</file>
+
+<file path="src/models/.gitkeep">
+
+</file>
+
+<file path="src/server.js">
+import dotenv from 'dotenv';
+dotenv.config();
+
+import app from './app.js';
+import { testConnection } from './config/database.js';
+import { getEmailConfig } from './config/email.config.js';
+
+const PORT = process.env.PORT || 3000;
+
+const startServer = async () => {
+  try {
+    // Validar configuración de email
+    getEmailConfig();
+    console.log('✓ Configuración de email validada correctamente');
+  } catch (error) {
+    console.error('✗ Error en configuración de email:', error.message);
+    process.exit(1);
+  }
+
+  await testConnection();
+
+  app.listen(PORT, () => {
+    console.log(`servidor corriendo en http://localhost:${PORT}`);
+  });
+};
+
+startServer();
+</file>
+
+<file path="src/services/.gitkeep">
+
+</file>
+
+<file path="src/services/facebook-oauth.service.js">
+import { getFacebookConfig } from '../config/facebook.config.js';
+
+const isDevelopment = () => process.env.NODE_ENV === 'development';
+
+const getGraphApiBaseUrl = () => {
+  const { graphApiVersion } = getFacebookConfig();
+  return `https://graph.facebook.com/${graphApiVersion}`;
+};
+
+const maskValue = (value = '') => {
+  if (!value) return '';
+  if (value.length <= 8) return '********';
+  return `${value.slice(0, 4)}...${value.slice(-4)}`;
+};
+
+const safeJson = async (response) => {
+  const text = await response.text();
+
+  try {
+    return text ? JSON.parse(text) : {};
+  } catch {
+    return { raw: text };
+  }
+};
+
+const formatFacebookError = (data, fallbackMessage) => {
+  const fbError = data?.error;
+
+  if (!fbError) {
+    return {
+      message: fallbackMessage,
+      raw: data?.raw,
+    };
+  }
+
+  return {
+    message: fbError.message || fallbackMessage,
+    type: fbError.type,
+    code: fbError.code,
+    subcode: fbError.error_subcode,
+    fbtraceId: fbError.fbtrace_id,
+  };
+};
+
+const normalizeFacebookProfile = (profile) => {
+  const fullName = profile.name || '';
+  const [firstName = '', ...lastNameParts] = fullName.trim().split(' ').filter(Boolean);
+
+  return {
+    facebookId: profile.id,
+    email: profile.email,
+    nombre: profile.first_name || firstName || '',
+    apellido: profile.last_name || lastNameParts.join(' ') || '',
+    avatar_url: profile.picture?.data?.url || null,
+  };
+};
+
+export const generateFacebookAuthUrl = () => {
+  try {
+    const config = getFacebookConfig();
+    const params = new URLSearchParams({
+      client_id: config.appId,
+      redirect_uri: config.callbackUrl,
+      scope: 'email,public_profile',
+      response_type: 'code',
+    });
+
+    return {
+      success: true,
+      authUrl: `https://www.facebook.com/${config.graphApiVersion}/dialog/oauth?${params.toString()}`,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error.message,
+    };
+  }
+};
+
+export const exchangeFacebookCodeForToken = async (code) => {
+  try {
+    const config = getFacebookConfig();
+    const endpoint = `${getGraphApiBaseUrl()}/oauth/access_token`;
+    const params = new URLSearchParams({
+      client_id: config.appId,
+      client_secret: config.appSecret,
+      redirect_uri: config.callbackUrl,
+      code,
+    });
+
+    if (isDevelopment()) {
+      console.info('[Facebook OAuth] Intercambiando code por access_token', {
+        endpoint,
+        params: {
+          client_id: config.appId,
+          client_secret: maskValue(config.appSecret),
+          redirect_uri: config.callbackUrl,
+          code: maskValue(code),
+        },
+      });
+    }
+
+    const response = await fetch(`${endpoint}?${params.toString()}`);
+    const data = await safeJson(response);
+
+    if (!response.ok || !data.access_token) {
+      const facebookError = formatFacebookError(
+        data,
+        'No fue posible obtener el access_token de Facebook.'
+      );
+
+      if (isDevelopment()) {
+        console.error('[Facebook OAuth] Error al intercambiar code', {
+          status: response.status,
+          facebookError,
+        });
+      }
+
+      return {
+        success: false,
+        error: facebookError.message,
+        status: response.status,
+        facebookError,
+      };
+    }
+
+    return {
+      success: true,
+      accessToken: data.access_token,
+    };
+  } catch (error) {
+    if (isDevelopment()) {
+      console.error('[Facebook OAuth] Error inesperado al intercambiar code', {
+        message: error.message,
+      });
+    }
+
+    return {
+      success: false,
+      error: error.message,
+    };
+  }
+};
+
+export const getFacebookUserInfo = async (accessToken) => {
+  try {
+    const endpoint = `${getGraphApiBaseUrl()}/me`;
+    const params = new URLSearchParams({
+      fields: 'id,name,first_name,last_name,email,picture',
+      access_token: accessToken,
+    });
+
+    if (isDevelopment()) {
+      console.info('[Facebook OAuth] Consultando perfil de Facebook', {
+        endpoint,
+        params: {
+          fields: 'id,name,first_name,last_name,email,picture',
+          access_token: maskValue(accessToken),
+        },
+      });
+    }
+
+    const response = await fetch(`${endpoint}?${params.toString()}`);
+    const data = await safeJson(response);
+
+    if (!response.ok) {
+      const facebookError = formatFacebookError(
+        data,
+        'No fue posible obtener informacion de Facebook.'
+      );
+
+      if (isDevelopment()) {
+        console.error('[Facebook OAuth] Error al obtener perfil', {
+          status: response.status,
+          facebookError,
+        });
+      }
+
+      return {
+        success: false,
+        error: facebookError.message,
+        status: response.status,
+        facebookError,
+      };
+    }
+
+    const userInfo = normalizeFacebookProfile(data);
+    if (!userInfo.email) {
+      return {
+        success: false,
+        error: 'Facebook no retorno un email para el usuario.',
+      };
+    }
+
+    return {
+      success: true,
+      ...userInfo,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error.message,
+    };
+  }
+};
+</file>
+
+<file path="src/services/google-oauth.service.js">
+import { OAuth2Client } from 'google-auth-library';
+import { getGoogleAuthUrlConfig, getGoogleConfig } from '../config/google.config.js';
+
+let oauthClient = null;
+
+export const getOAuthClient = () => {
+  if (oauthClient) {
+    return oauthClient;
+  }
+
+  const config = getGoogleConfig();
+  
+  oauthClient = new OAuth2Client({
+    clientId: config.clientId,
+    clientSecret: config.clientSecret,
+    redirectUri: config.callbackUrl,
+  });
+
+  return oauthClient;
+};
+
+export const verifyGoogleToken = async (idToken) => {
+  try {
+    const client = getOAuthClient();
+    const ticket = await client.verifyIdToken({
+      idToken,
+      audience: getGoogleConfig().clientId,
+    });
+
+    const payload = ticket.getPayload();
+    
+    return {
+      success: true,
+      googleId: payload.sub,
+      email: payload.email,
+      nombre: payload.given_name || '',
+      apellido: payload.family_name || '',
+      avatar_url: payload.picture || null,
+      email_verified: payload.email_verified || false,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error.message,
+    };
+  }
+};
+
+export const exchangeCodeForTokens = async (code) => {
+  try {
+    const client = getOAuthClient();
+    const { tokens } = await client.getToken(code);
+    
+    return {
+      success: true,
+      tokens,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error.message,
+    };
+  }
+};
+
+export const getGoogleUserInfo = async (accessToken) => {
+  try {
+    const response = await fetch('https://www.googleapis.com/oauth2/v2/userinfo', {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Google API error: ${response.statusText}`);
+    }
+
+    const userInfo = await response.json();
+
+    return {
+      success: true,
+      googleId: userInfo.id,
+      email: userInfo.email,
+      nombre: userInfo.given_name || userInfo.name || '',
+      apellido: userInfo.family_name || '',
+      avatar_url: userInfo.picture || null,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error.message,
+    };
+  }
+};
+
+export const generateAuthUrl = () => {
+  try {
+    const config = getGoogleAuthUrlConfig();
+    const client = new OAuth2Client({
+      clientId: config.clientId,
+      redirectUri: config.callbackUrl,
+    });
+    const scopes = [
+      'openid',
+      'email',
+      'profile',
+    ];
+
+    const authUrl = client.generateAuthUrl({
+      access_type: 'offline',
+      scope: scopes,
+      prompt: 'consent',
+    });
+
+    return {
+      success: true,
+      authUrl,
+      isConfigured: config.isConfigured,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error.message,
+    };
+  }
+};
+</file>
+
+<file path="src/utils/response.js">
+// respuesta exitosa
+export const successResponse = (res, data, message = 'ok', statusCode = 200) => {
+  res.status(statusCode).json({ status: 'success', message, data });
+};
+
+// respuesta de error
+export const errorResponse = (res, message = 'error', statusCode = 400) => {
+  res.status(statusCode).json({ status: 'error', message });
+};
+</file>
+
+<file path="tests/config/email-config.test.js">
+/**
+ * Tests para email.config.js - Configuración centralizada de email
+ * Valida que todas las variables requeridas estén presentes y sean válidas
+ */
+
+import dotenv from 'dotenv';
+dotenv.config({ path: '.env' });
+
+import assert from 'assert';
+import { getEmailConfig } from '../../src/config/email.config.js';
+
+const testResults = [];
+
+const test = (name, fn) => {
+  try {
+    fn();
+    testResults.push({ name, status: '[PASS] PASS', error: null });
+    console.log(`[PASS] ${name}`);
+  } catch (error) {
+    testResults.push({ name, status: '[FAIL] FAIL', error: error.message });
+    console.error(`[FAIL] ${name}`);
+    console.error(`   Error: ${error.message}`);
+  }
+};
+
+console.log('\n[CONFIG] TESTS: Configuración de Email (email.config.js)\n');
+console.log('=' .repeat(60));
+
+// Test 1: Obtener configuración sin errores
+test('Obtener configuración de email', () => {
+  const config = getEmailConfig();
+  assert.ok(config, 'Config debe existir');
+  assert.ok(config.host, 'EMAIL_HOST debe existir');
+  assert.ok(config.port, 'EMAIL_PORT debe existir');
+  assert.ok(config.user, 'EMAIL_USER debe existir');
+  assert.ok(config.pass, 'EMAIL_PASS debe existir');
+  assert.ok(config.from, 'EMAIL_FROM debe existir');
+});
+
+// Test 2: Validar tipos de datos
+test('Validar tipos de datos', () => {
+  const config = getEmailConfig();
+  assert.strictEqual(typeof config.host, 'string', 'host debe ser string');
+  assert.strictEqual(typeof config.port, 'number', 'port debe ser number');
+  assert.strictEqual(typeof config.user, 'string', 'user debe ser string');
+  assert.strictEqual(typeof config.pass, 'string', 'pass debe ser string');
+  assert.strictEqual(typeof config.from, 'string', 'from debe ser string');
+});
+
+// Test 3: Validar puerto en rango válido
+test('Validar rango de puerto SMTP', () => {
+  const config = getEmailConfig();
+  assert.ok(config.port >= 1, 'Puerto debe ser >= 1');
+  assert.ok(config.port <= 65535, 'Puerto debe ser <= 65535');
+  assert.ok([25, 587, 465].includes(config.port), 'Puerto típico SMTP (25, 587, 465)');
+});
+
+// Test 4: Validar formato de EMAIL_FROM
+test('Validar formato de EMAIL_FROM', () => {
+  const config = getEmailConfig();
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  assert.ok(emailRegex.test(config.from), `EMAIL_FROM debe ser válido: ${config.from}`);
+});
+
+// Test 5: Validar hosts conocidos
+test('Host SMTP válido o conocido', () => {
+  const config = getEmailConfig();
+  const knownHosts = ['smtp.mailtrap.io', 'smtp.gmail.com', 'smtp.sendgrid.net', 'localhost'];
+  assert.ok(
+    knownHosts.includes(config.host) || config.host.includes('mail'),
+    `Host debe ser conocido o contener 'mail': ${config.host}`
+  );
+});
+
+// Test 6: No contiene valores de prueba inválidos
+test('No contiene valores de ejemplo sin cambiar', () => {
+  const config = getEmailConfig();
+  const invalidValues = ['your_email@mailtrap.io', 'your_password', 'smtp.example.com'];
+  
+  assert.ok(!invalidValues.includes(config.user), 'EMAIL_USER no debe ser valor de ejemplo');
+  assert.ok(!invalidValues.includes(config.pass), 'EMAIL_PASS no debe ser valor de ejemplo');
+  assert.ok(!invalidValues.includes(config.host), 'EMAIL_HOST no debe ser valor de ejemplo');
+});
+
+// Test 7: Cache de configuración funciona
+test('Cache de configuración (singleton)', () => {
+  const config1 = getEmailConfig();
+  const config2 = getEmailConfig();
+  assert.strictEqual(config1, config2, 'Debe retornar la misma instancia (cache)');
+});
+
+// Test 8: Estructura completa
+test('Estructura de configuración completa', () => {
+  const config = getEmailConfig();
+  const expectedKeys = ['host', 'port', 'user', 'pass', 'from'];
+  const actualKeys = Object.keys(config);
+  
+  expectedKeys.forEach(key => {
+    assert.ok(actualKeys.includes(key), `Config debe tener propiedad: ${key}`);
+  });
+});
+
+// Resumen
+console.log('\n' + '='.repeat(60));
+console.log('\n[SUMMARY] RESUMEN DE TESTS\n');
+
+const total = testResults.length;
+const passed = testResults.filter(r => r.status === '[PASS] PASS').length;
+const failed = testResults.filter(r => r.status === '[FAIL] FAIL').length;
+
+testResults.forEach(r => {
+  console.log(`${r.status} ${r.name}`);
+  if (r.error) {
+    console.log(`   [WARNING] ${r.error}`);
+  }
+});
+
+console.log('\n' + '='.repeat(60));
+console.log(`Total: ${total} | Pasado: ${passed} | Fallido: ${failed}`);
+
+if (failed === 0) {
+  console.log('\n[PASS] TODOS LOS TESTS PASARON\n');
+  process.exit(0);
+} else {
+  console.log(`\n[FAIL] ${failed} TEST(S) FALLARON\n`);
+  process.exit(1);
+}
+</file>
+
+<file path="tests/email/welcome.test.js">
+#!/usr/bin/env node
+
+/**
+ * Test: Welcome Email
+ * USO: node tests/email/welcome.test.js
+ * 
+ * Requiere variables .env configuradas:
+ * - SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS
+ * - FRONTEND_URL (opcional)
+ */
+
+import 'dotenv/config';
+import { enviarCorreoBienvenida } from '../../src/services/email.service.js';
+
+const colors = {
+  reset: '\x1b[0m',
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  blue: '\x1b[34m',
+};
+
+const log = {
+  info: (msg) => console.log(`${colors.blue}${msg}${colors.reset}`),
+  success: (msg) => console.log(`${colors.green}${msg}${colors.reset}`),
+  error: (msg) => console.log(`${colors.red}${msg}${colors.reset}`),
+};
+
+const testWelcomeEmail = async () => {
+  console.log('\n' + colors.blue + '═══════════════════════════════════════' + colors.reset);
+  console.log(colors.blue + '  Testing: Welcome Email' + colors.reset);
+  console.log(colors.blue + '═══════════════════════════════════════\n' + colors.reset);
+
+  const testUser = {
+    email: process.env.TEST_EMAIL || 'test@ejemplo.com',
+    nombre: 'Test',
+    apellido: 'Usuario',
+  };
+
+  log.info(`Sending welcome email to: ${testUser.email}`);
+  log.info(`User: ${testUser.nombre} ${testUser.apellido}\n`);
+
+  try {
+    const result = await enviarCorreoBienvenida(
+      testUser.email,
+      testUser.nombre,
+      testUser.apellido
+    );
+
+    if (result) {
+      log.success('Welcome email sent successfully');
+      log.info('User should receive email within minutes\n');
+      process.exit(0);
+    } else {
+      log.error('Could not send welcome email');
+      log.info('Check console for details\n');
+      process.exit(1);
+    }
+  } catch (error) {
+    log.error(`Error: ${error.message}`);
+    log.info('\nPossible solutions:');
+    log.info('1. Verify SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS in .env');
+    log.info('2. Confirm SMTP service is available');
+    log.info('3. Check credentials (user/password correct)');
+    log.info('4. For development, use https://mailtrap.io (free trial)\n');
+    process.exit(1);
+  }
+};
+
+testWelcomeEmail();
+</file>
+
+<file path="tests/run-all.js">
+#!/usr/bin/env node
+
+/**
+ * Run All Tests
+ * USO: node tests/run-all.js [pattern]
+ * 
+ * Ejemplos:
+ *   node tests/run-all.js         (ejecuta todos)
+ *   node tests/run-all.js email   (solo tests de email)
+ *   node tests/run-all.js auth    (solo tests de auth)
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const pattern = process.argv[2] || '';
+const __filename = fileURLToPath(import.meta.url);
+const testDir = path.dirname(__filename);
+
+const colors = {
+  reset: '\x1b[0m',
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  blue: '\x1b[34m',
+  yellow: '\x1b[33m',
+};
+
+const log = {
+  info: (msg) => console.log(`${colors.blue}${msg}${colors.reset}`),
+  success: (msg) => console.log(`${colors.green}${msg}${colors.reset}`),
+  error: (msg) => console.log(`${colors.red}${msg}${colors.reset}`),
+  warn: (msg) => console.log(`${colors.yellow}${msg}${colors.reset}`),
+};
+
+function findTestFiles(dir, pattern = '') {
+  const files = [];
+  
+  const walkDir = (currentPath) => {
+    const entries = fs.readdirSync(currentPath);
+    
+    for (const entry of entries) {
+      const fullPath = path.join(currentPath, entry);
+      const stat = fs.statSync(fullPath);
+      
+      if (stat.isDirectory() && entry !== 'node_modules') {
+        walkDir(fullPath);
+      } else if (entry.endsWith('.test.js') || entry.endsWith('.spec.js')) {
+        if (!pattern || fullPath.includes(pattern)) {
+          files.push(fullPath);
+        }
+      }
+    }
+  };
+  
+  walkDir(dir);
+  return files;
+}
+
+async function runTest(testFile) {
+  return new Promise((resolve) => {
+    const testName = path.relative(process.cwd(), testFile);
+    
+    log.info(`\n▶ Running: ${testName}`);
+    
+    const proc = spawn('node', [testFile], {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    });
+    
+    proc.on('close', (code) => {
+      if (code === 0) {
+        resolve({ passed: true });
+      } else {
+        resolve({ passed: false });
+      }
+    });
+    
+    proc.on('error', (error) => {
+      log.error(`Error running test: ${error.message}`);
+      resolve({ passed: false });
+    });
+  });
+}
+
+async function main() {
+  console.log(colors.blue + '═══════════════════════════════════════' + colors.reset);
+  console.log(colors.blue + '  Running Test Suite' + colors.reset);
+  console.log(colors.blue + '═══════════════════════════════════════' + colors.reset);
+  
+  if (pattern) {
+    log.info(`Pattern: ${pattern}`);
+  }
+  
+  const testFiles = findTestFiles(testDir, pattern);
+  
+  if (testFiles.length === 0) {
+    log.warn('No test files found');
+    process.exit(1);
+  }
+  
+  log.info(`\nFound ${testFiles.length} test file(s)\n`);
+  
+  let passed = 0;
+  let failed = 0;
+  
+  for (const testFile of testFiles) {
+    const result = await runTest(testFile);
+    if (result.passed) {
+      passed++;
+    } else {
+      failed++;
+    }
+  }
+  
+  console.log(colors.blue + '\n═══════════════════════════════════════' + colors.reset);
+  console.log(colors.blue + '  Summary' + colors.reset);
+  console.log(colors.blue + '═══════════════════════════════════════' + colors.reset);
+  console.log(`Total: ${testFiles.length}`);
+  log.success(`Passed: ${passed}`);
+  log.error(`Failed: ${failed}`);
+  
+  if (failed === 0) {
+    log.success('\nAll tests passed!\n');
+    process.exit(0);
+  } else {
+    log.error('\nSome tests failed\n');
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  log.error(`Critical error: ${error.message}`);
+  process.exit(1);
+});
+</file>
+
+<file path="validate-facebook-credentials.js">
+#!/usr/bin/env node
+
+import 'dotenv/config';
+import { getFacebookConfig } from './src/config/facebook.config.js';
+
+const isPlaceholder = (value) => {
+  if (!value) return true;
+
+  const normalizedValue = value.toLowerCase();
+  return (
+    normalizedValue.includes('your_') ||
+    normalizedValue.includes('tu_') ||
+    normalizedValue.includes('clave_secreta') ||
+    normalizedValue.includes('app_id') ||
+    normalizedValue.includes('app_secret')
+  );
+};
+
+try {
+  const config = getFacebookConfig();
+  const warnings = [];
+
+  if (isPlaceholder(config.appId)) {
+    warnings.push('FACEBOOK_APP_ID parece ser un valor de ejemplo.');
+  }
+
+  if (isPlaceholder(config.appSecret)) {
+    warnings.push('FACEBOOK_APP_SECRET parece ser un valor de ejemplo.');
+  }
+
+  console.log('[OK] FACEBOOK_APP_ID configurado.');
+  console.log('[OK] FACEBOOK_APP_SECRET configurado.');
+  console.log(`[OK] FACEBOOK_CALLBACK_URL: ${config.callbackUrl}`);
+  console.log(`[OK] FACEBOOK_GRAPH_API_VERSION: ${config.graphApiVersion}`);
+
+  if (warnings.length > 0) {
+    console.log('\n[AVISO] Revisa estas advertencias:');
+    warnings.forEach((warning) => console.log(`- ${warning}`));
+    process.exit(1);
+  }
+
+  console.log('\n[SUCCESS] Credenciales de Facebook OAuth cargadas correctamente.');
+} catch (error) {
+  console.error('[ERROR] No se pudo validar Facebook OAuth.');
+  console.error(error.message);
+  process.exit(1);
+}
+</file>
+
+<file path="validate-google-credentials.js">
+#!/usr/bin/env node
+/**
+ * SCRIPT DE VALIDACIÓN: Google OAuth Credentials
+ * 
+ * Valida que:
+ * 1. GOOGLE_CLIENT_ID esté definido en .env
+ * 2. GOOGLE_CLIENT_SECRET esté definido en .env
+ * 3. Los valores tengan formato correcto
+ * 4. El backend puede cargar la configuración
+ */
+
+import dotenv from 'dotenv';
+import { fileURLToPath } from 'url';
+import path from 'path';
+import fs from 'fs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+console.log('\nGoogle OAuth Credentials Validation');
+console.log('=====================================\n');
+
+// Cargar .env
+const envPath = path.join(__dirname, '.env');
+if (!fs.existsSync(envPath)) {
+  console.error('[ERROR] Archivo .env no encontrado');
+  console.error(`   Crea el archivo: ${envPath}`);
+  console.error(`   Basado en: ${envPath}.example\n`);
+  process.exit(1);
+}
+
+dotenv.config({ path: envPath });
+
+// Validar variables
+const clientId = process.env.GOOGLE_CLIENT_ID;
+const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
+const callbackUrl = process.env.GOOGLE_CALLBACK_URL;
+
+const errors = [];
+const warnings = [];
+
+console.log('[VALIDACION] Verificando variables...\n');
+
+// Validar CLIENT_ID
+if (!clientId) {
+  errors.push('GOOGLE_CLIENT_ID no está definido');
+  console.log('[ERROR] GOOGLE_CLIENT_ID: NO CONFIGURADO');
+} else if (!clientId.includes('.apps.googleusercontent.com')) {
+  errors.push('GOOGLE_CLIENT_ID tiene formato incorrecto');
+  console.log(`[ERROR] GOOGLE_CLIENT_ID: Formato incorrecto`);
+  console.log(`   Esperado: xxxxx.apps.googleusercontent.com`);
+  console.log(`   Recibido: ${clientId.substring(0, 30)}...`);
+} else {
+  console.log(`[OK] GOOGLE_CLIENT_ID: ${clientId.substring(0, 30)}...`);
+}
+
+// Validar CLIENT_SECRET
+if (!clientSecret) {
+  errors.push('GOOGLE_CLIENT_SECRET no está definido');
+  console.log('[ERROR] GOOGLE_CLIENT_SECRET: NO CONFIGURADO');
+} else if (!clientSecret.startsWith('GOCSPX-') && clientSecret.length < 20) {
+  warnings.push('GOOGLE_CLIENT_SECRET podría tener formato incorrecto');
+  console.log(`[AVISO] GOOGLE_CLIENT_SECRET: Posible formato incorrecto`);
+  console.log(`   Longitud: ${clientSecret.length} caracteres`);
+  console.log(`   Formato esperado: GOCSPX-xxxxxxxxxxxxxxxxxxxxxxxx`);
+} else {
+  console.log(`[OK] GOOGLE_CLIENT_SECRET: ${clientSecret.substring(0, 20)}...`);
+}
+
+// Validar CALLBACK_URL
+if (!callbackUrl) {
+  warnings.push('GOOGLE_CALLBACK_URL no está definido');
+  console.log('[AVISO] GOOGLE_CALLBACK_URL: NO CONFIGURADO (usará default)');
+} else {
+  console.log(`[OK] GOOGLE_CALLBACK_URL: ${callbackUrl}`);
+}
+
+console.log();
+
+// Intentar cargar configuración
+console.log('[CONFIG] Cargando configuración de backend...\n');
+
+try {
+  const { getGoogleConfig } = await import('./src/config/google.config.js');
+  const config = getGoogleConfig();
+  
+  console.log('[OK] Configuración cargada exitosamente');
+  console.log(`  - Client ID: ${config.clientId.substring(0, 30)}...`);
+  console.log(`  - Client Secret: ${config.clientSecret.substring(0, 20)}...`);
+  console.log(`  - Callback URL: ${config.callbackUrl}`);
+  console.log();
+} catch (error) {
+  errors.push(`No se pudo cargar configuración: ${error.message}`);
+  console.error(`[ERROR] Error: ${error.message}\n`);
+}
+
+// Resumen
+console.log('RESUMEN');
+console.log('═════════════════════════════════════════════════════\n');
+
+if (errors.length === 0 && warnings.length === 0) {
+  console.log('[SUCCESS] TODAS LAS VALIDACIONES PASARON');
+  console.log('\nGoogle OAuth está correctamente configurado.');
+  console.log('   El backend está listo para usar autenticación con Google.\n');
+  process.exit(0);
+} else {
+  if (errors.length > 0) {
+    console.log('[ERROR] ERRORES ENCONTRADOS:\n');
+    errors.forEach((err, i) => console.log(`   ${i + 1}. ${err}`));
+    console.log();
+  }
+  
+  if (warnings.length > 0) {
+    console.log('[AVISO] ADVERTENCIAS:\n');
+    warnings.forEach((warn, i) => console.log(`   ${i + 1}. ${warn}`));
+    console.log();
+  }
+  
+  if (errors.length > 0) {
+    console.log('PRÓXIMOS PASOS:');
+    console.log('   1. Lee: GOOGLE_OAUTH_SETUP.md');
+    console.log('   2. Ve a: https://console.cloud.google.com/');
+    console.log('   3. Sigue todos los pasos para obtener credenciales');
+    console.log('   4. Copia los valores a .env');
+    console.log('   5. Ejecuta este script nuevamente\n');
+    process.exit(1);
+  } else {
+    console.log('SUGERENCIAS:');
+    console.log('   - Verifica que los valores sean correctos\n');
+    process.exit(0);
+  }
+}
+</file>
+
+<file path=".dockerignore">
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+.env
+.git
+.github
+coverage
+dist
+uploads
+tests
+docs
+*.log
+</file>
+
+<file path="Dockerfile">
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+COPY . .
+
+EXPOSE 3000
+
+CMD ["npm", "start"]
+</file>
+
+<file path="docs/README.md">
+# 📚 Documentación - Backend GreenAlert
+
+Índice centralizado de documentación técnica del Backend.
+
+---
+
+## 📁 Estructura
+
+```
+docs/
+├── tests/                       📍 DOCUMENTACIÓN ACTUAL
+│   ├── INDEX.md                 Índice global de tests
+│   ├── EMAIL_CONFIG.md          Tests de configuración (8 tests)
+│   ├── EMAIL_VERIFICATION.md    Verificación de email
+│   ├── EMAIL_WELCOME.md         Email de bienvenida
+│   ├── AUTH_REGISTER.md         Registro de usuarios
+│   ├── MANUAL_EMAIL_CONFIG.md   Pruebas manuales
+│   └── RESUMEN_FINAL.md         Estado actual
+│
+├── archived/                    📦 HISTÓRICO
+│   ├── README.md
+│   ├── CARPETA_TESTS.md
+│   ├── IMPLEMENTACION_CORREOS.md
+│   ├── IMPLEMENTACION_VERIFICACION_EMAIL.md
+│   └── TESTING_VERIFICACION_EMAIL.md
+│
+├── ENDPOINTS_PERFIL.md          Endpoints de perfil de usuario
+├── VERIFICACION_EMAIL.md        Verificación de email (original)
+├── TEST_VERIFICACION_EMAIL.md   Tests manuales (original)
+└── ENVIO_CORREOS.md             Envío de correos (original)
+```
+
+---
+
+## 🎯 Inicio Rápido
+
+### Para Tests
+→ Ver: [tests/INDEX.md](tests/INDEX.md)
+
+**Ejecutar tests:**
+```bash
+node tests/run-all.js config
+```
+
+### Para Configuración de Email
+→ Ver: [tests/EMAIL_CONFIG.md](tests/EMAIL_CONFIG.md)
+
+### Para Endpoints API
+→ Ver: [ENDPOINTS_PERFIL.md](ENDPOINTS_PERFIL.md)
+
+### Para Verificación de Email
+→ Ver: [tests/EMAIL_VERIFICATION.md](tests/EMAIL_VERIFICATION.md)
+
+---
+
+## 📊 Contenido por Categoría
+
+### Mejoras Backend
+- `DOCKER_SERVICIOS.md` - Dockerizacion individual de servicios backend sin Docker Compose.
+
+### 🧪 Tests Automatizados
+- `tests/EMAIL_CONFIG.md` - 8 tests de configuración
+- `tests/EMAIL_VERIFICATION.md` - Tests de verificación
+- `tests/EMAIL_WELCOME.md` - Tests de bienvenida
+- `tests/AUTH_REGISTER.md` - Tests de registro
+
+### 📧 Sistema de Email
+- `tests/EMAIL_CONFIG.md` - Configuración centralizada
+- `tests/MANUAL_EMAIL_CONFIG.md` - Pruebas manuales paso a paso
+- `ENVIO_CORREOS.md` - Envío de correos
+- `VERIFICACION_EMAIL.md` - Verificación de email
+
+### 👤 Usuarios y Autenticación
+- `ENDPOINTS_PERFIL.md` - Endpoints de perfil
+- `tests/AUTH_REGISTER.md` - Registro de usuarios
+
+### 📦 Histórico
+- `archived/` - Documentación anterior (para referencia)
+
+---
+
+## ✅ Estado Actual
+
+| Componente | Tests | Documentación | Status |
+|---|---|---|---|
+| Config Email | 8 ✅ | ✅ | ✅ |
+| Email Verification | 5 | ✅ | ✅ |
+| Email Welcome | 1 | ✅ | ✅ |
+| Auth Register | 3 | ✅ | ✅ |
+| **TOTAL** | **17** | **6 archivos** | ✅ |
+
+---
+
+## 🚀 Próximos Pasos
+
+1. **Tests adicionales:**
+   - Login tests
+   - Password reset tests
+   - Reportes tests
+
+2. **Documentación:**
+   - API OpenAPI/Swagger
+   - Database schema
+   - Architecture diagram
+
+3. **CI/CD:**
+   - GitHub Actions workflow
+   - Automatic test execution
+
+---
+
+**Última actualización:** Abril 17, 2026  
+**Responsable:** Equipo de Backend
+</file>
+
+<file path="docs/regression-parity-208.md">
+# Regression tests y paridad interna
+
+## Estado inicial
+
+Antes de agregar artefactos para esta tarea se ejecuto:
+
+```bash
+npm run test:unit
+```
+
+Resultado: verde, `112/112`.
+
+## Cobertura automatizada
+
+- Rutas publicas sin `/api`: `tests/unit/route-prefix.test.js`.
+- `optionalAuth`: `tests/unit/optional-auth.test.js`.
+- Likes, vistas y trending: `tests/unit/likes-vistas-trending.test.js`.
+- IA y upload multiple: `tests/unit/clasificacion-ia.test.js`, `tests/unit/ia-service.test.js`, `tests/unit/reporte-upload-evidencias.test.js`.
+- Prediccion: `tests/unit/prediccion-service.test.js`.
+- Chatbot: `tests/unit/chatbot-conversacional.test.js`.
+- Notificaciones: `tests/unit/notificacion.controller.test.js`.
+- Contrato de endpoints usados por el frontend: `tests/unit/frontend-api-contract.test.js`.
+
+## Checklist de endpoints frontend
+
+El frontend consume `/api` como base URL. En desarrollo, Vite reescribe `/api` hacia el backend sin prefijo interno; por eso el backend debe responder rutas como `/reportes`, `/auth`, `/chatbot`, etc. cuando `API_PREFIX` esta vacio.
+
+Endpoints principales cubiertos por el contrato:
+
+- `GET /health`
+- `POST /auth/login`
+- `POST /auth/register`
+- `POST /auth/google`
+- `POST /auth/facebook`
+- `GET /categorias`
+- `GET /categorias/:codigo`
+- `GET /reportes`
+- `POST /reportes`
+- `GET /reportes/:id`
+- `PATCH /reportes/:id`
+- `DELETE /reportes/:id`
+- `POST /reportes/:id/like`
+- `GET /reportes/trending`
+- `GET /reportes/stats`
+- `GET /reportes/stats/categoria`
+- `GET /reportes/stats/timeline`
+- `GET /reportes/stats/heatmap`
+- `GET /reportes/stats/ia`
+- `POST /reportes/analizar-imagen`
+- `GET /reportes/export`
+- `GET /reportes/mis-reportes`
+- `GET /reportes/zonas-riesgo`
+- `GET /reportes/alertas-predictivas`
+- `GET /auth/perfil`
+- `PATCH /auth/perfil`
+- `PATCH /auth/avatar`
+- `PATCH /auth/cambiar-contrasena`
+- `PATCH /auth/notificaciones`
+- `POST /auth/forgot-password`
+- `POST /auth/reset-password`
+- `POST /auth/enviar-verificacion`
+- `POST /auth/verificar-email`
+- `GET /admin/usuarios/stats`
+- `GET /admin/usuarios`
+- `GET /admin/usuarios/:id`
+- `PATCH /admin/usuarios/:id/rol`
+- `PATCH /admin/usuarios/:id/estado`
+- `DELETE /admin/usuarios/:id`
+- `POST /chatbot/mensaje`
+- `GET /chatbot/faqs`
+- `GET /notificaciones`
+- `GET /notificaciones/contador`
+- `PATCH /notificaciones/:uuid/leida`
+- `PATCH /notificaciones/marcar-todas`
+- `DELETE /notificaciones/:uuid`
+
+## Diagnostico manual
+
+Para listar el contrato exportado por el frontend:
+
+```bash
+node tests/diagnose-frontend-contract.js
+```
+
+Para diagnosticar rutas contra un servidor levantado, usar `tests/diagnose-routes.js` ajustando `BASE_URL` si hace falta.
+
+## Diferencias intencionales
+
+- El backend no fuerza `/api` internamente por defecto. Esto permite que el proxy de Vite quite `/api` y mantenga compatibilidad local.
+- `API_PREFIX=/api` sigue disponible para despliegues que quieran montar el backend con prefijo real.
+</file>
+
+<file path="middlewares/errorHandler.js">
+// ruta no encontrada 
+export const notFoundHandler = (req, res, next) => {
+  res.status(404).json({
+    status: 'error',
+    message: `ruta no encontrada: ${req.method} ${req.originalUrl}`,
+  });
+};
+
+// manejador global de errores 
+ 
+export const errorHandler = (err, req, res, next) => {
+  console.error('error:', err.message);
+
+  const statusCode = err.statusCode || (err.name === 'MulterError' ? 400 : 500);
+
+  res.status(statusCode).json({
+    status: 'error',
+    message: err.message || 'error interno del servidor',
+    ...(process.env.NODE_ENV === 'development' && { stack: err.stack }),
+  });
+};
+</file>
+
+<file path="middlewares/rateLimit.middleware.js">
+import rateLimit from 'express-rate-limit';
+
+const buildRateLimit = ({ windowMs, max, message }) =>
+  rateLimit({
+    windowMs,
+    max,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: {
+      status: 'error',
+      message,
+    },
+  });
+
+export const authRateLimit = buildRateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: Number(process.env.RATE_LIMIT_AUTH_MAX) || 20,
+  message: 'Demasiadas solicitudes de autenticacion. Intenta nuevamente mas tarde.',
+});
+
+export const loginRateLimit = buildRateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: Number(process.env.RATE_LIMIT_LOGIN_MAX) || 5,
+  message: 'Demasiados intentos de inicio de sesion. Intenta nuevamente mas tarde.',
+});
+
+export const passwordResetRateLimit = buildRateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: Number(process.env.RATE_LIMIT_PASSWORD_RESET_MAX) || 5,
+  message: 'Demasiadas solicitudes de recuperacion de contrasena. Intenta mas tarde.',
+});
+</file>
+
+<file path="middlewares/validate-id.middleware.js">
+export const validatePositiveIdParam = (paramName = 'id') => (req, res, next) => {
+  const rawId = req.params?.[paramName];
+
+  if (typeof rawId !== 'string' || !/^[1-9]\d*$/.test(rawId)) {
+    return res.status(400).json({
+      status: 'error',
+      message: `${paramName} invalido. Debe ser un entero positivo.`,
+    });
+  }
+
+  req.params[paramName] = String(Number(rawId));
+  return next();
+};
+</file>
+
+<file path="migrations/003_add_google_oauth_support.sql">
+-- Migracion: Agregar soporte para Google OAuth
+-- Fecha: 2026-04-26
+-- Descripcion: Agrega columna google_id a usuarios para vincular cuentas de Google.
+
+ALTER TABLE usuarios
+  ADD COLUMN IF NOT EXISTS google_id VARCHAR(255) UNIQUE NULL AFTER uuid;
+
+CREATE INDEX IF NOT EXISTS idx_google_id ON usuarios(google_id);
+</file>
+
+<file path="migrations/005_add_email_verification_token.sql">
+-- Migracion: Agregar token de verificacion de correo
+-- Descripcion: Permite verificar cuentas por enlace seguro enviado por email.
+
+ALTER TABLE usuarios
+ADD COLUMN email_verification_token VARCHAR(64) NULL DEFAULT NULL COMMENT 'Hash SHA-256 del token de verificacion de correo',
+ADD COLUMN email_verification_exp DATETIME NULL DEFAULT NULL COMMENT 'Fecha de expiracion del token de verificacion de correo';
+
+CREATE INDEX idx_email_verification_token ON usuarios(email_verification_token);
+CREATE INDEX idx_email_verification_exp ON usuarios(email_verification_exp);
+</file>
+
+<file path="migrations/006_create_refresh_tokens.sql">
+-- Migracion: Crear tabla de refresh tokens
+-- Descripcion: Almacena refresh tokens hasheados para renovar access tokens e invalidar sesiones.
+
+CREATE TABLE IF NOT EXISTS refresh_tokens (
+  id_refresh_token INT AUTO_INCREMENT PRIMARY KEY,
+  id_usuario BIGINT UNSIGNED NOT NULL,
+  token_hash VARCHAR(64) NOT NULL UNIQUE,
+  expires_at DATETIME NOT NULL,
+  revoked_at DATETIME NULL,
+  user_agent VARCHAR(255) NULL,
+  ip_address VARCHAR(45) NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT fk_refresh_tokens_usuario FOREIGN KEY (id_usuario)
+    REFERENCES usuarios(id_usuario) ON DELETE CASCADE ON UPDATE CASCADE,
+
+  INDEX idx_refresh_token_hash (token_hash),
+  INDEX idx_refresh_usuario (id_usuario),
+  INDEX idx_refresh_expires_at (expires_at),
+  INDEX idx_refresh_revoked_at (revoked_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+</file>
+
+<file path="migrations/007_set_reportes_estado_default_pendiente.sql">
+-- Migracion: alinear estado inicial de reportes con reglas de edicion
+-- Los reportes nuevos deben iniciar como 'pendiente' para que el creador
+-- pueda editarlos antes de que pasen a revision.
+
+ALTER TABLE reportes
+  MODIFY estado ENUM('pendiente', 'en_revision', 'verificado', 'en_proceso', 'rechazado', 'resuelto')
+  DEFAULT 'pendiente';
+</file>
+
+<file path="migrations/008_add_notification_preferences_to_usuarios.sql">
+-- Migracion: Persistir preferencias de notificaciones del usuario
+-- Descripcion: Agrega una columna JSON para guardar preferencias configurables.
+
+ALTER TABLE usuarios
+  ADD COLUMN notification_preferences JSON NULL AFTER telefono;
+</file>
+
+<file path="migrations/012_create_notificaciones.sql">
+-- Migracion: notificaciones in-app por usuario
+CREATE TABLE IF NOT EXISTS notificaciones (
+  id_notificacion BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  uuid VARCHAR(36) UNIQUE NOT NULL,
+  id_usuario BIGINT UNSIGNED NOT NULL,
+  tipo ENUM('reporte_estado', 'reporte_comentario', 'reporte_creado', 'alerta_zona', 'sistema') NOT NULL,
+  titulo VARCHAR(150) NOT NULL,
+  mensaje TEXT NOT NULL,
+  referencia_tipo VARCHAR(30) NULL,
+  referencia_uuid VARCHAR(36) NULL,
+  link VARCHAR(255) NULL,
+  leida BOOLEAN DEFAULT FALSE,
+  leida_at DATETIME NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT fk_notificaciones_usuario
+    FOREIGN KEY (id_usuario)
+    REFERENCES usuarios(id_usuario)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE,
+
+  INDEX idx_notificaciones_usuario_leida (id_usuario, leida, created_at),
+  INDEX idx_notificaciones_uuid (uuid),
+  INDEX idx_notificaciones_referencia (referencia_tipo, referencia_uuid)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+</file>
+
+<file path="routes/admin.routes.js">
+import { Router } from 'express';
+import { verifyToken, requireRoles } from '../middlewares/auth.middleware.js';
+import { validatePositiveIdParam } from '../middlewares/validate-id.middleware.js';
+import {
+  listarUsuarios,
+  statsUsuarios,
+  obtenerUsuario,
+  cambiarRol,
+  cambiarEstado,
+  eliminarUsuario,
+} from '../src/controllers/admin.controller.js';
+
+const adminRouter = Router();
+
+adminRouter.use(verifyToken, requireRoles('admin'));
+
+adminRouter.get('/usuarios/stats', statsUsuarios);
+adminRouter.get('/usuarios', listarUsuarios);
+adminRouter.get('/usuarios/:id', validatePositiveIdParam('id'), obtenerUsuario);
+adminRouter.patch('/usuarios/:id/rol', validatePositiveIdParam('id'), cambiarRol);
+adminRouter.patch('/usuarios/:id/estado', validatePositiveIdParam('id'), cambiarEstado);
+adminRouter.delete('/usuarios/:id', validatePositiveIdParam('id'), eliminarUsuario);
+
+export default adminRouter;
+</file>
+
+<file path="routes/categoria-riesgo.routes.js">
+import { Router } from 'express';
+import { verifyToken, requireRoles } from '../middlewares/auth.middleware.js';
+import {
+  obtenerTodasLasCategorias,
+  obtenerCategoriaPorCodigo,
+  obtenerReportesPorCategoria,
+  obtenerEstadisticasCategorias,
+  obtenerEstadisticasSeveridad,
+  crearCategoria,
+  actualizarCategoria,
+  cambiarEstadoCategoria,
+} from '../src/controllers/categoria-riesgo.controller.js';
+
+/**
+ * Router para gestionar categorías de riesgo ambiental
+ * 
+ * Rutas disponibles:
+ * - GET /api/categorias - Listar todas las categorías
+ * - GET /api/categorias/:codigo - Obtener detalle de una categoría
+ * - GET /api/categorias/:codigo/reportes - Listar reportes de una categoría
+ * - GET /api/categorias/estadisticas/resumen - Estadísticas por categoría
+ * - GET /api/categorias/estadisticas/por-severidad - Estadísticas por severidad
+ */
+
+const categoriaRouter = Router();
+
+// Estadísticas generales (debe ir antes de :codigo para evitar conflictos)
+categoriaRouter.get('/estadisticas/resumen', obtenerEstadisticasCategorias);
+categoriaRouter.get('/estadisticas/por-severidad', obtenerEstadisticasSeveridad);
+
+// Obtener todas las categorías
+categoriaRouter.get('/', obtenerTodasLasCategorias);
+categoriaRouter.post('/', verifyToken, requireRoles('admin'), crearCategoria);
+categoriaRouter.patch('/:codigo', verifyToken, requireRoles('admin'), actualizarCategoria);
+categoriaRouter.patch('/:codigo/estado', verifyToken, requireRoles('admin'), cambiarEstadoCategoria);
+
+// Obtener reportes de una categoría específica
+categoriaRouter.get('/:codigo/reportes', obtenerReportesPorCategoria);
+
+// Obtener detalle de una categoría
+categoriaRouter.get('/:codigo', obtenerCategoriaPorCodigo);
+
+export default categoriaRouter;
+</file>
+
+<file path="routes/notificacion.routes.js">
+import { Router } from 'express';
+import { verifyToken } from '../middlewares/auth.middleware.js';
+import {
+  contadorNotificaciones,
+  eliminarNotificacion,
+  listarNotificaciones,
+  marcarLeida,
+  marcarTodasLeidas,
+} from '../src/controllers/notificacion.controller.js';
+
+const notificacionRouter = Router();
+
+notificacionRouter.use(verifyToken);
+
+notificacionRouter.get('/contador', contadorNotificaciones);
+notificacionRouter.patch('/marcar-todas', marcarTodasLeidas);
+notificacionRouter.get('/', listarNotificaciones);
+notificacionRouter.patch('/:uuid/leida', marcarLeida);
+notificacionRouter.delete('/:uuid', eliminarNotificacion);
+
+export default notificacionRouter;
+</file>
+
+<file path="scripts/sql/00_create_database.sql">
+CREATE DATABASE IF NOT EXISTS `green-alert`
+  DEFAULT CHARACTER SET utf8mb4
+  COLLATE utf8mb4_unicode_ci;
+
+USE `green-alert`;
+</file>
+
+<file path="scripts/sql/verify_schema.sql">
+-- Ejecutar despues de DATABASE_SCHEMA_COMPLETE.sql o de las migraciones.
+-- Devuelve las tablas y columnas criticas esperadas por el backend.
+
+SELECT table_name
+FROM information_schema.tables
+WHERE table_schema = DATABASE()
+  AND table_name IN (
+    'usuarios',
+    'categorias_riesgo',
+    'reportes',
+    'evidencias',
+    'refresh_tokens',
+    'reporte_likes',
+    'reporte_vistas',
+    'notificaciones'
+  )
+ORDER BY table_name;
+
+SELECT table_name, column_name, column_type, is_nullable
+FROM information_schema.columns
+WHERE table_schema = DATABASE()
+  AND (
+    (table_name = 'usuarios' AND column_name IN (
+      'google_id',
+      'facebook_id',
+      'notification_preferences',
+      'avatar_url',
+      'email_verificado',
+      'email_verification_token',
+      'otp_code_hash'
+    ))
+    OR (table_name = 'reportes' AND column_name IN (
+      'subcategoria',
+      'estado',
+      'comentario_moderacion',
+      'ia_etiquetas',
+      'ia_confianza',
+      'ia_procesado'
+    ))
+  )
+ORDER BY table_name, column_name;
+
+SELECT table_name, index_name
+FROM information_schema.statistics
+WHERE table_schema = DATABASE()
+  AND table_name = 'reportes'
+  AND index_name IN (
+    'idx_reportes_estado_created_at',
+    'idx_reportes_tipo_created_at',
+    'idx_reportes_latitud_longitud'
+  )
+ORDER BY table_name, index_name;
+</file>
+
+<file path="src/config/api-prefix.config.js">
+export const normalizeApiPrefix = (prefix) => {
+  if (typeof prefix !== 'string') return '';
+
+  const trimmedPrefix = prefix.trim();
+  if (!trimmedPrefix || trimmedPrefix === '/') return '';
+
+  const withLeadingSlash = trimmedPrefix.startsWith('/') ? trimmedPrefix : `/${trimmedPrefix}`;
+  return withLeadingSlash.replace(/\/+$/, '');
+};
+
+export const getApiPrefix = () => normalizeApiPrefix(process.env.API_PREFIX);
+</file>
+
+<file path="src/config/facebook.config.js">
+/**
+ * FACEBOOK OAUTH CONFIGURATION
+ * Centraliza y valida las variables de entorno para Facebook OAuth.
+ * No debe contener credenciales reales en el codigo.
+ */
+
+const validateFacebookConfig = () => {
+  const config = {
+    appId: process.env.FACEBOOK_APP_ID,
+    appSecret: process.env.FACEBOOK_APP_SECRET,
+    callbackUrl: process.env.FACEBOOK_CALLBACK_URL || 'http://localhost:3000/auth/facebook/callback',
+    graphApiVersion: process.env.FACEBOOK_GRAPH_API_VERSION || 'v20.0',
+  };
+
+  const missingVars = [];
+
+  if (!config.appId) missingVars.push('FACEBOOK_APP_ID');
+  if (!config.appSecret) missingVars.push('FACEBOOK_APP_SECRET');
+
+  if (missingVars.length > 0) {
+    throw new Error(
+      `Variables de entorno para Facebook OAuth no configuradas: ${missingVars.join(', ')}\n` +
+      'Completa estos valores en el archivo .env con las credenciales de Meta for Developers.'
+    );
+  }
+
+  return config;
+};
+
+let facebookConfig = null;
+
+export const getFacebookConfig = () => {
+  if (!facebookConfig) {
+    facebookConfig = validateFacebookConfig();
+  }
+
+  return facebookConfig;
+};
+
+export const isFacebookConfigured = () => (
+  Boolean(process.env.FACEBOOK_APP_ID && process.env.FACEBOOK_APP_SECRET)
+);
+
+export default getFacebookConfig;
+</file>
+
+<file path="src/config/google.config.js">
+/**
+ * GOOGLE OAUTH CONFIGURATION
+ * Centraliza y valida las variables de entorno para Google OAuth 2.0.
+ */
+
+const validateGoogleConfig = () => {
+  const config = {
+    clientId: process.env.GOOGLE_CLIENT_ID,
+    clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+    callbackUrl: process.env.GOOGLE_CALLBACK_URL || 'http://localhost:3000/auth/google/callback',
+  };
+
+  const missingVars = [];
+
+  if (!config.clientId) missingVars.push('GOOGLE_CLIENT_ID');
+  if (!config.clientSecret) missingVars.push('GOOGLE_CLIENT_SECRET');
+
+  if (missingVars.length > 0) {
+    throw new Error(
+      `Variables de entorno para Google OAuth no configuradas: ${missingVars.join(', ')}\n` +
+      `Por favor, completa estos valores en el archivo .env\n` +
+      `Referencia: ../GOOGLE_OAUTH_SETUP.md\n` +
+      `\nPasos:\n` +
+      `1. Ve a Google Cloud Console (console.cloud.google.com)\n` +
+      `2. Crea un proyecto nuevo\n` +
+      `3. Habilita Google+ API\n` +
+      `4. Crea credenciales OAuth 2.0\n` +
+      `5. Copia CLIENT_ID y CLIENT_SECRET a .env`
+    );
+  }
+
+  return config;
+};
+
+export const getGoogleAuthUrlConfig = () => ({
+  clientId: process.env.GOOGLE_CLIENT_ID || 'your_client_id_here.apps.googleusercontent.com',
+  callbackUrl: process.env.GOOGLE_CALLBACK_URL || 'http://localhost:3000/auth/google/callback',
+  isConfigured: Boolean(process.env.GOOGLE_CLIENT_ID),
+});
+
+let googleConfig = null;
+
+export const getGoogleConfig = () => {
+  if (!googleConfig) {
+    googleConfig = validateGoogleConfig();
+  }
+
+  return googleConfig;
+};
+
+if (process.env.NODE_ENV === 'development') {
+  try {
+    getGoogleConfig();
+    console.log('[OK] Google OAuth configuration loaded successfully');
+  } catch (error) {
+    console.warn('[AVISO] Google OAuth not yet configured:', error.message);
+  }
+}
+
+export default getGoogleConfig;
+</file>
+
+<file path="src/config/schema-compat.js">
+import pool from './database.js';
+
+const columnCache = new Map();
+const tableCache = new Map();
+
+const getDatabaseName = () => process.env.DB_NAME;
+
+export const tableExists = async (tableName) => {
+  const databaseName = getDatabaseName();
+  const cacheKey = `${databaseName}.${tableName}`;
+
+  if (tableCache.has(cacheKey)) {
+    return tableCache.get(cacheKey);
+  }
+
+  const [[row]] = await pool.execute(
+    `SELECT COUNT(*) AS total
+     FROM INFORMATION_SCHEMA.TABLES
+     WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?`,
+    [databaseName, tableName]
+  );
+
+  const exists = Number(row?.total) > 0;
+  tableCache.set(cacheKey, exists);
+  return exists;
+};
+
+export const columnExists = async (tableName, columnName) => {
+  const databaseName = getDatabaseName();
+  const cacheKey = `${databaseName}.${tableName}.${columnName}`;
+
+  if (columnCache.has(cacheKey)) {
+    return columnCache.get(cacheKey);
+  }
+
+  const [[row]] = await pool.execute(
+    `SELECT COUNT(*) AS total
+     FROM INFORMATION_SCHEMA.COLUMNS
+     WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? AND COLUMN_NAME = ?`,
+    [databaseName, tableName, columnName]
+  );
+
+  const exists = Number(row?.total) > 0;
+  columnCache.set(cacheKey, exists);
+  return exists;
+};
+
+export const clearSchemaCompatCache = () => {
+  columnCache.clear();
+  tableCache.clear();
+};
+</file>
+
+<file path="src/config/security.config.js">
+const DEFAULT_CORS_ORIGIN = 'http://localhost:5173';
+
+export const getAllowedCorsOrigins = () => {
+  const rawOrigins = process.env.CORS_ORIGIN || DEFAULT_CORS_ORIGIN;
+
+  return rawOrigins
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+};
+
+export const getCorsOptions = () => {
+  const allowedOrigins = getAllowedCorsOrigins();
+
+  return {
+    origin(origin, callback) {
+      if (!origin || allowedOrigins.includes(origin)) {
+        return callback(null, true);
+      }
+
+      return callback(null, false);
+    },
+    credentials: true,
+    methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+    allowedHeaders: ['Content-Type', 'Authorization'],
+    optionsSuccessStatus: 204,
+  };
+};
+
+export const getHelmetOptions = () => ({
+  crossOriginResourcePolicy: { policy: 'cross-origin' },
+});
+</file>
+
+<file path="src/config/upload.config.js">
+import path from 'path';
+
+const DEFAULT_UPLOAD_DIR = './uploads';
+const DEFAULT_MAX_FILE_SIZE = 10 * 1024 * 1024;
+
+export const getUploadDir = () => {
+  const uploadDir = process.env.UPLOAD_DIR || DEFAULT_UPLOAD_DIR;
+
+  return path.resolve(process.cwd(), uploadDir);
+};
+
+export const getMaxFileSize = () => {
+  const value = Number(process.env.MAX_FILE_SIZE);
+
+  return Number.isFinite(value) && value > 0
+    ? value
+    : DEFAULT_MAX_FILE_SIZE;
+};
+</file>
+
+<file path="src/controllers/notificacion.controller.js">
+import { NotificacionModel } from '../models/notificacion.model.js';
+import { errorResponse, successResponse } from '../utils/response.js';
+
+export const crearNotificacion = async (payload) => {
+  try {
+    return await NotificacionModel.create(payload);
+  } catch (error) {
+    console.error('[notificaciones] error al crear:', error.message);
+    return null;
+  }
+};
+
+export const listarNotificaciones = async (req, res, next) => {
+  try {
+    const idUsuario = req.user?.sub;
+    if (!idUsuario) return errorResponse(res, 'No autorizado.', 401);
+
+    const filtroLeida = req.query?.leida === 'true'
+      ? true
+      : req.query?.leida === 'false'
+        ? false
+        : undefined;
+
+    const data = await NotificacionModel.findByUsuario(idUsuario, {
+      leida: filtroLeida,
+      limit: req.query?.limit,
+      offset: req.query?.offset,
+    });
+
+    res.setHeader('Cache-Control', 'no-store');
+    return successResponse(res, data, 'Notificaciones obtenidas.');
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const contadorNotificaciones = async (req, res, next) => {
+  try {
+    const idUsuario = req.user?.sub;
+    if (!idUsuario) return errorResponse(res, 'No autorizado.', 401);
+
+    const no_leidas = await NotificacionModel.contarNoLeidas(idUsuario);
+
+    res.setHeader('Cache-Control', 'no-store');
+    return successResponse(res, { no_leidas }, 'ok');
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const marcarLeida = async (req, res, next) => {
+  try {
+    const idUsuario = req.user?.sub;
+    if (!idUsuario) return errorResponse(res, 'No autorizado.', 401);
+
+    const { uuid } = req.params;
+    if (!uuid) return errorResponse(res, 'UUID requerido.', 400);
+
+    const ok = await NotificacionModel.marcarLeida(uuid, idUsuario);
+    if (!ok) return errorResponse(res, 'Notificacion no encontrada.', 404);
+
+    return successResponse(res, { uuid }, 'Notificacion marcada como leida.');
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const marcarTodasLeidas = async (req, res, next) => {
+  try {
+    const idUsuario = req.user?.sub;
+    if (!idUsuario) return errorResponse(res, 'No autorizado.', 401);
+
+    const actualizadas = await NotificacionModel.marcarTodasLeidas(idUsuario);
+
+    return successResponse(
+      res,
+      { actualizadas },
+      'Notificaciones marcadas como leidas.'
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const eliminarNotificacion = async (req, res, next) => {
+  try {
+    const idUsuario = req.user?.sub;
+    if (!idUsuario) return errorResponse(res, 'No autorizado.', 401);
+
+    const { uuid } = req.params;
+    if (!uuid) return errorResponse(res, 'UUID requerido.', 400);
+
+    const ok = await NotificacionModel.eliminar(uuid, idUsuario);
+    if (!ok) return errorResponse(res, 'Notificacion no encontrada.', 404);
+
+    return successResponse(res, { uuid }, 'Notificacion eliminada.');
+  } catch (error) {
+    return next(error);
+  }
+};
+</file>
+
+<file path="src/controllers/prediccion.controller.js">
+import {
+  calcularAlertasPredictivas,
+  calcularZonasRiesgo,
+  parseAlertasParams,
+  parseZonasParams,
+} from '../services/prediccion.service.js';
+import { successResponse } from '../utils/response.js';
+
+export const getZonasRiesgo = async (req, res, next) => {
+  try {
+    const payload = await calcularZonasRiesgo(parseZonasParams(req.query));
+    return successResponse(res, payload, 'Zonas de riesgo obtenidas correctamente.');
+  } catch (error) {
+    return next(error);
+  }
+};
+
+// Publico para que el frontend pueda mostrar alertas preventivas sin sesion.
+// No expone autores, usuarios ni IDs personales; solo agregados por zona.
+export const getAlertasPredictivas = async (req, res, next) => {
+  try {
+    const payload = await calcularAlertasPredictivas(parseAlertasParams(req.query));
+    return successResponse(res, payload, 'Alertas predictivas obtenidas correctamente.');
+  } catch (error) {
+    return next(error);
+  }
+};
+</file>
+
+<file path="src/models/like.model.js">
+import pool from '../config/database.js';
+import { tableExists } from '../config/schema-compat.js';
+
+export const LikeModel = {
+  toggle: async (id_reporte, id_usuario) => {
+    if (!await tableExists('reporte_likes')) {
+      return { liked: false, votos_relevancia: 0 };
+    }
+
+    const connection = await pool.getConnection();
+    try {
+      await connection.beginTransaction();
+
+      const [existingRows] = await connection.execute(
+        `SELECT id_like
+         FROM reporte_likes
+         WHERE id_reporte = ? AND id_usuario = ?
+         LIMIT 1
+         FOR UPDATE`,
+        [id_reporte, id_usuario]
+      );
+
+      const liked = existingRows.length === 0;
+      if (liked) {
+        await connection.execute(
+          `INSERT INTO reporte_likes (id_reporte, id_usuario)
+           VALUES (?, ?)`,
+          [id_reporte, id_usuario]
+        );
+        await connection.execute(
+          `UPDATE reportes
+           SET votos_relevancia = votos_relevancia + 1
+           WHERE id_reporte = ? AND deleted_at IS NULL`,
+          [id_reporte]
+        );
+      } else {
+        await connection.execute(
+          `DELETE FROM reporte_likes
+           WHERE id_reporte = ? AND id_usuario = ?`,
+          [id_reporte, id_usuario]
+        );
+        await connection.execute(
+          `UPDATE reportes
+           SET votos_relevancia = GREATEST(votos_relevancia - 1, 0)
+           WHERE id_reporte = ? AND deleted_at IS NULL`,
+          [id_reporte]
+        );
+      }
+
+      const [[row]] = await connection.execute(
+        `SELECT votos_relevancia
+         FROM reportes
+         WHERE id_reporte = ?`,
+        [id_reporte]
+      );
+
+      await connection.commit();
+      return {
+        liked,
+        votos_relevancia: Number(row?.votos_relevancia) || 0,
+      };
+    } catch (error) {
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  },
+
+  hasLiked: async (id_reporte, id_usuario) => {
+    if (!id_usuario || !await tableExists('reporte_likes')) {
+      return false;
+    }
+
+    const [rows] = await pool.execute(
+      `SELECT id_like
+       FROM reporte_likes
+       WHERE id_reporte = ? AND id_usuario = ?
+       LIMIT 1`,
+      [id_reporte, id_usuario]
+    );
+
+    return rows.length > 0;
+  },
+
+  likedSet: async (id_reportes = [], id_usuario) => {
+    const ids = [...new Set(id_reportes.map(Number).filter(Number.isFinite))];
+
+    if (!id_usuario || ids.length === 0 || !await tableExists('reporte_likes')) {
+      return new Set();
+    }
+
+    const placeholders = ids.map(() => '?').join(', ');
+    const [rows] = await pool.execute(
+      `SELECT id_reporte
+       FROM reporte_likes
+       WHERE id_usuario = ? AND id_reporte IN (${placeholders})`,
+      [id_usuario, ...ids]
+    );
+
+    return new Set(rows.map((row) => Number(row.id_reporte)));
+  },
+};
+</file>
+
+<file path="src/models/notificacion.model.js">
+import { randomUUID } from 'crypto';
+import pool from '../config/database.js';
+
+export const NotificacionModel = {
+  create: async ({
+    id_usuario,
+    tipo,
+    titulo,
+    mensaje,
+    referencia_tipo = null,
+    referencia_uuid = null,
+    link = null,
+  }) => {
+    const uuid = randomUUID();
+    const [result] = await pool.execute(
+      `INSERT INTO notificaciones
+         (uuid, id_usuario, tipo, titulo, mensaje, referencia_tipo, referencia_uuid, link)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        uuid,
+        id_usuario,
+        tipo,
+        titulo,
+        mensaje,
+        referencia_tipo,
+        referencia_uuid,
+        link,
+      ]
+    );
+
+    return { id_notificacion: result.insertId, uuid };
+  },
+
+  findByUsuario: async (id_usuario, { leida, limit = 20, offset = 0 } = {}) => {
+    const where = ['id_usuario = ?'];
+    const params = [id_usuario];
+
+    if (leida === true || leida === false) {
+      where.push('leida = ?');
+      params.push(leida ? 1 : 0);
+    }
+
+    const safeLimit = Math.max(1, Math.min(100, parseInt(limit, 10) || 20));
+    const safeOffset = Math.max(0, parseInt(offset, 10) || 0);
+
+    const [rows] = await pool.execute(
+      `SELECT id_notificacion, uuid, tipo, titulo, mensaje,
+              referencia_tipo, referencia_uuid, link,
+              leida, leida_at, created_at
+       FROM notificaciones
+       WHERE ${where.join(' AND ')}
+       ORDER BY created_at DESC
+       LIMIT ${safeLimit} OFFSET ${safeOffset}`,
+      params
+    );
+
+    const [[meta]] = await pool.execute(
+      `SELECT
+         COUNT(*) AS total,
+         SUM(CASE WHEN leida = 0 THEN 1 ELSE 0 END) AS no_leidas
+       FROM notificaciones
+       WHERE id_usuario = ?`,
+      [id_usuario]
+    );
+
+    return {
+      items: rows.map((row) => ({
+        ...row,
+        leida: Boolean(row.leida),
+      })),
+      meta: {
+        total: Number(meta?.total) || 0,
+        no_leidas: Number(meta?.no_leidas) || 0,
+        limit: safeLimit,
+        offset: safeOffset,
+      },
+    };
+  },
+
+  contarNoLeidas: async (id_usuario) => {
+    const [[row]] = await pool.execute(
+      `SELECT COUNT(*) AS total
+       FROM notificaciones
+       WHERE id_usuario = ? AND leida = 0`,
+      [id_usuario]
+    );
+
+    return Number(row?.total) || 0;
+  },
+
+  marcarLeida: async (uuid, id_usuario) => {
+    const [result] = await pool.execute(
+      `UPDATE notificaciones
+       SET leida = 1, leida_at = COALESCE(leida_at, NOW())
+       WHERE uuid = ? AND id_usuario = ? AND leida = 0`,
+      [uuid, id_usuario]
+    );
+
+    if (result.affectedRows > 0) {
+      return true;
+    }
+
+    const [rows] = await pool.execute(
+      `SELECT 1
+       FROM notificaciones
+       WHERE uuid = ? AND id_usuario = ?
+       LIMIT 1`,
+      [uuid, id_usuario]
+    );
+
+    return rows.length > 0;
+  },
+
+  marcarTodasLeidas: async (id_usuario) => {
+    const [result] = await pool.execute(
+      `UPDATE notificaciones
+       SET leida = 1, leida_at = COALESCE(leida_at, NOW())
+       WHERE id_usuario = ? AND leida = 0`,
+      [id_usuario]
+    );
+
+    return result.affectedRows;
+  },
+
+  eliminar: async (uuid, id_usuario) => {
+    const [result] = await pool.execute(
+      `DELETE FROM notificaciones
+       WHERE uuid = ? AND id_usuario = ?`,
+      [uuid, id_usuario]
+    );
+
+    return result.affectedRows > 0;
+  },
+};
+
+export default NotificacionModel;
+</file>
+
+<file path="src/services/chatbot-offline.js">
+export const FAQ_GROUPS = [
+  {
+    titulo: 'Reportes',
+    items: [
+      { pregunta: 'Como crear un reporte ambiental?', prompt: 'Como creo un reporte ambiental?' },
+      { pregunta: 'Que evidencia puedo adjuntar?', prompt: 'Que evidencia puedo adjuntar a un reporte?' },
+      { pregunta: 'Como reviso el estado de mi reporte?', prompt: 'Como reviso el estado de mi reporte?' },
+    ],
+  },
+  {
+    titulo: 'Alertas',
+    items: [
+      { pregunta: 'Que son las zonas de riesgo?', prompt: 'Que son las zonas de riesgo predictivas?' },
+      { pregunta: 'Como activar alertas en mi zona?', prompt: 'Como activo alertas en mi zona?' },
+    ],
+  },
+  {
+    titulo: 'Cuenta',
+    items: [
+      { pregunta: 'Como verifico mi correo?', prompt: 'Como verifico mi correo electronico?' },
+      { pregunta: 'Como recupero mi contrasena?', prompt: 'Como recupero mi contrasena?' },
+    ],
+  },
+];
+
+const normalizeText = (value) => (
+  String(value || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+);
+
+export const detectIntent = (mensaje) => {
+  const text = normalizeText(mensaje);
+
+  if (/mis reportes|mis denuncias|cuantos reportes|estado de mi|seguimiento/.test(text)) {
+    return 'mis_reportes';
+  }
+  if (/reporte|denuncia|evidencia|foto|crear|enviar|adjuntar/.test(text)) return 'reportes';
+  if (/alerta|riesgo|zona|mapa|predic|cerca|ubicacion/.test(text)) return 'alertas';
+  if (/correo|verific|otp|codigo/.test(text)) return 'verificacion';
+  if (/contrase|password|recuper/.test(text)) return 'recuperacion';
+  if (/estado|moderacion|revision/.test(text)) return 'seguimiento';
+  return 'fallback';
+};
+
+export const buildSuggestions = (intent) => {
+  if (intent === 'reportes') {
+    return ['Que evidencia puedo adjuntar?', 'Como edito un reporte?', 'Como veo mis reportes?'];
+  }
+
+  if (intent === 'alertas') {
+    return ['Como activar alertas en mi zona?', 'Que significa riesgo critico?', 'Como se calcula el mapa?'];
+  }
+
+  if (intent === 'mis_reportes') {
+    return ['Como reviso el estado?', 'Puedo editar un reporte?', 'Como agrego evidencias?'];
+  }
+
+  return [
+    'Como crear un reporte ambiental?',
+    'Como verifico mi correo?',
+    'Que son las zonas de riesgo?',
+  ];
+};
+
+export const buildCards = (contexto = {}) => (
+  (contexto.alertasZona || []).slice(0, 3).map((alerta) => ({
+    titulo: `${alerta.tipo_dominante || 'Zona'} - riesgo ${alerta.nivel}`,
+    descripcion: `${alerta.n_reportes || 0} reporte(s), score ${alerta.score || 0}`,
+    tipo: 'alerta',
+    data: alerta,
+  }))
+);
+
+export const buildOfflineResponse = ({ mensaje, contexto = {} }) => {
+  const intent = detectIntent(mensaje);
+  const stats = contexto.global || {};
+  const usuario = contexto.usuario || null;
+  const totalReportes = Number(stats.total_reportes) || 0;
+  const municipios = Number(stats.municipios_activos) || 0;
+  const reportesUsuario = usuario?.total_reportes ?? usuario?.reportes?.length ?? 0;
+
+  const responses = {
+    reportes: 'Para crear un reporte entra a Nuevo reporte, selecciona categoria y severidad, describe el problema, agrega ubicacion y adjunta evidencias si las tienes.',
+    alertas: `Las zonas de riesgo se calculan con reportes recientes, severidad y concentracion geografica. Hay ${totalReportes} reportes registrados en ${municipios} municipio(s) activo(s).`,
+    verificacion: 'Despues del registro enviamos un codigo de 6 digitos al correo. Puedes ingresarlo en la pantalla de verificacion o solicitar uno nuevo cuando termine el contador.',
+    recuperacion: 'Para recuperar tu contrasena usa Olvidaste tu contrasena, escribe tu correo y abre el enlace recibido. El enlace expira por seguridad.',
+    seguimiento: 'Puedes revisar el estado en Mis reportes. Los moderadores pueden cambiar un reporte entre pendiente, en revision, verificado, en proceso, resuelto o rechazado.',
+    mis_reportes: usuario
+      ? `Tienes ${reportesUsuario} reporte(s) registrados. Revisa Mis reportes para ver estado, evidencias y comentarios de moderacion.`
+      : 'Para consultar tus reportes necesito que inicies sesion. Sin sesion puedo ayudarte con reportes, alertas y verificacion.',
+    fallback: 'Puedo ayudarte con reportes ambientales, verificacion de correo, recuperacion de contrasena, alertas de riesgo y seguimiento de reportes.',
+  };
+
+  const cards = buildCards(contexto);
+
+  return {
+    respuesta: responses[intent] || responses.fallback,
+    intent,
+    fuente: 'offline',
+    sugerencias: buildSuggestions(intent),
+    cards,
+    estadoAmbiental: cards.some((card) => ['critico', 'alto'].includes(card.data?.nivel))
+      ? 'alerta'
+      : 'optimo',
+  };
+};
+</file>
+
+<file path="src/services/chatbot.service.js">
+import { buildOfflineResponse } from './chatbot-offline.js';
+import { construirContextoChatbot } from './chatbot-context.js';
+
+const CACHE_TTL_MS = 30 * 1000;
+const cache = new Map();
+
+const getCacheKey = ({ mensaje, sessionId, user, lat, lng }) => JSON.stringify({
+  mensaje: String(mensaje || '').trim().toLowerCase(),
+  sessionId: sessionId || null,
+  userId: user?.sub || null,
+  lat: lat || null,
+  lng: lng || null,
+});
+
+const getCached = (key) => {
+  const entry = cache.get(key);
+  if (!entry || entry.expiresAt <= Date.now()) {
+    cache.delete(key);
+    return null;
+  }
+
+  return entry.value;
+};
+
+const setCached = (key, value) => {
+  cache.set(key, {
+    value,
+    expiresAt: Date.now() + CACHE_TTL_MS,
+  });
+  return value;
+};
+
+export const clearChatbotCache = () => {
+  cache.clear();
+};
+
+export const getChatbotCacheSize = () => cache.size;
+
+const fetchJson = async (url, options) => {
+  const response = await fetch(url, {
+    ...options,
+    signal: AbortSignal.timeout(4000),
+  });
+
+  if (!response.ok) return null;
+  return response.json();
+};
+
+const tryGroq = async ({ mensaje, contexto }) => {
+  if (!process.env.GROQ_API_KEY) return null;
+
+  const json = await fetchJson('https://api.groq.com/openai/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.GROQ_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: process.env.GROQ_MODEL || 'llama-3.1-8b-instant',
+      messages: [
+        { role: 'system', content: 'Responde como asistente ambiental de Green Alert. Mantén formato breve y accionable.' },
+        { role: 'user', content: JSON.stringify({ mensaje, contexto }) },
+      ],
+      temperature: 0.2,
+    }),
+  }).catch(() => null);
+
+  const respuesta = json?.choices?.[0]?.message?.content?.trim();
+  return respuesta ? { respuesta, fuente: 'groq' } : null;
+};
+
+const tryGemini = async ({ mensaje, contexto }) => {
+  if (!process.env.GEMINI_API_KEY) return null;
+
+  const model = process.env.GEMINI_MODEL || 'gemini-1.5-flash';
+  const json = await fetchJson(
+    `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${process.env.GEMINI_API_KEY}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contents: [{
+          parts: [{ text: JSON.stringify({ mensaje, contexto }) }],
+        }],
+      }),
+    }
+  ).catch(() => null);
+
+  const respuesta = json?.candidates?.[0]?.content?.parts?.[0]?.text?.trim();
+  return respuesta ? { respuesta, fuente: 'gemini' } : null;
+};
+
+export const generarRespuestaChatbot = async ({ mensaje, sessionId, user, lat, lng }) => {
+  const key = getCacheKey({ mensaje, sessionId, user, lat, lng });
+  const cached = getCached(key);
+  if (cached) {
+    return {
+      ...cached,
+      cache: true,
+    };
+  }
+
+  const contexto = await construirContextoChatbot({ user, lat, lng });
+  const offline = buildOfflineResponse({ mensaje, contexto });
+  const external = await tryGroq({ mensaje, contexto })
+    || await tryGemini({ mensaje, contexto });
+
+  const result = {
+    ...offline,
+    ...(external ? { respuesta: external.respuesta, fuente: external.fuente } : {}),
+    cache: false,
+  };
+
+  return setCached(key, result);
+};
+</file>
+
+<file path="src/services/clasificacion.service.js">
+import { CATEGORIAS_FALLBACK } from '../models/categoria-riesgo.model.js';
+
+const CATEGORY_HINTS = [
+  {
+    categoria: 'agua',
+    subcategoria: 'vertimiento',
+    severidad: 'alto',
+    keywords: ['agua', 'rio', 'quebrada', 'inundacion', 'vertimiento', 'alcantarilla'],
+  },
+  {
+    categoria: 'aire',
+    subcategoria: 'humo',
+    severidad: 'medio',
+    keywords: ['aire', 'humo', 'quema', 'gases', 'polvo'],
+  },
+  {
+    categoria: 'residuos',
+    subcategoria: 'basuras',
+    severidad: 'medio',
+    keywords: ['basura', 'residuo', 'escombro', 'desecho', 'lixiviado'],
+  },
+  {
+    categoria: 'deforestacion',
+    subcategoria: 'tala',
+    severidad: 'alto',
+    keywords: ['arbol', 'bosque', 'tala', 'deforestacion', 'vegetacion'],
+  },
+  {
+    categoria: 'otro',
+    subcategoria: null,
+    severidad: 'medio',
+    keywords: [],
+  },
+];
+
+const normalizeText = (value) => (
+  typeof value === 'string'
+    ? value.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase()
+    : ''
+);
+
+const getCategoriaNombre = (codigo) => (
+  CATEGORIAS_FALLBACK.find((categoria) => categoria.codigo === codigo)?.nombre || 'Otro'
+);
+
+export const clasificarImagen = async ({ originalname = '', mimetype = '' } = {}) => {
+  const text = normalizeText(`${originalname} ${mimetype}`);
+  const match = CATEGORY_HINTS.find((hint) => (
+    hint.keywords.some((keyword) => text.includes(keyword))
+  )) || CATEGORY_HINTS[CATEGORY_HINTS.length - 1];
+  const matchedKeywords = match.keywords.filter((keyword) => text.includes(keyword));
+  const confidence = Math.min(0.95, 0.55 + (matchedKeywords.length * 0.12));
+  const etiquetas = [
+    match.categoria,
+    ...(match.subcategoria ? [match.subcategoria] : []),
+    ...matchedKeywords,
+  ];
+
+  return {
+    categoria: match.categoria,
+    nombre: getCategoriaNombre(match.categoria),
+    confianza: Number(confidence.toFixed(2)),
+    subcategoria: match.subcategoria,
+    confianza_subcategoria: match.subcategoria ? Number(Math.max(0.45, confidence - 0.08).toFixed(2)) : 0,
+    severidad: match.severidad,
+    confianza_severidad: Number(Math.max(0.5, confidence - 0.1).toFixed(2)),
+    etiquetas: [...new Set(etiquetas)].slice(0, 8),
+  };
+};
+</file>
+
+<file path="src/services/ia.service.js">
+const KEYWORD_TAGS = [
+  {
+    tag: 'agua',
+    keywords: ['agua', 'rio', 'quebrada', 'inundacion', 'vertimiento', 'alcantarilla'],
+  },
+  {
+    tag: 'aire',
+    keywords: ['aire', 'humo', 'quema', 'olor', 'gases', 'polvo'],
+  },
+  {
+    tag: 'residuos',
+    keywords: ['basura', 'residuos', 'escombros', 'desechos', 'lixiviado'],
+  },
+  {
+    tag: 'vegetacion',
+    keywords: ['arbol', 'bosque', 'tala', 'deforestacion', 'vegetacion'],
+  },
+  {
+    tag: 'fauna',
+    keywords: ['animal', 'fauna', 'peces', 'aves', 'muerte animal'],
+  },
+  {
+    tag: 'riesgo_salud',
+    keywords: ['enfermedad', 'salud', 'toxico', 'contaminado', 'plaga'],
+  },
+];
+
+const SEVERITY_WEIGHT = {
+  bajo: 0.15,
+  medio: 0.25,
+  alto: 0.35,
+  critico: 0.45,
+};
+
+const normalizeText = (value) => (
+  typeof value === 'string'
+    ? value.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase()
+    : ''
+);
+
+const clampConfidence = (value) => Math.max(0.1, Math.min(0.99, value));
+
+export const analyzeReporte = (reporte) => {
+  const text = normalizeText([
+    reporte?.tipo_contaminacion,
+    reporte?.nivel_severidad,
+    reporte?.titulo,
+    reporte?.descripcion,
+    reporte?.direccion,
+    reporte?.municipio,
+    reporte?.departamento,
+  ].filter(Boolean).join(' '));
+
+  const tags = new Set();
+  const matchedKeywords = [];
+
+  for (const group of KEYWORD_TAGS) {
+    const matches = group.keywords.filter((keyword) => text.includes(keyword));
+    if (matches.length > 0) {
+      tags.add(group.tag);
+      matchedKeywords.push(...matches);
+    }
+  }
+
+  if (reporte?.tipo_contaminacion) {
+    tags.add(normalizeText(reporte.tipo_contaminacion).replace(/\s+/g, '_'));
+  }
+
+  if (reporte?.nivel_severidad) {
+    tags.add(`severidad_${normalizeText(reporte.nivel_severidad)}`);
+  }
+
+  const hasLocation = reporte?.latitud !== null && reporte?.latitud !== undefined &&
+    reporte?.longitud !== null && reporte?.longitud !== undefined;
+  const confidence = clampConfidence(
+    0.35 +
+    (matchedKeywords.length * 0.08) +
+    (SEVERITY_WEIGHT[normalizeText(reporte?.nivel_severidad)] || 0) +
+    (hasLocation ? 0.1 : 0)
+  );
+
+  return {
+    etiquetas: Array.from(tags).slice(0, 8),
+    confianza: Number(confidence.toFixed(2)),
+    procesado: true,
+    resumen: {
+      matchedKeywords: Array.from(new Set(matchedKeywords)).slice(0, 12),
+      hasLocation,
+    },
+  };
+};
+</file>
+
+<file path="src/services/oauth-callback-code.service.js">
+import crypto from 'crypto';
+
+const DEFAULT_TTL_MS = 2 * 60 * 1000;
+const callbackCodes = new Map();
+
+const getTtlMs = () => {
+  const value = Number(process.env.OAUTH_CALLBACK_CODE_TTL_SECONDS);
+  return Number.isFinite(value) && value > 0 ? value * 1000 : DEFAULT_TTL_MS;
+};
+
+const deleteExpiredCodes = () => {
+  const now = Date.now();
+
+  for (const [code, entry] of callbackCodes.entries()) {
+    if (entry.expiresAt <= now) {
+      callbackCodes.delete(code);
+    }
+  }
+};
+
+export const createOAuthCallbackCode = (payload) => {
+  deleteExpiredCodes();
+
+  const code = crypto.randomBytes(32).toString('base64url');
+  callbackCodes.set(code, {
+    payload,
+    expiresAt: Date.now() + getTtlMs(),
+  });
+
+  return code;
+};
+
+export const consumeOAuthCallbackCode = (code) => {
+  if (typeof code !== 'string' || !code) {
+    return null;
+  }
+
+  const entry = callbackCodes.get(code);
+  callbackCodes.delete(code);
+
+  if (!entry || entry.expiresAt <= Date.now()) {
+    return null;
+  }
+
+  return entry.payload;
+};
+
+export const clearOAuthCallbackCodes = () => {
+  callbackCodes.clear();
+};
+</file>
+
+<file path="src/services/prediccion.service.js">
+import { ReporteModel } from '../models/reporte.model.js';
+
+export const PREDICCION_CACHE_TTL_MS = 5 * 60 * 1000;
+export const DEFAULT_CELDA_GRADOS = 0.05;
+
+const cache = new Map();
+const NIVEL_RANK = { bajo: 1, medio: 2, alto: 3, critico: 4 };
+const SCORE_NIVEL = [
+  { min: 80, nivel: 'critico' },
+  { min: 60, nivel: 'alto' },
+  { min: 35, nivel: 'medio' },
+  { min: 0, nivel: 'bajo' },
+];
+
+const toNumber = (value) => {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+};
+
+const validationError = (message) => {
+  const error = new Error(message);
+  error.statusCode = 400;
+  return error;
+};
+
+const clampInt = (value, { fallback, min, max }) => {
+  if (value === undefined || value === null || value === '') return fallback;
+  const parsed = parseInt(value, 10);
+  if (!Number.isFinite(parsed)) {
+    throw validationError(`El parametro debe ser un entero entre ${min} y ${max}.`);
+  }
+  return Math.max(min, Math.min(max, parsed));
+};
+
+const parseDateDesde = (dias) => {
+  const safeDias = clampInt(dias, { fallback: 30, min: 1, max: 365 });
+  const desde = new Date();
+  desde.setDate(desde.getDate() - safeDias);
+  return { safeDias, desde };
+};
+
+const cacheKey = (name, params) => `${name}:${JSON.stringify(params)}`;
+
+const getCached = (key) => {
+  const entry = cache.get(key);
+  if (!entry || entry.expiresAt <= Date.now()) {
+    cache.delete(key);
+    return null;
+  }
+
+  return entry.value;
+};
+
+const setCached = (key, value) => {
+  cache.set(key, {
+    value,
+    expiresAt: Date.now() + PREDICCION_CACHE_TTL_MS,
+  });
+  return value;
+};
+
+export const invalidatePrediccionCache = () => {
+  cache.clear();
+};
+
+export const getPrediccionCacheSize = () => cache.size;
+
+const validateTipo = (tipo) => (
+  typeof tipo === 'string' && tipo.trim() ? tipo.trim().toLowerCase() : null
+);
+
+export const parseZonasParams = (query = {}) => {
+  const { safeDias, desde } = parseDateDesde(query.dias);
+  const minScore = query.min_score === undefined || query.min_score === ''
+    ? 30
+    : Number(query.min_score);
+
+  if (!Number.isFinite(minScore) || minScore < 0 || minScore > 100) {
+    throw validationError('min_score debe ser un numero entre 0 y 100.');
+  }
+
+  return {
+    dias: safeDias,
+    desde,
+    tipo: validateTipo(query.tipo),
+    min_score: minScore,
+  };
+};
+
+export const parseAlertasParams = (query = {}) => {
+  const zonasParams = parseZonasParams(query);
+  const limite = clampInt(query.limite, { fallback: 10, min: 1, max: 50 });
+  const nivel_min = query.nivel_min === undefined || query.nivel_min === ''
+    ? 'medio'
+    : String(query.nivel_min).toLowerCase();
+  if (!NIVEL_RANK[nivel_min]) {
+    throw validationError('nivel_min debe ser uno de: bajo, medio, alto, critico.');
+  }
+  const lat = toNumber(query.lat);
+  const lng = toNumber(query.lng);
+  const radio_km = toNumber(query.radio_km);
+
+  if (query.lat !== undefined && (lat === null || lat < -90 || lat > 90)) {
+    throw validationError('lat debe ser un numero entre -90 y 90.');
+  }
+  if (query.lng !== undefined && (lng === null || lng < -180 || lng > 180)) {
+    throw validationError('lng debe ser un numero entre -180 y 180.');
+  }
+  if (query.radio_km !== undefined && (radio_km === null || radio_km <= 0 || radio_km > 500)) {
+    throw validationError('radio_km debe ser un numero mayor a 0 y menor o igual a 500.');
+  }
+
+  return {
+    ...zonasParams,
+    limite,
+    nivel_min,
+    lat: lat !== null && lat >= -90 && lat <= 90 ? lat : null,
+    lng: lng !== null && lng >= -180 && lng <= 180 ? lng : null,
+    radio_km: radio_km !== null && radio_km > 0 ? Math.min(radio_km, 500) : null,
+  };
+};
+
+const gridKeyFor = (lat, lng, cellSize = DEFAULT_CELDA_GRADOS) => {
+  const latCell = Math.floor(Number(lat) / cellSize) * cellSize;
+  const lngCell = Math.floor(Number(lng) / cellSize) * cellSize;
+  return `${latCell.toFixed(4)}:${lngCell.toFixed(4)}`;
+};
+
+const scoreZona = (reportes) => {
+  const severidadPromedio = reportes.reduce(
+    (sum, reporte) => sum + (NIVEL_RANK[reporte.nivel_severidad] || 1),
+    0
+  ) / Math.max(1, reportes.length);
+  const recencia = reportes.reduce((sum, reporte) => {
+    const createdAt = new Date(reporte.created_at).getTime();
+    const days = Number.isFinite(createdAt)
+      ? Math.max(0, (Date.now() - createdAt) / 86400000)
+      : 365;
+    return sum + Math.max(0, 30 - days);
+  }, 0) / Math.max(1, reportes.length);
+  const score = Math.min(100, Math.round((reportes.length * 16) + (severidadPromedio * 14) + recencia));
+  const nivel = SCORE_NIVEL.find((item) => score >= item.min)?.nivel || 'bajo';
+
+  return { score, nivel, severidadPromedio };
+};
+
+const buildZonas = (reportes, { min_score }) => {
+  const grouped = new Map();
+
+  for (const reporte of reportes) {
+    const lat = Number(reporte.latitud);
+    const lng = Number(reporte.longitud);
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) continue;
+
+    const key = gridKeyFor(lat, lng);
+    grouped.set(key, [...(grouped.get(key) || []), reporte]);
+  }
+
+  return [...grouped.entries()]
+    .map(([key, items]) => {
+      const [latCell, lngCell] = key.split(':').map(Number);
+      const { score, nivel, severidadPromedio } = scoreZona(items);
+      const tipoCounts = new Map();
+      let latest = null;
+
+      for (const item of items) {
+        tipoCounts.set(item.tipo_contaminacion, (tipoCounts.get(item.tipo_contaminacion) || 0) + 1);
+        const itemDate = new Date(item.created_at).getTime();
+        if (!latest || itemDate > new Date(latest).getTime()) latest = item.created_at;
+      }
+
+      const [tipoDominante] = [...tipoCounts.entries()].sort((a, b) => b[1] - a[1])[0] || ['otro'];
+
+      return {
+        id: key,
+        zona_id: key,
+        centro: {
+          lat: Number((latCell + (DEFAULT_CELDA_GRADOS / 2)).toFixed(6)),
+          lng: Number((lngCell + (DEFAULT_CELDA_GRADOS / 2)).toFixed(6)),
+        },
+        tipo_dominante: tipoDominante,
+        n_reportes: items.length,
+        severidad_promedio: Number(severidadPromedio.toFixed(2)),
+        ultimo_reporte: latest,
+        score,
+        nivel,
+      };
+    })
+    .filter((zona) => zona.score >= min_score)
+    .sort((a, b) => b.score - a.score || b.n_reportes - a.n_reportes);
+};
+
+const distanceKm = (a, b) => {
+  const radius = 6371;
+  const dLat = ((b.lat - a.lat) * Math.PI) / 180;
+  const dLng = ((b.lng - a.lng) * Math.PI) / 180;
+  const lat1 = (a.lat * Math.PI) / 180;
+  const lat2 = (b.lat * Math.PI) / 180;
+  const h = Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) ** 2;
+  return 2 * radius * Math.asin(Math.sqrt(h));
+};
+
+export const calcularZonasRiesgo = async (params) => {
+  const key = cacheKey('zonas', {
+    dias: params.dias,
+    tipo: params.tipo,
+    min_score: params.min_score,
+  });
+  const cached = getCached(key);
+  if (cached) return cached;
+
+  const reportes = await ReporteModel.findParaPrediccion({
+    desde: params.desde,
+    tipo: params.tipo,
+  });
+  const payload = {
+    actualizado_en: new Date().toISOString(),
+    celda_grados: DEFAULT_CELDA_GRADOS,
+    zonas: buildZonas(reportes, params),
+  };
+
+  return setCached(key, payload);
+};
+
+export const calcularAlertasPredictivas = async (params) => {
+  const key = cacheKey('alertas', {
+    dias: params.dias,
+    tipo: params.tipo,
+    min_score: params.min_score,
+    limite: params.limite,
+    nivel_min: params.nivel_min,
+    lat: params.lat,
+    lng: params.lng,
+    radio_km: params.radio_km,
+  });
+  const cached = getCached(key);
+  if (cached) return cached;
+
+  const zonasPayload = await calcularZonasRiesgo({ ...params, min_score: params.min_score ?? 0 });
+  const minRank = NIVEL_RANK[params.nivel_min] || NIVEL_RANK.medio;
+  const origin = params.lat !== null && params.lng !== null ? { lat: params.lat, lng: params.lng } : null;
+
+  const alertas = zonasPayload.zonas
+    .filter((zona) => (NIVEL_RANK[zona.nivel] || 1) >= minRank)
+    .filter((zona) => !params.tipo || zona.tipo_dominante === params.tipo)
+    .map((zona) => ({
+      id: zona.id,
+      zona_id: zona.zona_id,
+      centro: zona.centro,
+      tipo_dominante: zona.tipo_dominante,
+      n_reportes: zona.n_reportes,
+      score: zona.score,
+      nivel: zona.nivel,
+      ultimo_reporte: zona.ultimo_reporte,
+      distancia_km: origin ? Number(distanceKm(origin, zona.centro).toFixed(2)) : null,
+    }))
+    .filter((alerta) => !origin || !params.radio_km || alerta.distancia_km <= params.radio_km)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, params.limite);
+
+  const payload = {
+    generado_en: new Date().toISOString(),
+    alertas,
+  };
+
+  return setCached(key, payload);
+};
+</file>
+
+<file path="src/utils/constantes-validacion.js">
+/**
+ * VALIDACIONES USADAS EN PERFIL Y SEGURIDAD.
+ */
+
+/**
+ * Valida el nombre de usuario para operaciones de perfil.
+ * Reglas:
+ * - Debe ser string no vacio (null, undefined y solo espacios -> false)
+ * - Debe tener entre 2 y 50 caracteres (sin contar espacios al inicio/fin)
+ * - Rechaza caracteres peligrosos como < > ; ` " \ / { } [ ]
+ *
+ * @param {string} nombre
+ * @returns {boolean}
+ */
+export const validarNombreUsuario = (nombre) => {
+  if (typeof nombre !== 'string') return false;
+
+  const valor = nombre.trim();
+  if (!valor) return false;
+  if (valor.length < 2 || valor.length > 50) return false;
+
+  const caracteresPeligrosos = /[<>;`"\\/{}\[\]]/;
+  if (caracteresPeligrosos.test(valor)) return false;
+
+  return true;
+};
+
+/**
+ * Valida telefono para perfil (campo opcional).
+ * Reglas:
+ * - null, undefined, cadena vacia o solo espacios -> true
+ * - Si trae valor, debe ser telefono valido (7 a 15 digitos, permite prefijo +)
+ * - Se aceptan separadores comunes: espacio, guion y parentesis
+ *
+ * @param {string|null|undefined} telefono
+ * @returns {boolean}
+ */
+export const validarTelefono = (telefono) => {
+  if (telefono === null || telefono === undefined) return true;
+  if (typeof telefono !== 'string') return false;
+
+  const valor = telefono.trim();
+  if (!valor) return true;
+
+  const normalizado = valor.replace(/[\s()-]/g, '');
+  return /^\+?[0-9]{7,15}$/.test(normalizado);
+};
+
+/**
+ * Valida password para cambio de clave.
+ * Reglas:
+ * - Debe ser string no vacio (null, undefined y solo espacios -> false)
+ * - Minimo 8 caracteres
+ * - Al menos una letra y un numero
+ *
+ * @param {string} password
+ * @returns {boolean}
+ */
+export const validarPassword = (password) => {
+  if (typeof password !== 'string') return false;
+
+  const valor = password.trim();
+  if (!valor) return false;
+  if (valor.length < 8) return false;
+
+  const tieneLetra = /[A-Za-z]/.test(valor);
+  const tieneNumero = /[0-9]/.test(valor);
+
+  return tieneLetra && tieneNumero;
+};
+</file>
+
+<file path="tests/auth/login.test.js">
+#!/usr/bin/env node
+
+/**
+ * Test: User Login
+ * USO: node tests/auth/login.test.js
+ * 
+ * TODO: Implementar tests para login
+ */
+
+import 'dotenv/config';
+import fetch from 'node-fetch';
+
+const API_URL = (process.env.API_URL || 'http://localhost:3000').replace(/\/+$/, '');
+let testsPassed = 0;
+let testsFailed = 0;
+
+const colors = {
+  reset: '\x1b[0m',
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  blue: '\x1b[34m',
+};
+
+const log = {
+  success: (msg) => console.log(`${colors.green}✓ ${msg}${colors.reset}`),
+  error: (msg) => console.log(`${colors.red}✗ ${msg}${colors.reset}`),
+  info: (msg) => console.log(`${colors.blue}ℹ ${msg}${colors.reset}`),
+};
+
+const assert = (condition, testName) => {
+  if (condition) {
+    log.success(testName);
+    testsPassed++;
+  } else {
+    log.error(testName);
+    testsFailed++;
+  }
+};
+
+async function testConnection() {
+  log.info('\n--- TEST 0: Connection ---');
+  try {
+    const response = await fetch(`${API_URL}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'test@test.com', password: 'test' }),
+    });
+    
+    assert(response.status !== undefined, 'Server responding');
+    return true;
+  } catch {
+    log.error('Server not responding. Make sure Backend is running.');
+    return false;
+  }
+}
+
+async function runAllTests() {
+  console.log('\n' + colors.blue + '═══════════════════════════════════════' + colors.reset);
+  console.log(colors.blue + '  Testing: User Login' + colors.reset);
+  console.log(colors.blue + '═══════════════════════════════════════\n' + colors.reset);
+
+  const connected = await testConnection();
+  if (!connected) process.exit(1);
+
+  // TODO: Add more tests here
+  log.info('\nTests not implemented yet');
+
+  console.log('\n' + colors.blue + '═══════════════════════════════════════' + colors.reset);
+  console.log(colors.blue + '  Results' + colors.reset);
+  console.log(colors.blue + '═══════════════════════════════════════' + colors.reset);
+  console.log(`Total: ${testsPassed + testsFailed}`);
+  
+  process.exit(0);
+}
+
+runAllTests().catch((error) => {
+  log.error(`Critical error: ${error.message}`);
+  process.exit(1);
+});
+</file>
+
+<file path="tests/auth/password-reset.test.js">
+#!/usr/bin/env node
+
+/**
+ * Test: Password Reset
+ * USO: node tests/auth/password-reset.test.js
+ * 
+ * TODO: Implementar tests para reset de contraseña
+ */
+
+import 'dotenv/config';
+import fetch from 'node-fetch';
+
+const API_URL = (process.env.API_URL || 'http://localhost:3000').replace(/\/+$/, '');
+let testsPassed = 0;
+let testsFailed = 0;
+
+const colors = {
+  reset: '\x1b[0m',
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  blue: '\x1b[34m',
+};
+
+const log = {
+  success: (msg) => console.log(`${colors.green}✓ ${msg}${colors.reset}`),
+  error: (msg) => console.log(`${colors.red}✗ ${msg}${colors.reset}`),
+  info: (msg) => console.log(`${colors.blue}ℹ ${msg}${colors.reset}`),
+};
+
+const assert = (condition, testName) => {
+  if (condition) {
+    log.success(testName);
+    testsPassed++;
+  } else {
+    log.error(testName);
+    testsFailed++;
+  }
+};
+
+async function testConnection() {
+  log.info('\n--- TEST 0: Connection ---');
+  try {
+    const response = await fetch(`${API_URL}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'test@test.com', password: 'test' }),
+    });
+    
+    assert(response.status !== undefined, 'Server responding');
+    return true;
+  } catch {
+    log.error('Server not responding. Make sure Backend is running.');
+    return false;
+  }
+}
+
+async function runAllTests() {
+  console.log('\n' + colors.blue + '═══════════════════════════════════════' + colors.reset);
+  console.log(colors.blue + '  Testing: Password Reset' + colors.reset);
+  console.log(colors.blue + '═══════════════════════════════════════\n' + colors.reset);
+
+  const connected = await testConnection();
+  if (!connected) process.exit(1);
+
+  // TODO: Add more tests here
+  log.info('\nTests not implemented yet');
+
+  console.log('\n' + colors.blue + '═══════════════════════════════════════' + colors.reset);
+  console.log(colors.blue + '  Results' + colors.reset);
+  console.log(colors.blue + '═══════════════════════════════════════' + colors.reset);
+  console.log(`Total: ${testsPassed + testsFailed}`);
+  
+  process.exit(0);
+}
+
+runAllTests().catch((error) => {
+  log.error(`Critical error: ${error.message}`);
+  process.exit(1);
+});
+</file>
+
+<file path="tests/auth/register.test.js">
+#!/usr/bin/env node
+
+/**
+ * Test: User Registration
+ * USO: node tests/auth/register.test.js
+ */
+
+import 'dotenv/config';
+import fetch from 'node-fetch';
+
+const API_URL = (process.env.API_URL || 'http://localhost:3000').replace(/\/+$/, '');
+let testsPassed = 0;
+let testsFailed = 0;
+
+const colors = {
+  reset: '\x1b[0m',
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  blue: '\x1b[34m',
+};
+
+const log = {
+  success: (msg) => console.log(`${colors.green}✓ ${msg}${colors.reset}`),
+  error: (msg) => console.log(`${colors.red}✗ ${msg}${colors.reset}`),
+  info: (msg) => console.log(`${colors.blue}ℹ ${msg}${colors.reset}`),
+};
+
+const assert = (condition, testName) => {
+  if (condition) {
+    log.success(testName);
+    testsPassed++;
+  } else {
+    log.error(testName);
+    testsFailed++;
+  }
+};
+
+async function testConnection() {
+  log.info('\n--- TEST 0: Connection ---');
+  try {
+    const response = await fetch(`${API_URL}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'test@test.com', password: 'test' }),
+    });
+    
+    assert(response.status !== undefined, 'Server responding');
+    return true;
+  } catch {
+    log.error('Server not responding. Make sure Backend is running.');
+    return false;
+  }
+}
+
+async function testValidRegistration() {
+  log.info('\n--- TEST 1: Valid Registration ---');
+  try {
+    const email = `test-${Date.now()}@ejemplo.com`;
+    const response = await fetch(`${API_URL}/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        nombre: 'Test',
+        apellido: 'User',
+        email: email,
+        password: 'SecurePass123!',
+        telefono: '+1234567890',
+      }),
+    });
+    
+    const data = await response.json();
+    assert(response.status === 201, 'Status 201');
+    assert(data.data?.token, 'JWT token generated');
+    assert(data.data?.user?.email === email, 'Email matches');
+    assert(data.data?.user?.email_verificado === 0, 'Email not verified by default');
+    
+    return true;
+  } catch (error) {
+    log.error(`Error: ${error.message}`);
+    return false;
+  }
+}
+
+async function testInvalidEmail() {
+  log.info('\n--- TEST 2: Invalid Email (Should fail) ---');
+  try {
+    const response = await fetch(`${API_URL}/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        nombre: 'Test',
+        apellido: 'User',
+        email: 'not-an-email',
+        password: 'SecurePass123!',
+      }),
+    });
+    
+    const data = await response.json();
+    assert(response.status === 400, 'Status 400');
+    assert(data.status === 'error', 'Status error');
+  } catch (error) {
+    log.error(`Error: ${error.message}`);
+  }
+}
+
+async function testShortPassword() {
+  log.info('\n--- TEST 3: Short Password (Should fail) ---');
+  try {
+    const response = await fetch(`${API_URL}/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        nombre: 'Test',
+        apellido: 'User',
+        email: `test-${Date.now()}@ejemplo.com`,
+        password: 'short',
+      }),
+    });
+    
+    const data = await response.json();
+    assert(response.status === 400, 'Status 400');
+    assert(data.status === 'error', 'Status error');
+  } catch (error) {
+    log.error(`Error: ${error.message}`);
+  }
+}
+
+async function runAllTests() {
+  console.log('\n' + colors.blue + '═══════════════════════════════════════' + colors.reset);
+  console.log(colors.blue + '  Testing: User Registration' + colors.reset);
+  console.log(colors.blue + '═══════════════════════════════════════\n' + colors.reset);
+
+  const connected = await testConnection();
+  if (!connected) process.exit(1);
+
+  await testValidRegistration();
+  await testInvalidEmail();
+  await testShortPassword();
+
+  console.log('\n' + colors.blue + '═══════════════════════════════════════' + colors.reset);
+  console.log(colors.blue + '  Results' + colors.reset);
+  console.log(colors.blue + '═══════════════════════════════════════' + colors.reset);
+  console.log(`Total: ${testsPassed + testsFailed}`);
+  console.log(`${colors.green}Passed: ${testsPassed}${colors.reset}`);
+  console.log(`${colors.red}Failed: ${testsFailed}${colors.reset}`);
+  
+  process.exit(testsFailed > 0 ? 1 : 0);
+}
+
+runAllTests().catch((error) => {
+  log.error(`Critical error: ${error.message}`);
+  process.exit(1);
+});
+</file>
+
+<file path="tests/diagnose-frontend-contract.js">
+#!/usr/bin/env node
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const backendDir = path.resolve(path.dirname(__filename), '..');
+const repoDir = path.resolve(backendDir, '..');
+const frontendApiPath = path.join(repoDir, 'Frontend', 'src', 'services', 'api.js');
+
+const source = await fs.readFile(frontendApiPath, 'utf8');
+const regex = /export const (\w+)\s*=.*?api\.(get|post|patch|delete)\((`[^`]+`|'[^']+'|"[^"]+")/gs;
+
+console.log('Contrato consumido por Frontend/src/services/api.js\n');
+let total = 0;
+for (const match of source.matchAll(regex)) {
+  const [, name, method, rawPath] = match;
+  const endpoint = rawPath.slice(1, -1);
+  console.log(`${method.toUpperCase().padEnd(6)} ${endpoint.padEnd(42)} ${name}`);
+  total += 1;
+}
+
+console.log(`\nTotal endpoints exportados: ${total}`);
+console.log('Nota: el frontend usa baseURL /api y Vite reescribe /api hacia el backend sin prefijo interno.');
+</file>
+
+<file path="tests/diagnose-routes.js">
+#!/usr/bin/env node
+/**
+ * Test simple para diagnosticar rutas disponibles
+ */
+
+const BASE_URL = 'http://localhost:3000';
+
+async function testRoute(method, path) {
+  try {
+    const response = await fetch(`${BASE_URL}${path}`, { method });
+    console.log(`${method} ${path}: ${response.status}`);
+    return response.status;
+  } catch (error) {
+    console.log(`${method} ${path}: ERROR - ${error.message}`);
+    return null;
+  }
+}
+
+async function main() {
+  console.log('Diagnosticando rutas disponibles...\n');
+
+  // Test rutas básicas
+  console.log('Rutas básicas:');
+  await testRoute('GET', '/health');
+  await testRoute('GET', '/');
+  
+  // Test rutas auth
+  console.log('\nRutas Auth:');
+  await testRoute('POST', '/auth/register');
+  await testRoute('POST', '/auth/login');
+  await testRoute('POST', '/auth/enviar-verificacion');
+  await testRoute('GET', '/auth/verify-email');
+  
+  // Test rutas reportes
+  console.log('\nRutas Reportes:');
+  await testRoute('GET', '/reportes/mis-reportes');
+  await testRoute('GET', '/reportes');
+  await testRoute('POST', '/reportes');
+
+  // Test con headers adicionales
+  console.log('\nRutas con Bearer token inválido:');
+  const headers = {
+    'Authorization': 'Bearer invalid-token'
+  };
+  
+  try {
+    const response = await fetch(`${BASE_URL}/auth/enviar-verificacion`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({})
+    });
+    console.log(`POST /auth/enviar-verificacion: ${response.status}`);
+    const data = await response.json();
+    console.log(`Response:`, data);
+  } catch (error) {
+    console.log(`Error:`, error.message);
+  }
+}
+
+main().catch(console.error);
+</file>
+
+<file path="tests/email/smtp-send.test.js">
+#!/usr/bin/env node
+
+import 'dotenv/config';
+import {
+  enviarCorreo,
+  generarTemplateBaseCorreo,
+  verificarConexionSmtp,
+} from '../../src/services/email.service.js';
+
+const colors = {
+  reset: '\x1b[0m',
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  blue: '\x1b[34m',
+};
+
+const log = {
+  info: (msg) => console.log(`${colors.blue}${msg}${colors.reset}`),
+  success: (msg) => console.log(`${colors.green}${msg}${colors.reset}`),
+  error: (msg) => console.error(`${colors.red}${msg}${colors.reset}`),
+};
+
+const main = async () => {
+  const to = process.env.EMAIL_TEST_TO || process.env.EMAIL_FROM;
+
+  if (!to) {
+    throw new Error('Define EMAIL_TEST_TO o EMAIL_FROM en Backend/.env');
+  }
+
+  log.info('Validando conexion SMTP...');
+  await verificarConexionSmtp();
+  log.success('Conexion SMTP valida.');
+
+  log.info(`Enviando correo de prueba a ${to}...`);
+  const html = generarTemplateBaseCorreo({
+    title: 'Correo de prueba',
+    subtitle: 'Configuracion SMTP',
+    previewText: 'Prueba local del servicio de correos de GreenAlert.',
+    content: `
+      <div class="message">
+        Este mensaje confirma que Nodemailer puede enviar correos desde el backend de GreenAlert.
+      </div>
+      <div class="panel">
+        <h3>Entorno</h3>
+        <ul>
+          <li>Proveedor SMTP: ${process.env.EMAIL_HOST}</li>
+          <li>Puerto SMTP: ${process.env.EMAIL_PORT}</li>
+          <li>Fecha de prueba: ${new Date().toISOString()}</li>
+        </ul>
+      </div>
+    `,
+  });
+
+  const info = await enviarCorreo(to, 'GreenAlert - prueba SMTP', html);
+  log.success('Correo enviado correctamente.');
+  log.info(`Message ID: ${info.messageId}`);
+};
+
+main().catch((error) => {
+  log.error(`Error en prueba SMTP: ${error.message}`);
+  process.exit(1);
+});
+</file>
+
+<file path="tests/email/verification.test.js">
+#!/usr/bin/env node
+
+/**
+ * Test: Email Verification
+ * USO: node tests/email/verification.test.js
+ */
+
+import 'dotenv/config';
+import fetch from 'node-fetch';
+
+const API_URL = (process.env.API_URL || 'http://localhost:3000').replace(/\/+$/, '');
+const TEST_EMAIL_BASE = `test-${Date.now()}`;
+let testsPassed = 0;
+let testsFailed = 0;
+
+const colors = {
+  reset: '\x1b[0m',
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+};
+
+const log = {
+  success: (msg) => console.log(`${colors.green}✓ ${msg}${colors.reset}`),
+  error: (msg) => console.log(`${colors.red}✗ ${msg}${colors.reset}`),
+  info: (msg) => console.log(`${colors.blue}ℹ ${msg}${colors.reset}`),
+  warn: (msg) => console.log(`${colors.yellow}! ${msg}${colors.reset}`),
+};
+
+const assert = (condition, testName) => {
+  if (condition) {
+    log.success(testName);
+    testsPassed++;
+  } else {
+    log.error(testName);
+    testsFailed++;
+  }
+};
+
+async function testConnection() {
+  log.info('\n--- TEST 0: Connection to Server ---');
+  try {
+    const response = await fetch(`${API_URL}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'test@test.com', password: 'test' }),
+      timeout: 5000,
+    });
+
+    assert(response.status !== undefined, 'Server responding');
+    return true;
+  } catch (error) {
+    log.error(`Server not responding: ${error.message}`);
+    log.warn('Make sure Backend is running at http://localhost:3000');
+    return false;
+  }
+}
+
+async function testRegister() {
+  log.info('\n--- TEST 1: Register User ---');
+  try {
+    const response = await fetch(`${API_URL}/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        nombre: 'Test',
+        apellido: 'Verificacion',
+        email: `${TEST_EMAIL_BASE}@ejemplo.com`,
+        password: 'SecurePass123!',
+        telefono: '+1234567890',
+      }),
+    });
+
+    const data = await response.json();
+    
+    assert(response.status === 201, 'Status 201');
+    assert(data.data?.token, 'JWT token generated');
+    assert(data.data?.user?.email_verificado === 0, 'Email not verified');
+    
+    return data.data;
+  } catch (error) {
+    log.error(`Error registering: ${error.message}`);
+    return null;
+  }
+}
+
+async function testSendVerification(jwt) {
+  log.info('\n--- TEST 2: Send Verification Email ---');
+  try {
+    const response = await fetch(`${API_URL}/auth/enviar-verificacion`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${jwt}`,
+      },
+    });
+
+    const data = await response.json();
+    
+    assert(response.status === 200, 'Status 200');
+    assert(data.status === 'success', 'Status success');
+    
+    return true;
+  } catch (error) {
+    log.error(`Error sending: ${error.message}`);
+    return false;
+  }
+}
+
+async function testNoAuth() {
+  log.info('\n--- TEST 3: No Authentication (Should fail) ---');
+  try {
+    const response = await fetch(`${API_URL}/auth/enviar-verificacion`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const data = await response.json();
+    
+    assert(response.status === 401, 'Status 401');
+    assert(data.status === 'error', 'Status error');
+    assert(data.message, 'Correct message');
+    
+    return true;
+  } catch (error) {
+    log.error(`Error: ${error.message}`);
+    return false;
+  }
+}
+
+async function testNoToken() {
+  log.info('\n--- TEST 4: No Token in Query (Should fail) ---');
+  try {
+    const response = await fetch(`${API_URL}/auth/verify-email`, {
+      method: 'GET',
+    });
+
+    const data = await response.json();
+    
+    assert(response.status === 400, 'Status 400');
+    assert(data.status === 'error', 'Status error');
+    assert(data.message.includes('Token'), 'Message mentions token');
+    
+    return true;
+  } catch (error) {
+    log.error(`Error: ${error.message}`);
+    return false;
+  }
+}
+
+async function testInvalidToken() {
+  log.info('\n--- TEST 5: Invalid Token (Should fail) ---');
+  try {
+    const response = await fetch(`${API_URL}/auth/verify-email?token=invalid_token_xyz123`, {
+      method: 'GET',
+    });
+
+    const data = await response.json();
+    
+    assert(response.status === 400, 'Status 400');
+    assert(data.status === 'error', 'Status error');
+    assert(data.message.includes('invalido'), 'Message mentions invalid');
+    
+    return true;
+  } catch (error) {
+    log.error(`Error: ${error.message}`);
+    return false;
+  }
+}
+
+async function runAllTests() {
+  console.log('\n' + colors.blue + '═══════════════════════════════════════' + colors.reset);
+  console.log(colors.blue + '  Testing: Email Verification' + colors.reset);
+  console.log(colors.blue + '═══════════════════════════════════════\n' + colors.reset);
+
+  const connected = await testConnection();
+  if (!connected) {
+    process.exit(1);
+  }
+
+  const userData = await testRegister();
+  if (!userData) {
+    log.error('Could not register user. Aborting.');
+    process.exit(1);
+  }
+
+  await testSendVerification(userData.token);
+  await testNoAuth();
+  await testNoToken();
+  await testInvalidToken();
+
+  console.log('\n' + colors.blue + '═══════════════════════════════════════' + colors.reset);
+  console.log(colors.blue + '  Results' + colors.reset);
+  console.log(colors.blue + '═══════════════════════════════════════' + colors.reset);
+  console.log(`Total: ${testsPassed + testsFailed}`);
+  console.log(`${colors.green}Passed: ${testsPassed}${colors.reset}`);
+  console.log(`${colors.red}Failed: ${testsFailed}${colors.reset}`);
+  
+  if (testsFailed === 0) {
+    console.log(`\n${colors.green}✓ All tests passed${colors.reset}\n`);
+    process.exit(0);
+  } else {
+    console.log(`\n${colors.red}✗ Some tests failed${colors.reset}\n`);
+    process.exit(1);
+  }
+}
+
+runAllTests().catch((error) => {
+  log.error(`Critical error: ${error.message}`);
+  process.exit(1);
+});
+</file>
+
+<file path="tests/integration-v2.test.js">
+#!/usr/bin/env node
+/**
+ * Test Suite Mejorado: Features implementadas
+ */
+
+import assert from 'assert';
+
+const BASE_URL = (process.env.API_URL || 'http://localhost:3000').replace(/\/+$/, '');
+
+const colors = {
+  reset: '\x1b[0m',
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  blue: '\x1b[34m',
+  yellow: '\x1b[33m',
+  cyan: '\x1b[36m',
+};
+
+const log = {
+  test: (msg) => console.log(`${colors.cyan}✓ TEST: ${msg}${colors.reset}`),
+  pass: (msg) => console.log(`${colors.green} PASS: ${msg}${colors.reset}`),
+  fail: (msg) => console.log(`${colors.red} FAIL: ${msg}${colors.reset}`),
+  info: (msg) => console.log(`${colors.blue}ℹ INFO: ${msg}${colors.reset}`),
+  section: (msg) => console.log(`\n${colors.cyan}═══════════════════════════════════\n  ${msg}\n═══════════════════════════════════${colors.reset}\n`),
+};
+
+let testsPassed = 0;
+let testsFailed = 0;
+let testToken = '';
+let testUserId = '';
+let testEmail = '';
+
+async function apiRequest(method, endpoint, body = null, token = null) {
+  const headers = {
+    'Content-Type': 'application/json',
+  };
+  
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  const options = {
+    method,
+    headers,
+  };
+
+  if (body) {
+    options.body = JSON.stringify(body);
+  }
+
+  try {
+    const response = await fetch(`${BASE_URL}${endpoint}`, options);
+    const data = await response.json();
+    return { status: response.status, data };
+  } catch (error) {
+    throw error;
+  }
+}
+
+async function test(name, fn) {
+  log.test(name);
+  try {
+    await fn();
+    log.pass(name);
+    testsPassed++;
+  } catch (error) {
+    log.fail(`${name}: ${error.message}`);
+    testsFailed++;
+  }
+}
+
+async function runTests() {
+  log.section('TEST SUITE: Green Alert Backend Features');
+
+  // ─── 1. REGISTRO Y AUTENTICACIÓN ───
+  log.section('1. REGISTRO Y AUTENTICACIÓN');
+
+  await test('Registro de usuario exitoso', async () => {
+    testEmail = `test-${Date.now()}@example.com`;
+    const res = await apiRequest('POST', '/auth/register', {
+      nombre: 'Test',
+      apellido: 'User',
+      email: testEmail,
+      password: 'TestPass123!',
+    });
+    
+    assert.strictEqual(res.status, 201, `Expected 201, got ${res.status}`);
+    assert(res.data?.data?.token, 'Token en respuesta');
+    assert(res.data?.data?.user?.id_usuario, 'Usuario creado con ID');
+    
+    testUserId = res.data?.data?.user?.id_usuario;
+    testToken = res.data?.data?.token;
+    log.info(`Registro exitoso. Token obtenido: ${testToken.substring(0, 20)}...`);
+  });
+
+  await test('Login exitoso con usuario registrado', async () => {
+    if (!testEmail) {
+      log.info('Saltando - sin email de prueba');
+      return;
+    }
+    
+    const res = await apiRequest('POST', '/auth/login', {
+      email: testEmail,
+      password: 'TestPass123!',
+    });
+    
+    assert([200, 201].includes(res.status), `Expected 200/201, got ${res.status}`);
+    assert(res.data?.data?.token, 'Token retornado en login');
+    testToken = res.data?.data?.token;
+  });
+
+  // ─── 2. ENDPOINTS OTP ───
+  log.section('2. ENDPOINTS OTP EMAIL VERIFICATION');
+
+  await test('POST /auth/enviar-verificacion devuelve 401 sin token', async () => {
+    const res = await apiRequest('POST', '/auth/enviar-verificacion', {});
+    assert.strictEqual(res.status, 401, `Expected 401, got ${res.status}`);
+  });
+
+  await test('GET /auth/verify-email devuelve 400 sin parámetros', async () => {
+    const res = await apiRequest('GET', '/auth/verify-email');
+    assert([400, 404].includes(res.status), `Expected 400/404, got ${res.status}`);
+  });
+
+  // ─── 3. GET /api/reportes/MIS-REPORTES ───
+  log.section('3. GET /api/reportes/MIS-REPORTES');
+
+  await test('Acceso a mis-reportes requiere autenticación', async () => {
+    const res = await apiRequest('GET', '/reportes/mis-reportes');
+    assert.strictEqual(res.status, 401, `Expected 401, got ${res.status}`);
+  });
+
+  await test('Acceso a mis-reportes con token válido devuelve lista', async () => {
+    if (!testToken) {
+      log.info('Saltando - sin token');
+      return;
+    }
+
+    const res = await apiRequest('GET', '/reportes/mis-reportes', null, testToken);
+    assert.strictEqual(res.status, 200, `Expected 200, got ${res.status}`);
+    assert(Array.isArray(res.data?.data?.reportes), 'Reportes debe ser array');
+    assert(typeof res.data?.data?.total === 'number', 'Total es número');
+  });
+
+  // ─── 4. CREAR REPORTE PARA TESTS ───
+  log.section('4. CREAR REPORTE DE PRUEBA');
+
+  let testReporteId = null;
+  
+  await test('Crear reporte con usuario autenticado', async () => {
+    if (!testToken) {
+      log.info('Saltando - sin token');
+      return;
+    }
+
+    const res = await apiRequest('POST', '/reportes', {
+      tipo_contaminacion: 'inundacion',
+      nivel_severidad: 'medio',
+      titulo: 'Test Report Title',
+      descripcion: 'Test report description',
+      direccion: 'Calle Test 123',
+      municipio: 'Test City',
+      departamento: 'Test Dept',
+      latitud: 10.5,
+      longitud: -73.5,
+    }, testToken);
+
+    if (res.status === 201) {
+      testReporteId = res.data?.data?.reporte?.id_reporte;
+      log.info(`Reporte creado: ${testReporteId}`);
+    }
+  });
+
+  // ─── 5. ENDPOINTS ADICIONALES ───
+  log.section('5. ENDPOINTS ADICIONALES');
+
+  await test('Health check está disponible', async () => {
+    const res = await apiRequest('GET', '/health');
+    assert.strictEqual(res.status, 200, `Expected 200, got ${res.status}`);
+    assert(res.data?.status, 'Health status disponible');
+  });
+
+  await test('GET /reportes devuelve lista pública', async () => {
+    const res = await apiRequest('GET', '/reportes');
+    assert.strictEqual(res.status, 200, `Expected 200, got ${res.status}`);
+    assert(Array.isArray(res.data?.data?.reportes), 'Reportes debe ser array');
+  });
+
+  // ─── RESULTADOS FINALES ───
+  log.section('RESULTADOS FINALES');
+  log.pass(`Tests pasados: ${testsPassed}`);
+  log.fail(`Tests fallidos: ${testsFailed}`);
+  console.log(`\nTotal: ${testsPassed + testsFailed} tests\n`);
+
+  process.exit(testsFailed > 0 ? 1 : 0);
+}
+
+// Ejecutar tests
+setTimeout(() => {
+  runTests().catch(error => {
+    console.error('Error fatal:', error.message);
+    process.exit(1);
+  });
+}, 1000);
+</file>
+
+<file path="tests/integration.test.js">
+#!/usr/bin/env node
+/**
+ * Test Suite: Features implementadas
+ * 1. OTP Email Verification
+ * 2. GET /api/reportes/mis-reportes
+ * 3. Report editing restrictions
+ * 4. Moderation comments
+ * 5. Welcome email
+ */
+
+import assert from 'assert';
+
+const BASE_URL = (process.env.API_URL || 'http://localhost:3000').replace(/\/+$/, '');
+
+// Color codes for terminal output
+const colors = {
+  reset: '\x1b[0m',
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  blue: '\x1b[34m',
+  yellow: '\x1b[33m',
+  cyan: '\x1b[36m',
+};
+
+const log = {
+  test: (msg) => console.log(`${colors.cyan}[TEST] TEST: ${msg}${colors.reset}`),
+  pass: (msg) => console.log(`${colors.green}[PASS] PASS: ${msg}${colors.reset}`),
+  fail: (msg) => console.log(`${colors.red}[FAIL] FAIL: ${msg}${colors.reset}`),
+  info: (msg) => console.log(`${colors.blue}[INFO] INFO: ${msg}${colors.reset}`),
+  warn: (msg) => console.log(`${colors.yellow}[WARN] WARN: ${msg}${colors.reset}`),
+  section: (msg) => console.log(`\n${colors.cyan}═══════════════════════════════════\n  ${msg}\n═══════════════════════════════════${colors.reset}\n`),
+};
+
+let testsPassed = 0;
+let testsFailed = 0;
+let testToken = '';
+let testUserId = '';
+let testReporteId = '';
+
+// Helper function for API requests
+async function apiRequest(method, endpoint, body = null, token = null) {
+  const headers = {
+    'Content-Type': 'application/json',
+  };
+  
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  const options = {
+    method,
+    headers,
+  };
+
+  if (body) {
+    options.body = JSON.stringify(body);
+  }
+
+  try {
+    const response = await fetch(`${BASE_URL}${endpoint}`, options);
+    const data = await response.json();
+    return { status: response.status, data };
+  } catch (error) {
+    throw error;
+  }
+}
+
+// Test wrapper
+async function test(name, fn) {
+  log.test(name);
+  try {
+    await fn();
+    log.pass(name);
+    testsPassed++;
+  } catch (error) {
+    log.fail(`${name}: ${error.message}`);
+    testsFailed++;
+  }
+}
+
+// ============================================
+// TEST SUITE
+// ============================================
+
+async function runTests() {
+  log.section('TEST SUITE: Green Alert Backend Features');
+
+  // ─── 1. REGISTRO Y AUTENTICACIÓN ───
+  log.section('1. REGISTRO Y AUTENTICACIÓN');
+
+  await test('Registro de usuario exitoso', async () => {
+    const res = await apiRequest('POST', '/auth/register', {
+      nombre: 'Test',
+      apellido: 'User',
+      email: `test-${Date.now()}@example.com`,
+      password: 'TestPass123!',
+    });
+    
+    log.info(`Registro response: status=${res.status}, data=${JSON.stringify(res.data)}`);
+    assert.strictEqual(res.status, 201, `Expected 201, got ${res.status}`);
+    assert(res.data.data?.user, 'Usuario creado');
+    assert(res.data.data?.pendingEmailVerification === true, 'Email verification pendiente');
+    
+    testUserId = res.data.data?.user?.id_usuario;
+  });
+
+  await test('Login exitoso', async () => {
+    const res = await apiRequest('POST', '/auth/login', {
+      email: 'test-user@example.com',
+      password: 'password123',
+    });
+    
+    // Permitir 200 o 401 (usuario no existe por ahora)
+    assert([200, 401].includes(res.status), `Login response ${res.status}`);
+  });
+
+  // ─── 2. OTP EMAIL VERIFICATION ───
+  log.section('2. OTP EMAIL VERIFICATION');
+
+  await test('Enviar verificación OTP requiere token', async () => {
+    const res = await apiRequest('POST', '/auth/enviar-verificacion', {});
+    
+    assert.strictEqual(res.status, 401, `Expected 401, got ${res.status}`);
+    assert(res.data.message, 'Mensaje de error disponible');
+  });
+
+  await test('Verificación OTP con token inválido falla', async () => {
+    const res = await apiRequest('POST', '/auth/verificar-email', 
+      { otp_code: '123456' },
+      'invalid-token'
+    );
+    
+    assert.strictEqual(res.status, 403, `Expected 403, got ${res.status}`);
+  });
+
+  // ─── 3. GET /api/reportes/MIS-REPORTES ───
+  log.section('3. GET /api/reportes/MIS-REPORTES');
+
+  await test('Acceso a mis-reportes requiere autenticación', async () => {
+    const res = await apiRequest('GET', '/reportes/mis-reportes');
+    
+    assert.strictEqual(res.status, 401, `Expected 401, got ${res.status}`);
+    assert(res.data.message, 'Mensaje de error disponible');
+  });
+
+  // ─── 4. CREAR REPORTE PARA TESTS ───
+  log.section('4. CREAR REPORTE DE PRUEBA');
+
+  // Necesito un token válido. Voy a crear un usuario de prueba
+  let res = await apiRequest('POST', '/auth/register', {
+    nombre: 'Report',
+    apellido: 'Tester',
+    email: `reporter-${Date.now()}@example.com`,
+    password: 'TestPass123!',
+  });
+
+  if (res.status === 201) {
+    // Intentar login con este usuario (usar email del registro)
+    const testEmail = res.data.data.user.email;
+    
+    res = await apiRequest('POST', '/auth/login', {
+      email: testEmail,
+      password: 'TestPass123!',
+    });
+
+    if (res.status === 200) {
+      testToken = res.data.data.token;
+      log.info(`Token obtenido: ${testToken.substring(0, 20)}...`);
+
+      // Crear un reporte
+      res = await apiRequest('POST', '/reportes', 
+        {
+          tipo_contaminacion: 'agua',
+          nivel_severidad: 'medio',
+          titulo: 'Test Report',
+          descripcion: 'Test description',
+          direccion: 'Test Location',
+          municipio: 'Valledupar',
+          departamento: 'Cesar',
+          latitud: 10.5,
+          longitud: -73.5,
+        },
+        testToken
+      );
+
+      if (res.status === 201) {
+        testReporteId = res.data.data.reporte.id_reporte;
+        log.info(`Reporte creado: ${testReporteId}`);
+      }
+    }
+  }
+
+  // ─── 5. RESTRICCIONES DE EDICIÓN ───
+  log.section('5. RESTRICCIONES DE EDICIÓN DE REPORTES');
+
+  await test('Listar mis reportes retorna array', async () => {
+    if (!testToken) {
+      log.warn('Saltando - no hay token disponible');
+      return;
+    }
+
+    const res = await apiRequest('GET', '/reportes/mis-reportes', null, testToken);
+    
+    assert([200, 401].includes(res.status), `Expected 200 or 401, got ${res.status}`);
+    if (res.status === 200) {
+      assert(Array.isArray(res.data.data?.reportes), 'Reportes debe ser array');
+    }
+  });
+
+  await test('Propietario no puede editar reporte después de pendiente', async () => {
+    if (!testToken || !testReporteId) {
+      log.warn('Saltando - no hay token o reporte disponible');
+      return;
+    }
+
+    // Intentar cambiar estado (lo cual debería estar bloqueado después de pendiente)
+    const res = await apiRequest('PATCH', `/reportes/${testReporteId}`,
+      { estado: 'en_revision' },
+      testToken
+    );
+
+    // Debería retornar 403 si el reporte ya no está en pendiente
+    // O 200 si todavía está en pendiente (es válido cambiar)
+    assert([200, 400, 403].includes(res.status), `Expected 200, 400 or 403, got ${res.status}`);
+  });
+
+  // ─── 6. COMENTARIOS DE MODERACIÓN ───
+  log.section('6. COMENTARIOS DE MODERACIÓN');
+
+  await test('Rechazar reporte requiere comentario', async () => {
+    if (!testToken || !testReporteId) {
+      log.warn('Saltando - no hay token o reporte disponible');
+      return;
+    }
+
+    // Intentar rechazar sin comentario
+    const res = await apiRequest('PATCH', `/reportes/${testReporteId}`,
+      { estado: 'rechazado' },
+      testToken
+    );
+
+    // Podría fallar por permisos (no es mod) o por validación
+    assert([400, 403].includes(res.status), `Expected 400 or 403, got ${res.status}`);
+  });
+
+  // ─── 7. ENDPOINTS ADICIONALES ───
+  log.section('7. ENDPOINTS ADICIONALES');
+
+  await test('Health check está disponible', async () => {
+    const res = await apiRequest('GET', '/health');
+    
+    assert.strictEqual(res.status, 200, `Expected 200, got ${res.status}`);
+    assert(res.data.status, 'Health status disponible');
+  });
+
+  // ─── RESULTADOS FINALES ───
+  log.section('RESULTADOS FINALES');
+  log.pass(`Tests pasados: ${testsPassed}`);
+  log.fail(`Tests fallidos: ${testsFailed}`);
+  console.log(`\nTotal: ${testsPassed + testsFailed} tests\n`);
+
+  process.exit(testsFailed > 0 ? 1 : 0);
+}
+
+// Ejecutar tests
+setTimeout(() => {
+  runTests().catch(error => {
+    console.error('Error fatale:', error);
+    process.exit(1);
+  });
+}, 1000); // Esperar 1 segundo para asegurar que el servidor está listo
+</file>
+
+<file path="tests/models/usuario.pagination.test.js">
+import assert from 'assert';
+import { fileURLToPath } from 'url';
+import { UsuarioModel } from '../../src/models/usuario.model.js';
+
+const testName = 'Usuario Model - Pagination (LIMIT/OFFSET)';
+
+export const tests = [
+  {
+    name: `${testName} - Should find all users without pagination`,
+    run: async () => {
+      // Arrange: No limit/offset provided
+      const result = await UsuarioModel.findAll({});
+      
+      // Assert: Should return array (even if empty)
+      assert(Array.isArray(result), 'Result should be an array');
+    }
+  },
+
+  {
+    name: `${testName} - Should apply LIMIT correctly`,
+    run: async () => {
+      // Arrange: Set limit to 2
+      const result = await UsuarioModel.findAll({ limit: 2 });
+      
+      // Assert: Should return at most 2 records
+      assert(result.length <= 2, `Expected at most 2 records, got ${result.length}`);
+    }
+  },
+
+  {
+    name: `${testName} - Should apply LIMIT and OFFSET correctly`,
+    run: async () => {
+      // Arrange: Get page 2 with 2 records per page
+      const page1 = await UsuarioModel.findAll({ limit: 2, offset: 0 });
+      const page2 = await UsuarioModel.findAll({ limit: 2, offset: 2 });
+      
+      // Assert: Different records on each page (if data exists)
+      if (page1.length > 0 && page2.length > 0) {
+        const page1Ids = page1.map(u => u.id_usuario);
+        const page2Ids = page2.map(u => u.id_usuario);
+        
+        const hasDifference = !page1Ids.every(id => page2Ids.includes(id));
+        assert(hasDifference || page1.length < 2, 'Pagination should return different records');
+      }
+    }
+  },
+
+  {
+    name: `${testName} - Should reject negative LIMIT`,
+    run: async () => {
+      // Arrange & Act & Assert: Should throw error for negative limit
+      try {
+        await UsuarioModel.findAll({ limit: -1 });
+        assert.fail('Should have thrown error for negative limit');
+      } catch (error) {
+        assert(
+          error.message.includes('limit must be a non-negative integer'),
+          `Expected error about limit, got: ${error.message}`
+        );
+      }
+    }
+  },
+
+  {
+    name: `${testName} - Should reject negative OFFSET`,
+    run: async () => {
+      // Arrange & Act & Assert: Should throw error for negative offset
+      try {
+        await UsuarioModel.findAll({ limit: 10, offset: -1 });
+        assert.fail('Should have thrown error for negative offset');
+      } catch (error) {
+        assert(
+          error.message.includes('offset must be a non-negative integer'),
+          `Expected error about offset, got: ${error.message}`
+        );
+      }
+    }
+  },
+
+  {
+    name: `${testName} - Should reject non-numeric LIMIT`,
+    run: async () => {
+      // Arrange & Act & Assert: Should throw error for non-numeric limit
+      try {
+        await UsuarioModel.findAll({ limit: 'abc' });
+        assert.fail('Should have thrown error for non-numeric limit');
+      } catch (error) {
+        assert(
+          error.message.includes('limit must be a non-negative integer'),
+          `Expected error about limit validation, got: ${error.message}`
+        );
+      }
+    }
+  },
+
+  {
+    name: `${testName} - Should handle LIMIT with search filter`,
+    run: async () => {
+      // Arrange: Add search with pagination
+      const result = await UsuarioModel.findAll({ 
+        search: 'test', 
+        limit: 5 
+      });
+      
+      // Assert: Should return array with max 5 records
+      assert(Array.isArray(result), 'Result should be an array');
+      assert(result.length <= 5, 'Should respect limit even with search filter');
+    }
+  },
+
+  {
+    name: `${testName} - Should handle LIMIT with role filter`,
+    run: async () => {
+      // Arrange: Add role filter with pagination
+      const result = await UsuarioModel.findAll({ 
+        rol: 'ciudadano', 
+        limit: 10,
+        offset: 0
+      });
+      
+      // Assert: Should return array with correct constraints
+      assert(Array.isArray(result), 'Result should be an array');
+      assert(result.length <= 10, 'Should respect limit');
+      result.forEach(user => {
+        assert.strictEqual(user.rol, 'ciudadano', 'Should filter by role');
+      });
+    }
+  },
+
+  {
+    name: `${testName} - Should handle OFFSET without LIMIT (should be ignored)`,
+    run: async () => {
+      // Arrange: Pass offset without limit
+      const result = await UsuarioModel.findAll({ offset: 5 });
+      
+      // Assert: Should return all records (offset ignored without limit)
+      assert(Array.isArray(result), 'Result should be an array');
+    }
+  },
+
+  {
+    name: `${testName} - Should handle zero LIMIT`,
+    run: async () => {
+      // Arrange & Act
+      const result = await UsuarioModel.findAll({ limit: 0 });
+      
+      // Assert: Valid but returns no records
+      assert(Array.isArray(result), 'Result should be an array');
+      assert.strictEqual(result.length, 0, 'LIMIT 0 should return no records');
+    }
+  }
+];
+
+const isMainModule = process.argv[1] === fileURLToPath(import.meta.url);
+
+if (isMainModule) {
+  let failed = 0;
+
+  for (const test of tests) {
+    try {
+      await test.run();
+      console.log(`[PASS] ${test.name}`);
+    } catch (error) {
+      failed++;
+      console.error(`[FAIL] ${test.name}`);
+      console.error(`  ${error.message}`);
+    }
+  }
+
+  process.exit(failed > 0 ? 1 : 0);
+}
+</file>
+
+<file path="tests/README.md">
+# [TESTS] Tests - Backend GreenAlert
+
+Tests automatizados y documentación centralizada para validar funcionalidades del Backend.
+
+---
+
+## [STRUCTURE] Estructura
+
+```
+tests/
+├── config/
+│   └── email-config.test.js       (8 tests - Configuración de email)
+├── email/
+│   ├── verification.test.js       (5 tests - Verificación de email)
+│   └── welcome.test.js            (1 test - Email de bienvenida)
+├── auth/
+│   ├── register.test.js           (3 tests - Registro de usuario)
+│   ├── login.test.js              (placeholder)
+│   └── password-reset.test.js     (placeholder)
+├── run-all.js                     (Test runner)
+└── README.md                       (Este archivo)
+
+docs/tests/                         [DOCS] DOCUMENTACIÓN CENTRALIZADA
+├── INDEX.md                        (Índice de todos los tests)
+├── EMAIL_CONFIG.md                 (Detalles - Config centralizada)
+├── EMAIL_VERIFICATION.md           (Detalles - Verificación email)
+├── EMAIL_WELCOME.md                (Detalles - Email bienvenida)
+├── AUTH_REGISTER.md                (Detalles - Registro usuarios)
+└── MANUAL_EMAIL_CONFIG.md          (Pruebas manuales)
+```
+
+---
+
+## 🚀 Ejecutar Tests
+
+### Todos los tests
+```bash
+npm test
+```
+
+`npm test` ejecuta la suite unitaria estable con `node:test`.
+
+### Runner legacy
+```bash
+node tests/run-all.js
+```
+
+### Tests específicos por categoría
+```bash
+# Solo tests de config
+node tests/run-all.js config
+
+# Solo tests de email
+node tests/run-all.js email
+
+# Solo tests de auth
+node tests/run-all.js auth
+
+# Búsqueda específica
+node tests/run-all.js verification
+node tests/run-all.js register
+```
+
+### Test individual
+```bash
+node tests/config/email-config.test.js
+node tests/email/verification.test.js
+node tests/auth/register.test.js
+```
+
+---
+
+## 📊 Cobertura Actual
+
+| Componente | Tests | Estado |
+|---|---|---|
+| **Config Email** | 8 | ✅ |
+| **Email Verification** | 5 | ✅ |
+| **Email Welcome** | 1 | ✅ |
+| **Auth Register** | 3 | ✅ |
+| **Auth Login** | - | ⏳ |
+| **Password Reset** | - | ⏳ |
+| **Total** | **17** | ✅ |
+
+---
+
+## [DOCS] Documentación Detallada
+
+Cada test tiene documentación técnica completa en `docs/tests/`:
+
+- **[INDEX.md](../docs/tests/INDEX.md)** - Índice global y guía completa de todos los tests
+
+### Tests de Configuración
+- **[EMAIL_CONFIG.md](../docs/tests/EMAIL_CONFIG.md)** - 8 tests detallados de validación de email
+
+### Tests de Email
+- **[EMAIL_VERIFICATION.md](../docs/tests/EMAIL_VERIFICATION.md)** - Flujo de verificación
+- **[EMAIL_WELCOME.md](../docs/tests/EMAIL_WELCOME.md)** - Correo de bienvenida
+
+### Tests de Autenticación
+- **[AUTH_REGISTER.md](../docs/tests/AUTH_REGISTER.md)** - Validaciones de registro
+
+### Pruebas Manuales
+- **[MANUAL_EMAIL_CONFIG.md](../docs/tests/MANUAL_EMAIL_CONFIG.md)** - Verificaciones paso a paso
+
+---
+
+## [PASS] Ejemplo de Ejecución
+
+### Input
+```bash
+node tests/run-all.js config
+```
+
+### Output
+```
+[TESTS] TESTS: Configuración de Email (email.config.js)
+
+    "test:email": "node tests/email/verification.test.js",
+    "test:auth": "node tests/auth/register.test.js"
+  }
+}
+```
+
+### Requisitos
+- Node.js 14+
+- Backend corriendo en http://localhost:3000
+- .env configurado con SMTP (para tests de email)
+- BD con tablas requeridas
+
+## Test Scripts incluidos
+
+### Email
+- `verification.test.js` - Verificación de email (5 tests)
+- `welcome.test.js` - Email de bienvenida
+
+### Auth
+- `register.test.js` - Registro de usuario
+- `login.test.js` - Login
+- `password-reset.test.js` - Reseteo de contraseña
+
+## Reportes
+
+Los tests reportan:
+- Status HTTP
+- Validaciones funcionales
+- Errores esperados
+- Estado final en BD
+
+Formato:
+```
+✓ Test passed
+✗ Test failed
+
+Results:
+Total: 20
+Passed: 18
+Failed: 2
+```
+
+## Agregar Nuevos Tests
+
+1. Crear archivo en la carpeta correspondiente: `tests/{feature}/{action}.test.js`
+2. Usar el mismo patrón de colores y logging
+3. Exportar función de test para `run-all.js`
+4. Documentar en README
+5. Agregar a package.json scripts
+
+## Documentación Detallada
+
+Ver archivos en [Backend/docs/](../docs/):
+- `TEST_VERIFICACION_EMAIL.md` - Tests manuales paso a paso
+- `VERIFICACION_EMAIL.md` - Implementación técnica
+</file>
+
+<file path="tests/unit/categoria-admin-crud.test.js">
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  actualizarCategoria,
+  cambiarEstadoCategoria,
+  crearCategoria,
+} from '../../src/controllers/categoria-riesgo.controller.js';
+import { CategoriaRiesgoModel } from '../../src/models/categoria-riesgo.model.js';
+
+const createResponse = () => ({
+  statusCode: null,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+});
+
+test('crearCategoria crea una categoria valida', async (t) => {
+  let findCalls = 0;
+  t.mock.method(CategoriaRiesgoModel, 'findByCodigoIncludingInactive', async (codigo) => {
+    findCalls += 1;
+    if (findCalls === 1) {
+      assert.equal(codigo, 'calidad_aire');
+      return null;
+    }
+
+    return {
+      id_categoria: 10,
+      codigo,
+      nombre: 'Calidad del aire',
+      activo: 1,
+    };
+  });
+  t.mock.method(CategoriaRiesgoModel, 'create', async () => 10);
+
+  const req = {
+    body: {
+      codigo: ' Calidad_Aire ',
+      nombre: 'Calidad del aire',
+      descripcion: 'Reportes sobre contaminacion atmosferica',
+      color_hex: '#16a34a',
+      activo: true,
+    },
+  };
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await crearCategoria(req, res, next);
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(CategoriaRiesgoModel.create.mock.callCount(), 1);
+  assert.deepEqual(CategoriaRiesgoModel.create.mock.calls[0].arguments[0], {
+    codigo: 'calidad_aire',
+    nombre: 'Calidad del aire',
+    descripcion: 'Reportes sobre contaminacion atmosferica',
+    color_hex: '#16a34a',
+    activo: true,
+  });
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('crearCategoria rechaza codigo duplicado', async (t) => {
+  t.mock.method(CategoriaRiesgoModel, 'findByCodigoIncludingInactive', async () => ({
+    codigo: 'inundacion',
+  }));
+  t.mock.method(CategoriaRiesgoModel, 'create', async () => {
+    throw new Error('No debe crear categorias duplicadas');
+  });
+
+  const req = {
+    body: {
+      codigo: 'inundacion',
+      nombre: 'Inundacion',
+    },
+  };
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await crearCategoria(req, res, next);
+
+  assert.equal(res.statusCode, 409);
+  assert.equal(res.body.message, 'Ya existe una categoria con ese codigo.');
+  assert.equal(CategoriaRiesgoModel.create.mock.callCount(), 0);
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('actualizarCategoria actualiza metadata permitida', async (t) => {
+  t.mock.method(CategoriaRiesgoModel, 'findByCodigoIncludingInactive', async (codigo) => ({
+    id_categoria: 5,
+    codigo,
+    nombre: 'Categoria existente',
+    activo: 1,
+  }));
+  t.mock.method(CategoriaRiesgoModel, 'updateByCodigo', async () => true);
+
+  const req = {
+    params: { codigo: 'inundacion' },
+    body: {
+      nombre: 'Inundaciones',
+      color_hex: '#2563eb',
+      nivel_prioridad_default: 2,
+    },
+  };
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await actualizarCategoria(req, res, next);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(CategoriaRiesgoModel.updateByCodigo.mock.callCount(), 1);
+  assert.equal(CategoriaRiesgoModel.updateByCodigo.mock.calls[0].arguments[0], 'inundacion');
+  assert.deepEqual(CategoriaRiesgoModel.updateByCodigo.mock.calls[0].arguments[1], {
+    nombre: 'Inundaciones',
+    color_hex: '#2563eb',
+    nivel_prioridad_default: 2,
+  });
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('cambiarEstadoCategoria activa o desactiva categoria', async (t) => {
+  t.mock.method(CategoriaRiesgoModel, 'findByCodigoIncludingInactive', async (codigo) => ({
+    id_categoria: 5,
+    codigo,
+    nombre: 'Inundacion',
+    activo: 0,
+  }));
+  t.mock.method(CategoriaRiesgoModel, 'updateActivoByCodigo', async () => true);
+
+  const req = {
+    params: { codigo: 'inundacion' },
+    body: { activo: false },
+  };
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await cambiarEstadoCategoria(req, res, next);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(CategoriaRiesgoModel.updateActivoByCodigo.mock.callCount(), 1);
+  assert.deepEqual(CategoriaRiesgoModel.updateActivoByCodigo.mock.calls[0].arguments, [
+    'inundacion',
+    false,
+  ]);
+  assert.equal(next.mock.callCount(), 0);
+});
+</file>
+
+<file path="tests/unit/categoria-severidad-stats.test.js">
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { obtenerEstadisticasSeveridad } from '../../src/controllers/categoria-riesgo.controller.js';
+import { CategoriaRiesgoModel } from '../../src/models/categoria-riesgo.model.js';
+import { ReporteModel } from '../../src/models/reporte.model.js';
+
+const createResponse = () => ({
+  statusCode: null,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+});
+
+test('obtenerEstadisticasSeveridad usa una consulta agrupada y conserva formato de respuesta', async (t) => {
+  t.mock.method(CategoriaRiesgoModel, 'getEstadisticasPorSeveridad', async () => ([
+    {
+      codigo: 'inundacion',
+      nombre: 'Inundacion',
+      icono: 'waves',
+      color_hex: '#2563eb',
+      bajo: 1,
+      medio: 2,
+      alto: 3,
+      critico: 4,
+    },
+    {
+      codigo: 'residuos',
+      nombre: 'Residuos',
+      icono: 'trash',
+      color_hex: '#16a34a',
+      bajo: 0,
+      medio: 5,
+      alto: 0,
+      critico: 1,
+    },
+  ]));
+  t.mock.method(ReporteModel, 'findAll', async () => {
+    throw new Error('No debe consultar reportes por categoria');
+  });
+
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await obtenerEstadisticasSeveridad({}, res, next);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body.data.estadisticasPorSeveridad.inundacion, {
+    nombre_categoria: 'Inundacion',
+    icono: 'waves',
+    color: '#2563eb',
+    por_severidad: {
+      bajo: 1,
+      medio: 2,
+      alto: 3,
+      critico: 4,
+    },
+  });
+  assert.deepEqual(res.body.data.estadisticasPorSeveridad.residuos.por_severidad, {
+    bajo: 0,
+    medio: 5,
+    alto: 0,
+    critico: 1,
+  });
+  assert.equal(CategoriaRiesgoModel.getEstadisticasPorSeveridad.mock.callCount(), 1);
+  assert.equal(ReporteModel.findAll.mock.callCount(), 0);
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('CategoriaRiesgoModel.getEstadisticasPorSeveridad usa agregacion agrupada', () => {
+  const source = CategoriaRiesgoModel.getEstadisticasPorSeveridad.toString();
+
+  assert.match(source, /SUM\(CASE WHEN r\.nivel_severidad = 'bajo'/);
+  assert.match(source, /GROUP BY cr\.id_categoria/);
+  assert.doesNotMatch(source, /ReporteModel\.findAll/);
+});
+</file>
+
+<file path="tests/unit/chatbot-conversacional.test.js">
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { enviarMensajeChatbot, clearChatbotRateLimit } from '../../src/controllers/chatbot.controller.js';
+import { detectIntent, buildOfflineResponse } from '../../src/services/chatbot-offline.js';
+import {
+  clearChatbotCache,
+  generarRespuestaChatbot,
+  getChatbotCacheSize,
+} from '../../src/services/chatbot.service.js';
+import { ReporteModel } from '../../src/models/reporte.model.js';
+
+const createResponse = () => ({
+  statusCode: null,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+});
+
+const mockContextQueries = (t) => {
+  t.mock.method(ReporteModel, 'getStats', async () => ({
+    total_reportes: 12,
+    municipios_activos: 3,
+  }));
+  t.mock.method(ReporteModel, 'findByUsuario', async () => ([
+    { id_reporte: 1, estado: 'pendiente', titulo: 'Reporte propio' },
+  ]));
+  t.mock.method(ReporteModel, 'countByUsuario', async () => 1);
+  t.mock.method(ReporteModel, 'findParaPrediccion', async () => []);
+};
+
+test('detectIntent reconoce intents principales', () => {
+  assert.equal(detectIntent('Quiero crear un reporte con foto'), 'reportes');
+  assert.equal(detectIntent('Hay alertas cerca de mi ubicacion?'), 'alertas');
+  assert.equal(detectIntent('Cuantos reportes tengo?'), 'mis_reportes');
+  assert.equal(detectIntent('Como verifico mi correo?'), 'verificacion');
+  assert.equal(detectIntent('Recuperar password'), 'recuperacion');
+});
+
+test('motor offline responde con contexto de usuario cuando hay JWT', () => {
+  const result = buildOfflineResponse({
+    mensaje: 'cuantos reportes tengo?',
+    contexto: {
+      global: { total_reportes: 12, municipios_activos: 3 },
+      usuario: { total_reportes: 2, reportes: [] },
+      alertasZona: [],
+    },
+  });
+
+  assert.equal(result.intent, 'mis_reportes');
+  assert.match(result.respuesta, /Tienes 2 reporte/);
+  assert.equal(result.fuente, 'offline');
+  assert.deepEqual(result.cards, []);
+});
+
+test('generarRespuestaChatbot funciona offline y usa cache', async (t) => {
+  clearChatbotCache();
+  mockContextQueries(t);
+
+  const first = await generarRespuestaChatbot({
+    mensaje: 'Que son las zonas de riesgo?',
+    sessionId: 's1',
+    user: { sub: 7 },
+  });
+  const second = await generarRespuestaChatbot({
+    mensaje: 'Que son las zonas de riesgo?',
+    sessionId: 's1',
+    user: { sub: 7 },
+  });
+
+  assert.equal(first.fuente, 'offline');
+  assert.equal(first.cache, false);
+  assert.equal(second.cache, true);
+  assert.equal(getChatbotCacheSize(), 1);
+  assert.equal(ReporteModel.getStats.mock.callCount(), 1);
+});
+
+test('enviarMensajeChatbot valida mensaje requerido y maximo 500 caracteres', async (t) => {
+  clearChatbotRateLimit();
+
+  const missingRes = createResponse();
+  await enviarMensajeChatbot({ body: {}, ip: '1.1.1.1' }, missingRes, t.mock.fn());
+
+  assert.equal(missingRes.statusCode, 400);
+  assert.equal(missingRes.body.message, 'El mensaje es requerido.');
+
+  const longRes = createResponse();
+  await enviarMensajeChatbot({
+    body: { mensaje: 'a'.repeat(501) },
+    ip: '1.1.1.2',
+  }, longRes, t.mock.fn());
+
+  assert.equal(longRes.statusCode, 400);
+  assert.equal(longRes.body.message, 'El mensaje no puede superar 500 caracteres.');
+});
+
+test('enviarMensajeChatbot aplica rate limit por sessionId', async (t) => {
+  clearChatbotCache();
+  clearChatbotRateLimit();
+  mockContextQueries(t);
+
+  for (let index = 0; index < 20; index += 1) {
+    const res = createResponse();
+    await enviarMensajeChatbot({
+      body: { mensaje: `Hola ${index}`, sessionId: 'limit-session' },
+      ip: '2.2.2.2',
+    }, res, t.mock.fn());
+    assert.notEqual(res.statusCode, 429);
+  }
+
+  const limited = createResponse();
+  await enviarMensajeChatbot({
+    body: { mensaje: 'mensaje final', sessionId: 'limit-session' },
+    ip: '2.2.2.2',
+  }, limited, t.mock.fn());
+
+  assert.equal(limited.statusCode, 429);
+  assert.equal(limited.body.message, 'Demasiados mensajes. Intenta nuevamente en un minuto.');
+});
+
+test('enviarMensajeChatbot conserva formato esperado por frontend', async (t) => {
+  clearChatbotCache();
+  clearChatbotRateLimit();
+  mockContextQueries(t);
+
+  const res = createResponse();
+  await enviarMensajeChatbot({
+    body: { mensaje: 'Como crear un reporte?', sessionId: 'fmt' },
+    user: { sub: 7 },
+    ip: '3.3.3.3',
+  }, res, t.mock.fn());
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.data.sessionId, 'fmt');
+  assert.equal(typeof res.body.data.respuesta, 'string');
+  assert.equal(res.body.data.intent, 'reportes');
+  assert.equal(res.body.data.fuente, 'offline');
+  assert.ok(Array.isArray(res.body.data.sugerencias));
+  assert.ok(Array.isArray(res.body.data.cards));
+  assert.ok(['optimo', 'alerta'].includes(res.body.data.estadoAmbiental));
+  assert.equal(typeof res.body.data.latencia_ms, 'number');
+});
+</file>
+
+<file path="tests/unit/clasificacion-ia.test.js">
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { clasificarImagen } from '../../src/services/clasificacion.service.js';
+import { analizarImagen, createReporte } from '../../src/controllers/reporte.controller.js';
+import { CategoriaRiesgoModel } from '../../src/models/categoria-riesgo.model.js';
+import { EvidenciaModel } from '../../src/models/evidencia.model.js';
+import { normalizeReporteIA, ReporteModel } from '../../src/models/reporte.model.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const testsDir = path.dirname(__filename);
+
+const createResponse = () => ({
+  statusCode: null,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+});
+
+const createValidRequest = (overrides = {}) => ({
+  user: { sub: 7 },
+  body: {
+    tipo_contaminacion: 'agua',
+    nivel_severidad: 'alto',
+    titulo: 'Reporte con IA',
+    descripcion: 'Vertimiento en rio',
+    direccion: 'Calle 10',
+    municipio: 'Valledupar',
+    departamento: 'Cesar',
+    latitud: 10.45,
+    longitud: -73.25,
+    ...overrides,
+  },
+});
+
+const mockReporteCreate = (t) => {
+  t.mock.method(CategoriaRiesgoModel, 'esValido', async () => true);
+  t.mock.method(ReporteModel, 'create', async () => 15);
+  t.mock.method(ReporteModel, 'findById', async () => ({
+    id_reporte: 15,
+    tipo_contaminacion: 'agua',
+    estado: 'pendiente',
+  }));
+  t.mock.method(ReporteModel, 'updateIaAnalysis', async () => true);
+  t.mock.method(EvidenciaModel, 'create', async () => 1);
+};
+
+test('clasificarImagen devuelve contrato esperado con fallback deterministico', async () => {
+  const result = await clasificarImagen({
+    originalname: 'foto-rio-agua-contaminada.jpg',
+    mimetype: 'image/jpeg',
+  });
+
+  assert.equal(result.categoria, 'agua');
+  assert.equal(result.nombre, 'Contaminacion de Agua');
+  assert.equal(result.subcategoria, 'vertimiento');
+  assert.equal(result.severidad, 'alto');
+  assert.ok(result.confianza > 0);
+  assert.ok(result.confianza_subcategoria > 0);
+  assert.ok(result.confianza_severidad > 0);
+  assert.ok(result.etiquetas.includes('agua'));
+
+  const fallback = await clasificarImagen({ originalname: 'sin-pistas.jpg' });
+  assert.equal(fallback.categoria, 'otro');
+  assert.equal(fallback.nombre, 'Otro');
+  assert.deepEqual(fallback.etiquetas, ['otro']);
+});
+
+test('analizarImagen exige imagen', async (t) => {
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await analizarImagen({ file: null }, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.message, 'Imagen requerida.');
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('analizarImagen clasifica y borra archivo temporal', async (t) => {
+  const tempPath = path.join(testsDir, 'tmp-analizar-imagen.jpg');
+  await fs.writeFile(tempPath, 'fake image bytes');
+
+  const req = {
+    file: {
+      path: tempPath,
+      originalname: 'agua-rio.jpg',
+      mimetype: 'image/jpeg',
+    },
+  };
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await analizarImagen(req, res, next);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.data.categoria, 'agua');
+  assert.equal(res.body.data.nombre, 'Contaminacion de Agua');
+  assert.equal(res.body.data.severidad, 'alto');
+  await assert.rejects(() => fs.access(tempPath));
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('createReporte persiste payload IA valido aceptado por el usuario', async (t) => {
+  mockReporteCreate(t);
+
+  const req = createValidRequest({
+    ia_procesado: '1',
+    ia_confianza: '0.82',
+    ia_etiquetas: JSON.stringify(['agua', 'vertimiento']),
+  });
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await createReporte(req, res, next);
+
+  assert.equal(res.statusCode, 201);
+  assert.deepEqual(ReporteModel.updateIaAnalysis.mock.calls[0].arguments[1], {
+    etiquetas: ['agua', 'vertimiento'],
+    confianza: 0.82,
+    procesado: true,
+  });
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('createReporte rechaza payload IA invalido sin crear reporte', async (t) => {
+  t.mock.method(CategoriaRiesgoModel, 'esValido', async () => {
+    throw new Error('No debe validar categoria con IA invalida');
+  });
+  t.mock.method(ReporteModel, 'create', async () => {
+    throw new Error('No debe insertar reporte con IA invalida');
+  });
+
+  const req = createValidRequest({
+    ia_procesado: '1',
+    ia_confianza: '0.82',
+    ia_etiquetas: '{json-invalido',
+  });
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await createReporte(req, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.message, 'ia_etiquetas debe ser un arreglo JSON valido.');
+  assert.equal(ReporteModel.create.mock.callCount(), 0);
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('normalizeReporteIA expone IA normalizada y no JSON crudo', () => {
+  const reporte = normalizeReporteIA({
+    id_reporte: 1,
+    ia_etiquetas: '["agua","rio"]',
+    ia_confianza: '0.75',
+    ia_procesado: 1,
+  });
+
+  assert.deepEqual(reporte.ia_etiquetas, ['agua', 'rio']);
+  assert.equal(reporte.ia_confianza, 0.75);
+  assert.equal(reporte.ia_procesado, true);
+
+  const invalid = normalizeReporteIA({
+    id_reporte: 2,
+    ia_etiquetas: 'json roto',
+    ia_confianza: null,
+    ia_procesado: 0,
+  });
+
+  assert.deepEqual(invalid.ia_etiquetas, []);
+  assert.equal(invalid.ia_confianza, null);
+  assert.equal(invalid.ia_procesado, false);
+});
+</file>
+
+<file path="tests/unit/database-schema.test.js">
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const backendDir = path.resolve(path.dirname(__filename), '../..');
+
+const readSchema = () => fs.readFile(
+  path.join(backendDir, 'DATABASE_SCHEMA_COMPLETE.sql'),
+  'utf8'
+);
+
+test('schema completo incluye tablas de soporte requeridas por el backend', async () => {
+  const schema = await readSchema();
+
+  for (const table of [
+    'usuarios',
+    'categorias_riesgo',
+    'reportes',
+    'evidencias',
+    'refresh_tokens',
+    'reporte_likes',
+    'reporte_vistas',
+    'notificaciones',
+  ]) {
+    assert.match(schema, new RegExp(`CREATE TABLE IF NOT EXISTS ${table} \\(`));
+  }
+});
+
+test('schema completo conserva columnas actuales de auth, IA y moderacion', async () => {
+  const schema = await readSchema();
+
+  for (const column of [
+    'google_id VARCHAR(255) UNIQUE NULL',
+    'facebook_id VARCHAR(255) UNIQUE NULL',
+    'notification_preferences JSON NULL',
+    'avatar_url VARCHAR(255) NULL',
+    'email_verificado BOOLEAN DEFAULT FALSE',
+    'email_verification_token VARCHAR(64) NULL',
+    'subcategoria VARCHAR(100) NULL',
+    "estado ENUM('pendiente', 'en_revision', 'verificado', 'en_proceso', 'rechazado', 'resuelto')",
+    'comentario_moderacion TEXT NULL',
+    'ia_etiquetas JSON NULL',
+    'ia_confianza DECIMAL(5, 2) NULL',
+    'ia_procesado BOOLEAN DEFAULT FALSE',
+  ]) {
+    assert.ok(schema.includes(column), column);
+  }
+});
+
+test('schema completo incluye indices de prediccion', async () => {
+  const schema = await readSchema();
+
+  assert.ok(schema.includes('INDEX idx_reportes_estado_created_at (estado, created_at)'));
+  assert.ok(schema.includes('INDEX idx_reportes_tipo_created_at (tipo_contaminacion, created_at)'));
+  assert.ok(schema.includes('INDEX idx_reportes_latitud_longitud (latitud, longitud)'));
+});
+
+test('migraciones no tienen numeracion duplicada ni scripts sueltos de notificaciones', async () => {
+  const migrationsDir = path.join(backendDir, 'migrations');
+  const files = await fs.readdir(migrationsDir);
+  const numbered = files
+    .map((file) => file.match(/^(\d{3})_/)?.[1])
+    .filter(Boolean);
+  const duplicateNumbers = numbered.filter((number, index) => numbered.indexOf(number) !== index);
+
+  assert.deepEqual(duplicateNumbers, []);
+  assert.equal(files.includes('create_notificaciones.sql'), false);
+  assert.equal(files.includes('012_create_notificaciones.sql'), true);
+});
+</file>
+
+<file path="tests/unit/email-template.test.js">
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { generarTemplateBaseCorreo } from '../../src/services/email.service.js';
+
+test('generarTemplateBaseCorreo incluye titulo, subtitulo y contenido', () => {
+  const html = generarTemplateBaseCorreo({
+    title: 'Verificacion',
+    subtitle: 'Cuenta',
+    previewText: 'Previsualizacion',
+    content: '<p>Contenido seguro</p>',
+  });
+
+  assert.match(html, /Verificacion/);
+  assert.match(html, /Cuenta/);
+  assert.match(html, /Previsualizacion/);
+  assert.match(html, /Contenido seguro/);
+});
+
+test('generarTemplateBaseCorreo escapa datos controlados por parametros', () => {
+  const html = generarTemplateBaseCorreo({
+    title: '<script>alert(1)</script>',
+    subtitle: '"subtitulo"',
+    previewText: '<preview>',
+    content: '<p>Contenido interno</p>',
+    actionUrl: 'https://example.com?a=<x>',
+    actionText: 'Click <aqui>',
+  });
+
+  assert.doesNotMatch(html, /<script>alert\(1\)<\/script>/);
+  assert.match(html, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
+  assert.match(html, /&quot;subtitulo&quot;/);
+  assert.match(html, /Click &lt;aqui&gt;/);
+  assert.match(html, /https:\/\/example\.com\?a=&lt;x&gt;/);
+});
+</file>
+
+<file path="tests/unit/ia-service.test.js">
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { analyzeReporte } from '../../src/services/ia.service.js';
+
+test('analyzeReporte genera etiquetas, confianza y marca procesado', () => {
+  const result = analyzeReporte({
+    tipo_contaminacion: 'inundacion',
+    nivel_severidad: 'alto',
+    titulo: 'Vertimiento de agua contaminada en rio',
+    descripcion: 'Hay olor fuerte y residuos cerca de la quebrada.',
+    latitud: 1.25,
+    longitud: -76.5,
+  });
+
+  assert.equal(result.procesado, true);
+  assert.ok(result.confianza >= 0.1);
+  assert.ok(result.confianza <= 0.99);
+  assert.ok(result.etiquetas.includes('agua'));
+  assert.ok(result.etiquetas.includes('residuos'));
+  assert.ok(result.etiquetas.includes('inundacion'));
+  assert.ok(result.etiquetas.includes('severidad_alto'));
+  assert.equal(result.resumen.hasLocation, true);
+});
+
+test('analyzeReporte funciona con datos minimos', () => {
+  const result = analyzeReporte({
+    tipo_contaminacion: 'ruido',
+    nivel_severidad: 'medio',
+    titulo: 'Reporte ambiental',
+  });
+
+  assert.equal(result.procesado, true);
+  assert.deepEqual(result.etiquetas, ['ruido', 'severidad_medio']);
+  assert.equal(result.resumen.hasLocation, false);
+});
+</file>
+
+<file path="tests/unit/likes-vistas-trending.test.js">
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { LikeModel } from '../../src/models/like.model.js';
+import { ReporteModel } from '../../src/models/reporte.model.js';
+import { EvidenciaModel } from '../../src/models/evidencia.model.js';
+import { UsuarioModel } from '../../src/models/usuario.model.js';
+import pool from '../../src/config/database.js';
+import { clearSchemaCompatCache } from '../../src/config/schema-compat.js';
+import {
+  getReporteById,
+  getReportes,
+  getTrendingReportes,
+  toggleLikeReporte,
+} from '../../src/controllers/reporte.controller.js';
+
+const createResponse = () => ({
+  statusCode: null,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+});
+
+const createConnection = ({ likedInitially = false } = {}) => {
+  let liked = likedInitially;
+  let votos = liked ? 1 : 0;
+
+  return {
+    beginTransaction: async () => {},
+    commit: async () => {},
+    rollback: async () => {},
+    release: () => {},
+    execute: async (sql) => {
+      if (String(sql).includes('SELECT id_like')) {
+        return [liked ? [{ id_like: 1 }] : []];
+      }
+
+      if (String(sql).includes('INSERT INTO reporte_likes')) {
+        liked = true;
+        votos += 1;
+        return [{ affectedRows: 1 }];
+      }
+
+      if (String(sql).includes('DELETE FROM reporte_likes')) {
+        liked = false;
+        votos = Math.max(0, votos - 1);
+        return [{ affectedRows: 1 }];
+      }
+
+      if (String(sql).includes('UPDATE reportes')) {
+        return [{ affectedRows: 1 }];
+      }
+
+      if (String(sql).includes('SELECT votos_relevancia')) {
+        return [[{ votos_relevancia: votos }]];
+      }
+
+      return [[]];
+    },
+  };
+};
+
+test('LikeModel.toggle alterna like y unlike para el mismo usuario', async (t) => {
+  clearSchemaCompatCache();
+  t.mock.method(pool, 'execute', async () => [[{ total: 1 }]]);
+  const connection = createConnection();
+  t.mock.method(pool, 'getConnection', async () => connection);
+
+  const liked = await LikeModel.toggle(10, 21);
+  const unliked = await LikeModel.toggle(10, 21);
+
+  assert.deepEqual(liked, { liked: true, votos_relevancia: 1 });
+  assert.deepEqual(unliked, { liked: false, votos_relevancia: 0 });
+});
+
+test('toggleLikeReporte prohibe like al propio reporte', async (t) => {
+  t.mock.method(ReporteModel, 'findById', async () => ({
+    id_reporte: 10,
+    id_usuario: 21,
+  }));
+  t.mock.method(LikeModel, 'toggle', async () => {
+    throw new Error('No debe crear like propio');
+  });
+
+  const req = {
+    params: { id: '10' },
+    user: { sub: 21 },
+  };
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await toggleLikeReporte(req, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.message, 'No puedes reaccionar a tu propio reporte.');
+  assert.equal(LikeModel.toggle.mock.callCount(), 0);
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('getReportes y getTrendingReportes agregan liked_by_me con sesion opcional', async (t) => {
+  const reportes = [
+    { id_reporte: 10, titulo: 'Reporte 10' },
+    { id_reporte: 11, titulo: 'Reporte 11', trending_score: 8 },
+  ];
+  t.mock.method(ReporteModel, 'findAll', async () => reportes);
+  t.mock.method(ReporteModel, 'countAll', async () => 2);
+  t.mock.method(ReporteModel, 'findTrending', async () => reportes);
+  t.mock.method(LikeModel, 'likedSet', async () => new Set([11]));
+
+  const listRes = createResponse();
+  await getReportes({ query: {}, user: { sub: 21 } }, listRes, t.mock.fn());
+
+  assert.equal(listRes.body.data.reportes[0].liked_by_me, false);
+  assert.equal(listRes.body.data.reportes[1].liked_by_me, true);
+
+  const trendingRes = createResponse();
+  await getTrendingReportes({ query: {}, user: { sub: 21 } }, trendingRes, t.mock.fn());
+
+  assert.equal(trendingRes.body.data.reportes[0].liked_by_me, false);
+  assert.equal(trendingRes.body.data.reportes[1].liked_by_me, true);
+});
+
+test('registrarVistaUsuario solo incrementa con primera vista persistida', async (t) => {
+  clearSchemaCompatCache();
+  const calls = [];
+  let firstInsert = true;
+
+  t.mock.method(pool, 'execute', async (sql) => {
+    calls.push(String(sql));
+    if (String(sql).includes('INFORMATION_SCHEMA.TABLES')) {
+      return [[{ total: 1 }]];
+    }
+
+    if (String(sql).includes('INSERT IGNORE INTO reporte_vistas')) {
+      const affectedRows = firstInsert ? 1 : 0;
+      firstInsert = false;
+      return [{ affectedRows }];
+    }
+
+    return [{ affectedRows: 1 }];
+  });
+  t.mock.method(ReporteModel, 'incrementarVistas', async () => {});
+
+  const first = await ReporteModel.registrarVistaUsuario(10, 21);
+  const second = await ReporteModel.registrarVistaUsuario(10, 21);
+
+  assert.equal(first, true);
+  assert.equal(second, false);
+  assert.equal(ReporteModel.incrementarVistas.mock.callCount(), 1);
+  assert.ok(calls.some((sql) => sql.includes('INSERT IGNORE INTO reporte_vistas')));
+});
+
+test('getReporteById aplica throttle de vistas anonimas por refresh inmediato', async (t) => {
+  t.mock.method(ReporteModel, 'findById', async () => ({
+    id_reporte: 10,
+    id_usuario: 99,
+    titulo: 'Reporte',
+  }));
+  t.mock.method(ReporteModel, 'incrementarVistas', async () => {});
+  t.mock.method(EvidenciaModel, 'findByReporte', async () => []);
+  t.mock.method(UsuarioModel, 'findById', async () => null);
+
+  const createReq = () => ({
+    params: { id: '10' },
+    query: {},
+    headers: { 'user-agent': 'test-agent' },
+    ip: '127.0.0.1',
+    get(header) {
+      return this.headers[String(header).toLowerCase()];
+    },
+  });
+
+  await getReporteById(createReq(), createResponse(), t.mock.fn());
+  await getReporteById(createReq(), createResponse(), t.mock.fn());
+
+  assert.equal(ReporteModel.incrementarVistas.mock.callCount(), 1);
+});
+
+test('findTrending devuelve trending_score numerico', async (t) => {
+  t.mock.method(pool, 'execute', async () => [[{
+    id_reporte: 10,
+    titulo: 'Reporte',
+    trending_score: '42',
+  }]]);
+
+  const [reporte] = await ReporteModel.findTrending();
+
+  assert.equal(reporte.trending_score, 42);
+});
+</file>
+
+<file path="tests/unit/logout-global-auth.test.js">
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import jwt from 'jsonwebtoken';
+import { verifyTokenWhenAllDevicesLogout } from '../../middlewares/auth.middleware.js';
+
+const createResponse = () => ({
+  statusCode: null,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+});
+
+test('logout individual no exige JWT cuando allDevices no esta activo', () => {
+  const req = {
+    body: { refreshToken: 'refresh-token' },
+    headers: {},
+  };
+  const res = createResponse();
+  let nextCalled = false;
+
+  verifyTokenWhenAllDevicesLogout(req, res, () => {
+    nextCalled = true;
+  });
+
+  assert.equal(nextCalled, true);
+  assert.equal(res.statusCode, null);
+});
+
+test('logout global exige JWT cuando allDevices es true', () => {
+  const req = {
+    body: { allDevices: true },
+    headers: {},
+  };
+  const res = createResponse();
+  let nextCalled = false;
+
+  verifyTokenWhenAllDevicesLogout(req, res, () => {
+    nextCalled = true;
+  });
+
+  assert.equal(nextCalled, false);
+  assert.equal(res.statusCode, 401);
+});
+
+test('logout global acepta JWT valido y llena req.user', () => {
+  process.env.JWT_SECRET = 'test-secret';
+
+  const token = jwt.sign(
+    { sub: 12, email: 'test@example.com', rol: 'ciudadano' },
+    process.env.JWT_SECRET
+  );
+  const req = {
+    body: { allDevices: true },
+    headers: {
+      authorization: `Bearer ${token}`,
+    },
+  };
+  const res = createResponse();
+  let nextCalled = false;
+
+  verifyTokenWhenAllDevicesLogout(req, res, () => {
+    nextCalled = true;
+  });
+
+  assert.equal(nextCalled, true);
+  assert.equal(req.user.sub, 12);
+  assert.equal(res.statusCode, null);
+});
+</file>
+
+<file path="tests/unit/notificacion.controller.test.js">
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import http from 'node:http';
+import notificacionRouter from '../../routes/notificacion.routes.js';
+import {
+  contadorNotificaciones,
+  eliminarNotificacion,
+  listarNotificaciones,
+  marcarLeida,
+  marcarTodasLeidas,
+} from '../../src/controllers/notificacion.controller.js';
+import { updateReporte } from '../../src/controllers/reporte.controller.js';
+import { NotificacionModel } from '../../src/models/notificacion.model.js';
+import { ReporteModel } from '../../src/models/reporte.model.js';
+
+const createResponse = () => ({
+  statusCode: null,
+  body: null,
+  headers: {},
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+  setHeader(key, value) {
+    this.headers[key] = value;
+  },
+});
+
+const createMemoryStore = () => {
+  let nextId = 1;
+  const rows = [];
+
+  const create = async (data) => {
+    const row = {
+      id_notificacion: nextId,
+      uuid: `notif-${nextId}`,
+      leida: false,
+      leida_at: null,
+      created_at: new Date(nextId * 1000),
+      referencia_tipo: null,
+      referencia_uuid: null,
+      link: null,
+      ...data,
+    };
+    nextId += 1;
+    rows.push(row);
+    return { id_notificacion: row.id_notificacion, uuid: row.uuid };
+  };
+
+  return {
+    rows,
+    create,
+    findByUsuario: async (id_usuario, { leida, limit = 20, offset = 0 } = {}) => {
+      let items = rows.filter((row) => Number(row.id_usuario) === Number(id_usuario));
+      if (leida === true || leida === false) {
+        items = items.filter((row) => row.leida === leida);
+      }
+      items = items.sort((a, b) => b.id_notificacion - a.id_notificacion);
+
+      const ownRows = rows.filter((row) => Number(row.id_usuario) === Number(id_usuario));
+      return {
+        items: items.slice(Number(offset) || 0, (Number(offset) || 0) + (Number(limit) || 20)),
+        meta: {
+          total: ownRows.length,
+          no_leidas: ownRows.filter((row) => !row.leida).length,
+          limit: Number(limit) || 20,
+          offset: Number(offset) || 0,
+        },
+      };
+    },
+    contarNoLeidas: async (id_usuario) => (
+      rows.filter((row) => Number(row.id_usuario) === Number(id_usuario) && !row.leida).length
+    ),
+    marcarLeida: async (uuid, id_usuario) => {
+      const row = rows.find((item) => item.uuid === uuid && Number(item.id_usuario) === Number(id_usuario));
+      if (!row) return false;
+      row.leida = true;
+      row.leida_at = new Date();
+      return true;
+    },
+    marcarTodasLeidas: async (id_usuario) => {
+      let count = 0;
+      for (const row of rows) {
+        if (Number(row.id_usuario) === Number(id_usuario) && !row.leida) {
+          row.leida = true;
+          row.leida_at = new Date();
+          count += 1;
+        }
+      }
+      return count;
+    },
+    eliminar: async (uuid, id_usuario) => {
+      const index = rows.findIndex((row) => row.uuid === uuid && Number(row.id_usuario) === Number(id_usuario));
+      if (index === -1) return false;
+      rows.splice(index, 1);
+      return true;
+    },
+  };
+};
+
+const mockNotificationModel = (t, store) => {
+  t.mock.method(NotificacionModel, 'create', store.create);
+  t.mock.method(NotificacionModel, 'findByUsuario', store.findByUsuario);
+  t.mock.method(NotificacionModel, 'contarNoLeidas', store.contarNoLeidas);
+  t.mock.method(NotificacionModel, 'marcarLeida', store.marcarLeida);
+  t.mock.method(NotificacionModel, 'marcarTodasLeidas', store.marcarTodasLeidas);
+  t.mock.method(NotificacionModel, 'eliminar', store.eliminar);
+};
+
+test('contador devuelve no leidas y aisla por usuario', async (t) => {
+  const store = createMemoryStore();
+  mockNotificationModel(t, store);
+  await store.create({ id_usuario: 1, tipo: 'sistema', titulo: 'A', mensaje: 'Uno' });
+  await store.create({ id_usuario: 1, tipo: 'sistema', titulo: 'B', mensaje: 'Dos' });
+  await store.create({ id_usuario: 2, tipo: 'sistema', titulo: 'C', mensaje: 'Tres' });
+
+  const res = createResponse();
+  await contadorNotificaciones({ user: { sub: 1 } }, res, t.mock.fn());
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.data.no_leidas, 2);
+  assert.equal(res.headers['Cache-Control'], 'no-store');
+});
+
+test('listado devuelve solo notificaciones del usuario autenticado', async (t) => {
+  const store = createMemoryStore();
+  mockNotificationModel(t, store);
+  await store.create({ id_usuario: 1, tipo: 'sistema', titulo: 'A', mensaje: 'Uno' });
+  await store.create({ id_usuario: 2, tipo: 'sistema', titulo: 'B', mensaje: 'Dos' });
+
+  const res = createResponse();
+  await listarNotificaciones({ user: { sub: 1 }, query: {} }, res, t.mock.fn());
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.data.items.length, 1);
+  assert.equal(res.body.data.items[0].id_usuario, 1);
+  assert.equal(res.body.data.meta.total, 1);
+});
+
+test('marcar leida solo modifica notificaciones propias', async (t) => {
+  const store = createMemoryStore();
+  mockNotificationModel(t, store);
+  const own = await store.create({ id_usuario: 1, tipo: 'sistema', titulo: 'A', mensaje: 'Uno' });
+  const other = await store.create({ id_usuario: 2, tipo: 'sistema', titulo: 'B', mensaje: 'Dos' });
+
+  const ownRes = createResponse();
+  await marcarLeida(
+    { user: { sub: 1 }, params: { uuid: own.uuid } },
+    ownRes,
+    t.mock.fn()
+  );
+  assert.equal(ownRes.statusCode, 200);
+  assert.equal(store.rows.find((row) => row.uuid === own.uuid).leida, true);
+
+  const otherRes = createResponse();
+  await marcarLeida(
+    { user: { sub: 1 }, params: { uuid: other.uuid } },
+    otherRes,
+    t.mock.fn()
+  );
+  assert.equal(otherRes.statusCode, 404);
+  assert.equal(store.rows.find((row) => row.uuid === other.uuid).leida, false);
+});
+
+test('marcar todas solo afecta al usuario actual', async (t) => {
+  const store = createMemoryStore();
+  mockNotificationModel(t, store);
+  await store.create({ id_usuario: 1, tipo: 'sistema', titulo: 'A', mensaje: 'Uno' });
+  await store.create({ id_usuario: 1, tipo: 'sistema', titulo: 'B', mensaje: 'Dos' });
+  await store.create({ id_usuario: 2, tipo: 'sistema', titulo: 'C', mensaje: 'Tres' });
+
+  const res = createResponse();
+  await marcarTodasLeidas({ user: { sub: 1 } }, res, t.mock.fn());
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.data.actualizadas, 2);
+  assert.equal(store.rows.filter((row) => row.id_usuario === 1 && !row.leida).length, 0);
+  assert.equal(store.rows.filter((row) => row.id_usuario === 2 && !row.leida).length, 1);
+});
+
+test('eliminar solo borra notificaciones propias', async (t) => {
+  const store = createMemoryStore();
+  mockNotificationModel(t, store);
+  const own = await store.create({ id_usuario: 1, tipo: 'sistema', titulo: 'A', mensaje: 'Uno' });
+  const other = await store.create({ id_usuario: 2, tipo: 'sistema', titulo: 'B', mensaje: 'Dos' });
+
+  const forbidden = createResponse();
+  await eliminarNotificacion(
+    { user: { sub: 1 }, params: { uuid: other.uuid } },
+    forbidden,
+    t.mock.fn()
+  );
+  assert.equal(forbidden.statusCode, 404);
+
+  const ok = createResponse();
+  await eliminarNotificacion(
+    { user: { sub: 1 }, params: { uuid: own.uuid } },
+    ok,
+    t.mock.fn()
+  );
+  assert.equal(ok.statusCode, 200);
+  assert.equal(store.rows.some((row) => row.uuid === own.uuid), false);
+  assert.equal(store.rows.some((row) => row.uuid === other.uuid), true);
+});
+
+test('sin JWT todas las rutas de notificaciones responden 401', async () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/notificaciones', notificacionRouter);
+  const server = await new Promise((resolve) => {
+    const instance = http.createServer(app);
+    instance.listen(0, () => resolve(instance));
+  });
+
+  try {
+    const { port } = server.address();
+    const cases = [
+      ['GET', '/notificaciones'],
+      ['GET', '/notificaciones/contador'],
+      ['PATCH', '/notificaciones/marcar-todas'],
+      ['PATCH', '/notificaciones/notif-1/leida'],
+      ['DELETE', '/notificaciones/notif-1'],
+    ];
+
+    for (const [method, path] of cases) {
+      const response = await fetch(`http://127.0.0.1:${port}${path}`, { method });
+      assert.equal(response.status, 401, `${method} ${path}`);
+    }
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test('updateReporte genera notificacion al dueno cuando cambia estado o comentario', async (t) => {
+  const reportes = [
+    {
+      id_reporte: 10,
+      uuid: 'reporte-uuid',
+      id_usuario: 7,
+      estado: 'pendiente',
+      titulo: 'Rio contaminado',
+      comentario_moderacion: null,
+    },
+    {
+      id_reporte: 10,
+      uuid: 'reporte-uuid',
+      id_usuario: 7,
+      estado: 'verificado',
+      titulo: 'Rio contaminado',
+      comentario_moderacion: 'Se valido evidencia.',
+    },
+  ];
+
+  t.mock.method(ReporteModel, 'findById', async () => reportes.shift());
+  t.mock.method(ReporteModel, 'update', async () => true);
+  t.mock.method(NotificacionModel, 'create', async () => ({ id_notificacion: 1, uuid: 'notif-1' }));
+
+  const res = createResponse();
+  await updateReporte(
+    {
+      params: { id: '10' },
+      user: { sub: 99, rol: 'moderador' },
+      body: {
+        estado: 'verificado',
+        comentario_moderacion: 'Se valido evidencia.',
+      },
+    },
+    res,
+    t.mock.fn()
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(NotificacionModel.create.mock.callCount(), 2);
+  assert.equal(NotificacionModel.create.mock.calls[0].arguments[0].id_usuario, 7);
+  assert.equal(NotificacionModel.create.mock.calls[0].arguments[0].tipo, 'reporte_estado');
+  assert.equal(NotificacionModel.create.mock.calls[1].arguments[0].tipo, 'reporte_comentario');
+});
+
+test('fallo al crear notificacion no rompe updateReporte', async (t) => {
+  const reportes = [
+    {
+      id_reporte: 11,
+      uuid: 'reporte-uuid-2',
+      id_usuario: 7,
+      estado: 'pendiente',
+      titulo: 'Basura acumulada',
+      comentario_moderacion: null,
+    },
+    {
+      id_reporte: 11,
+      uuid: 'reporte-uuid-2',
+      id_usuario: 7,
+      estado: 'en_revision',
+      titulo: 'Basura acumulada',
+      comentario_moderacion: null,
+    },
+  ];
+
+  t.mock.method(ReporteModel, 'findById', async () => reportes.shift());
+  t.mock.method(ReporteModel, 'update', async () => true);
+  t.mock.method(NotificacionModel, 'create', async () => {
+    throw new Error('tabla no disponible');
+  });
+  t.mock.method(console, 'error', () => {});
+
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await updateReporte(
+    {
+      params: { id: '11' },
+      user: { sub: 99, rol: 'admin' },
+      body: { estado: 'en_revision' },
+    },
+    res,
+    next
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(next.mock.callCount(), 0);
+});
+</file>
+
+<file path="tests/unit/notification-preferences.test.js">
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { updateNotifications } from '../../src/controllers/auth.controller.js';
+import {
+  DEFAULT_NOTIFICATION_PREFERENCES,
+  parseNotificationPreferences,
+  UsuarioModel,
+} from '../../src/models/usuario.model.js';
+
+const createResponse = () => ({
+  statusCode: null,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+});
+
+test('parseNotificationPreferences mezcla defaults con preferencias guardadas', () => {
+  assert.deepEqual(parseNotificationPreferences(null), DEFAULT_NOTIFICATION_PREFERENCES);
+  assert.deepEqual(
+    parseNotificationPreferences('{"email_alerts":false,"weekly_summary":true}'),
+    {
+      email_alerts: false,
+      push_notifications: false,
+      report_updates: true,
+      weekly_summary: true,
+    }
+  );
+});
+
+test('updateNotifications guarda preferencias y conserva valores existentes', async (t) => {
+  const existingPreferences = {
+    email_alerts: true,
+    push_notifications: false,
+    report_updates: true,
+    weekly_summary: false,
+  };
+
+  t.mock.method(UsuarioModel, 'findByIdWithDetails', async () => ({
+    id_usuario: 7,
+    uuid: 'user-uuid',
+    nombre: 'Test',
+    apellido: 'User',
+    email: 'test@example.com',
+    rol: 'ciudadano',
+    activo: 1,
+    email_verificado: 1,
+    avatar_url: null,
+    telefono: null,
+    notification_preferences: existingPreferences,
+  }));
+  t.mock.method(UsuarioModel, 'updateNotificationPreferences', async (idUsuario, preferences) => ({
+    id_usuario: idUsuario,
+    uuid: 'user-uuid',
+    nombre: 'Test',
+    apellido: 'User',
+    email: 'test@example.com',
+    rol: 'ciudadano',
+    activo: 1,
+    email_verificado: 1,
+    avatar_url: null,
+    telefono: null,
+    notification_preferences: preferences,
+  }));
+
+  const req = {
+    user: { sub: 7 },
+    body: {
+      preferences: {
+        push_notifications: true,
+        weekly_summary: true,
+      },
+    },
+  };
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await updateNotifications(req, res, next);
+
+  const savedPreferences = UsuarioModel.updateNotificationPreferences.mock.calls[0].arguments[1];
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(savedPreferences, {
+    email_alerts: true,
+    push_notifications: true,
+    report_updates: true,
+    weekly_summary: true,
+  });
+  assert.deepEqual(res.body.data.preferences, savedPreferences);
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('updateNotifications rechaza claves no permitidas', async (t) => {
+  t.mock.method(UsuarioModel, 'updateNotificationPreferences', async () => {
+    throw new Error('No debe guardar preferencias invalidas');
+  });
+
+  const req = {
+    user: { sub: 7 },
+    body: {
+      preferences: {
+        sms_alerts: true,
+      },
+    },
+  };
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await updateNotifications(req, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.message, 'Preferencias no permitidas: sms_alerts.');
+  assert.equal(UsuarioModel.updateNotificationPreferences.mock.callCount(), 0);
+  assert.equal(next.mock.callCount(), 0);
+});
+</file>
+
+<file path="tests/unit/oauth-callback-code.test.js">
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  clearOAuthCallbackCodes,
+  consumeOAuthCallbackCode,
+  createOAuthCallbackCode,
+} from '../../src/services/oauth-callback-code.service.js';
+
+test.afterEach(() => {
+  clearOAuthCallbackCodes();
+  delete process.env.OAUTH_CALLBACK_CODE_TTL_SECONDS;
+});
+
+test('codigo OAuth temporal se consume una sola vez', () => {
+  const payload = {
+    accessToken: 'access-token',
+    refreshToken: 'refresh-token',
+    user: { id_usuario: 1 },
+  };
+
+  const code = createOAuthCallbackCode(payload);
+
+  assert.equal(typeof code, 'string');
+  assert.ok(code.length >= 32);
+  assert.deepEqual(consumeOAuthCallbackCode(code), payload);
+  assert.equal(consumeOAuthCallbackCode(code), null);
+});
+
+test('codigo OAuth expirado no entrega payload', async () => {
+  process.env.OAUTH_CALLBACK_CODE_TTL_SECONDS = '0.001';
+
+  const code = createOAuthCallbackCode({ accessToken: 'access-token' });
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  assert.equal(consumeOAuthCallbackCode(code), null);
+});
+</file>
+
+<file path="tests/unit/otp-generation.test.js">
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { generateOtpCode } from '../../src/controllers/auth.controller.js';
+
+test('generateOtpCode genera codigos OTP de 6 digitos', () => {
+  for (let index = 0; index < 100; index += 1) {
+    const code = generateOtpCode();
+
+    assert.match(code, /^\d{6}$/);
+    assert.ok(Number(code) >= 100000);
+    assert.ok(Number(code) <= 999999);
+  }
+});
+
+test('generateOtpCode genera multiples valores sin romper el formato', () => {
+  const codes = Array.from({ length: 50 }, () => generateOtpCode());
+
+  assert.equal(codes.length, 50);
+  assert.ok(codes.every((code) => /^\d{6}$/.test(code)));
+});
+</file>
+
+<file path="tests/unit/password-refresh-revocation.test.js">
+import crypto from 'node:crypto';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { changePassword, resetPassword } from '../../src/controllers/auth.controller.js';
+import { RefreshTokenModel } from '../../src/models/refresh-token.model.js';
+import { UsuarioModel } from '../../src/models/usuario.model.js';
+
+const hashPassword = (password) => {
+  const salt = crypto.randomBytes(16).toString('hex');
+  const derivedKey = crypto.scryptSync(password, salt, 64).toString('hex');
+  return `${salt}:${derivedKey}`;
+};
+
+const hashToken = (token) => crypto.createHash('sha256').update(token).digest('hex');
+
+const createResponse = () => ({
+  statusCode: null,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+});
+
+test('changePassword revoca refresh tokens del usuario', async (t) => {
+  const user = {
+    id_usuario: 7,
+    email: 'user@example.com',
+    password_hash: hashPassword('Current123'),
+  };
+
+  t.mock.method(UsuarioModel, 'findByEmail', async () => user);
+  t.mock.method(UsuarioModel, 'updatePassword', async (idUsuario) => ({
+    id_usuario: idUsuario,
+  }));
+  t.mock.method(RefreshTokenModel, 'revokeAllForUser', async () => 2);
+
+  const req = {
+    user: { sub: 7, email: 'user@example.com' },
+    body: {
+      currentPassword: 'Current123',
+      newPassword: 'NewPassword123',
+      confirmPassword: 'NewPassword123',
+    },
+  };
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await changePassword(req, res, next);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(RefreshTokenModel.revokeAllForUser.mock.callCount(), 1);
+  assert.equal(RefreshTokenModel.revokeAllForUser.mock.calls[0].arguments[0], 7);
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('resetPassword revoca refresh tokens del usuario', async (t) => {
+  const resetToken = 'reset-token-valid-1234567890';
+  const user = {
+    id_usuario: 11,
+    email: 'reset@example.com',
+    token_reset_exp: new Date(Date.now() + 60_000).toISOString(),
+  };
+
+  t.mock.method(UsuarioModel, 'findByResetToken', async (tokenHash) => {
+    assert.equal(tokenHash, hashToken(resetToken));
+    return user;
+  });
+  t.mock.method(UsuarioModel, 'updatePassword', async (idUsuario) => ({
+    id_usuario: idUsuario,
+  }));
+  t.mock.method(UsuarioModel, 'clearResetToken', async () => true);
+  t.mock.method(RefreshTokenModel, 'revokeAllForUser', async () => 3);
+
+  const req = {
+    body: {
+      token: resetToken,
+      newPassword: 'ResetPassword123',
+      confirmPassword: 'ResetPassword123',
+    },
+  };
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await resetPassword(req, res, next);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(UsuarioModel.clearResetToken.mock.callCount(), 1);
+  assert.equal(RefreshTokenModel.revokeAllForUser.mock.callCount(), 1);
+  assert.equal(RefreshTokenModel.revokeAllForUser.mock.calls[0].arguments[0], 11);
+  assert.equal(next.mock.callCount(), 0);
+});
+</file>
+
+<file path="tests/unit/prediccion-service.test.js">
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  calcularAlertasPredictivas,
+  calcularZonasRiesgo,
+  getPrediccionCacheSize,
+  invalidatePrediccionCache,
+  parseAlertasParams,
+  parseZonasParams,
+} from '../../src/services/prediccion.service.js';
+import { ReporteModel } from '../../src/models/reporte.model.js';
+
+const reportesBase = [
+  {
+    id_reporte: 1,
+    tipo_contaminacion: 'agua',
+    subcategoria: 'vertimiento',
+    estado: 'verificado',
+    nivel_severidad: 'alto',
+    latitud: 10.401,
+    longitud: -73.201,
+    municipio: 'Valledupar',
+    departamento: 'Cesar',
+    created_at: new Date().toISOString(),
+  },
+  {
+    id_reporte: 2,
+    tipo_contaminacion: 'agua',
+    subcategoria: 'vertimiento',
+    estado: 'resuelto',
+    nivel_severidad: 'critico',
+    latitud: 10.402,
+    longitud: -73.202,
+    municipio: 'Valledupar',
+    departamento: 'Cesar',
+    created_at: new Date().toISOString(),
+  },
+  {
+    id_reporte: 3,
+    tipo_contaminacion: 'aire',
+    subcategoria: 'humo',
+    estado: 'en_proceso',
+    nivel_severidad: 'medio',
+    latitud: 11.1,
+    longitud: -74.1,
+    municipio: 'Santa Marta',
+    departamento: 'Magdalena',
+    created_at: new Date().toISOString(),
+  },
+];
+
+test('calcularZonasRiesgo agrupa por grilla y no expone datos personales', async (t) => {
+  invalidatePrediccionCache();
+  t.mock.method(ReporteModel, 'findParaPrediccion', async () => reportesBase);
+
+  const result = await calcularZonasRiesgo(parseZonasParams({ min_score: '0' }));
+
+  assert.equal(result.celda_grados, 0.05);
+  assert.ok(result.actualizado_en);
+  assert.equal(result.zonas.length, 2);
+  assert.equal(result.zonas[0].tipo_dominante, 'agua');
+  assert.equal(result.zonas[0].n_reportes, 2);
+  assert.equal(Object.hasOwn(result.zonas[0], 'id_usuario'), false);
+  assert.equal(Object.hasOwn(result.zonas[0], 'autor_nombre'), false);
+});
+
+test('calcularAlertasPredictivas filtra por nivel, tipo, distancia y limite', async (t) => {
+  invalidatePrediccionCache();
+  t.mock.method(ReporteModel, 'findParaPrediccion', async () => reportesBase);
+
+  const result = await calcularAlertasPredictivas(parseAlertasParams({
+    min_score: '0',
+    nivel_min: 'alto',
+    tipo: 'agua',
+    limite: '1',
+    lat: '10.40',
+    lng: '-73.20',
+    radio_km: '20',
+  }));
+
+  assert.ok(result.generado_en);
+  assert.equal(result.alertas.length, 1);
+  assert.equal(result.alertas[0].tipo_dominante, 'agua');
+  assert.equal(result.alertas[0].nivel === 'alto' || result.alertas[0].nivel === 'critico', true);
+  assert.equal(Object.hasOwn(result.alertas[0], 'id_usuario'), false);
+});
+
+test('prediccion responde listas vacias sin datos', async (t) => {
+  invalidatePrediccionCache();
+  t.mock.method(ReporteModel, 'findParaPrediccion', async () => []);
+
+  const zonas = await calcularZonasRiesgo(parseZonasParams({}));
+  const alertas = await calcularAlertasPredictivas(parseAlertasParams({}));
+
+  assert.deepEqual(zonas.zonas, []);
+  assert.deepEqual(alertas.alertas, []);
+});
+
+test('prediccion usa cache TTL hasta invalidar', async (t) => {
+  invalidatePrediccionCache();
+  t.mock.method(ReporteModel, 'findParaPrediccion', async () => reportesBase);
+
+  await calcularZonasRiesgo(parseZonasParams({ min_score: '0' }));
+  await calcularZonasRiesgo(parseZonasParams({ min_score: '0' }));
+
+  assert.equal(ReporteModel.findParaPrediccion.mock.callCount(), 1);
+  assert.equal(getPrediccionCacheSize() > 0, true);
+
+  invalidatePrediccionCache();
+  assert.equal(getPrediccionCacheSize(), 0);
+
+  await calcularZonasRiesgo(parseZonasParams({ min_score: '0' }));
+  assert.equal(ReporteModel.findParaPrediccion.mock.callCount(), 2);
+});
+
+test('parseAlertasParams valida parametros geograficos y nivel', () => {
+  assert.throws(
+    () => parseAlertasParams({ lat: '91' }),
+    /lat debe ser un numero entre -90 y 90/
+  );
+  assert.throws(
+    () => parseAlertasParams({ nivel_min: 'urgente' }),
+    /nivel_min debe ser uno de/
+  );
+  assert.throws(
+    () => parseZonasParams({ min_score: '101' }),
+    /min_score debe ser un numero entre 0 y 100/
+  );
+});
+</file>
+
+<file path="tests/unit/reporte-estado-inicial.test.js">
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { ESTADO_INICIAL_REPORTE } from '../../src/models/reporte.model.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const backendRoot = path.resolve(path.dirname(__filename), '../..');
+
+const readBackendFile = (relativePath) => {
+  return fs.readFileSync(path.join(backendRoot, relativePath), 'utf8');
+};
+
+test('schema define pendiente como estado inicial de reportes', () => {
+  const schema = readBackendFile('DATABASE_SCHEMA_COMPLETE.sql');
+
+  assert.match(
+    schema,
+    /estado ENUM\('pendiente', 'en_revision', 'verificado', 'en_proceso', 'rechazado', 'resuelto'\) DEFAULT 'pendiente'/
+  );
+});
+
+test('modelo crea reportes nuevos con estado pendiente explicito', () => {
+  const model = readBackendFile('src/models/reporte.model.js');
+
+  const createStart = model.indexOf('create: async');
+  const updateStart = model.indexOf('update: async', createStart);
+  const createSection = model.slice(createStart, updateStart);
+
+  assert.match(createSection, /tipo_contaminacion, estado, nivel_severidad/);
+  assert.equal(ESTADO_INICIAL_REPORTE, 'pendiente');
+  assert.equal((createSection.match(/ESTADO_INICIAL_REPORTE/g) ?? []).length, 2);
+});
+
+test('controlador permite editar al propietario solo cuando el reporte esta pendiente', () => {
+  const controller = readBackendFile('src/controllers/reporte.controller.js');
+
+  assert.match(controller, /reporte\.estado !== ESTADO_INICIAL_REPORTE/);
+  assert.match(controller, /const allowed = isOwner\s*\?\s*\['titulo', 'descripcion', 'direccion', 'municipio', 'departamento'\]/);
+});
+</file>
+
+<file path="tests/unit/reporte-evidencias-gestion.test.js">
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  addEvidenciaReporte,
+  deleteEvidenciaReporte,
+  listEvidenciasReporte,
+} from '../../src/controllers/reporte.controller.js';
+import { EvidenciaModel } from '../../src/models/evidencia.model.js';
+import { ReporteModel } from '../../src/models/reporte.model.js';
+
+const createResponse = () => ({
+  statusCode: null,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+});
+
+const reporte = {
+  id_reporte: 15,
+  id_usuario: 7,
+  estado: 'pendiente',
+};
+
+test('listEvidenciasReporte permite listar al propietario del reporte', async (t) => {
+  t.mock.method(ReporteModel, 'findById', async () => reporte);
+  t.mock.method(EvidenciaModel, 'findByReporte', async () => ([
+    { id_evidencia: 1, id_reporte: 15, url_archivo: '/uploads/a.jpg' },
+  ]));
+
+  const req = {
+    params: { id: '15' },
+    user: { sub: 7, rol: 'ciudadano' },
+  };
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await listEvidenciasReporte(req, res, next);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.data.total, 1);
+  assert.equal(EvidenciaModel.findByReporte.mock.calls[0].arguments[0], 15);
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('listEvidenciasReporte rechaza usuario que no es propietario ni moderador', async (t) => {
+  t.mock.method(ReporteModel, 'findById', async () => reporte);
+  t.mock.method(EvidenciaModel, 'findByReporte', async () => {
+    throw new Error('No debe consultar evidencias sin permiso');
+  });
+
+  const req = {
+    params: { id: '15' },
+    user: { sub: 99, rol: 'ciudadano' },
+  };
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await listEvidenciasReporte(req, res, next);
+
+  assert.equal(res.statusCode, 403);
+  assert.equal(res.body.message, 'No tienes permiso para gestionar evidencias de este reporte.');
+  assert.equal(EvidenciaModel.findByReporte.mock.callCount(), 0);
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('addEvidenciaReporte agrega evidencia al reporte como moderador', async (t) => {
+  t.mock.method(ReporteModel, 'findById', async () => reporte);
+  t.mock.method(EvidenciaModel, 'create', async () => 22);
+  t.mock.method(EvidenciaModel, 'findById', async () => ({
+    id_evidencia: 22,
+    id_reporte: 15,
+    tipo_archivo: 'imagen',
+  }));
+
+  const req = {
+    params: { id: '15' },
+    user: { sub: 9, rol: 'moderador' },
+    file: {
+      mimetype: 'image/png',
+      filename: 'evidencia.png',
+      originalname: 'foto.png',
+      size: 1024,
+    },
+  };
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await addEvidenciaReporte(req, res, next);
+
+  assert.equal(res.statusCode, 201);
+  assert.deepEqual(EvidenciaModel.create.mock.calls[0].arguments[0], {
+    id_reporte: 15,
+    id_usuario: 9,
+    tipo_archivo: 'imagen',
+    url_archivo: '/uploads/evidencia.png',
+    nombre_original: 'foto.png',
+    mime_type: 'image/png',
+    tamano_bytes: 1024,
+    orden: 0,
+  });
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('deleteEvidenciaReporte elimina evidencia activa del reporte', async (t) => {
+  t.mock.method(ReporteModel, 'findById', async () => reporte);
+  t.mock.method(EvidenciaModel, 'findById', async () => ({
+    id_evidencia: 22,
+    id_reporte: 15,
+  }));
+  t.mock.method(EvidenciaModel, 'remove', async () => true);
+
+  const req = {
+    params: { id: '15', evidenciaId: '22' },
+    user: { sub: 7, rol: 'ciudadano' },
+  };
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await deleteEvidenciaReporte(req, res, next);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(EvidenciaModel.remove.mock.calls[0].arguments[0], 22);
+  assert.equal(next.mock.callCount(), 0);
+});
+</file>
+
+<file path="tests/unit/reporte-pagination-total.test.js">
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getReportes } from '../../src/controllers/reporte.controller.js';
+import { ReporteModel } from '../../src/models/reporte.model.js';
+
+const createResponse = () => ({
+  statusCode: null,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+});
+
+test('getReportes devuelve total real filtrado y paginacion', async (t) => {
+  const reportes = [
+    { id_reporte: 11, tipo_contaminacion: 'inundacion' },
+    { id_reporte: 12, tipo_contaminacion: 'inundacion' },
+  ];
+
+  t.mock.method(ReporteModel, 'findAll', async () => reportes);
+  t.mock.method(ReporteModel, 'countAll', async () => 8);
+
+  const req = {
+    query: {
+      tipo_contaminacion: 'inundacion',
+      estado: 'pendiente',
+      nivel_severidad: 'alto',
+      municipio: 'mocoa',
+      limit: '2',
+      offset: '4',
+    },
+  };
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await getReportes(req, res, next);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body.data, {
+    reportes,
+    total: 8,
+    limit: 2,
+    offset: 4,
+  });
+  assert.deepEqual(ReporteModel.findAll.mock.calls[0].arguments[0], {
+    tipo_contaminacion: 'inundacion',
+    estado: 'pendiente',
+    nivel_severidad: 'alto',
+    municipio: 'mocoa',
+    limit: 2,
+    offset: 4,
+  });
+  assert.deepEqual(ReporteModel.countAll.mock.calls[0].arguments[0], {
+    tipo_contaminacion: 'inundacion',
+    estado: 'pendiente',
+    nivel_severidad: 'alto',
+    municipio: 'mocoa',
+  });
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('getReportes total no depende de la cantidad devuelta en la pagina', async (t) => {
+  t.mock.method(ReporteModel, 'findAll', async () => []);
+  t.mock.method(ReporteModel, 'countAll', async () => 25);
+
+  const req = {
+    query: {
+      limit: '10',
+      offset: '20',
+    },
+  };
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await getReportes(req, res, next);
+
+  assert.equal(res.body.data.reportes.length, 0);
+  assert.equal(res.body.data.total, 25);
+  assert.equal(res.body.data.limit, 10);
+  assert.equal(res.body.data.offset, 20);
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('ReporteModel.countAll usa COUNT con filtros compartidos', () => {
+  const source = ReporteModel.countAll.toString();
+
+  assert.match(source, /COUNT\(\*\) AS total/);
+  assert.match(source, /buildReportesFilter/);
+  assert.doesNotMatch(source, /LIMIT/);
+  assert.doesNotMatch(source, /OFFSET/);
+});
+</file>
+
+<file path="tests/unit/reporte-upload-evidencias.test.js">
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { fileFilter } from '../../middlewares/upload.middleware.js';
+import { createReporte } from '../../src/controllers/reporte.controller.js';
+import { CategoriaRiesgoModel } from '../../src/models/categoria-riesgo.model.js';
+import { EvidenciaModel } from '../../src/models/evidencia.model.js';
+import { ReporteModel } from '../../src/models/reporte.model.js';
+
+const createResponse = () => ({
+  statusCode: null,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+});
+
+const createFile = (index, mimetype = 'image/png') => ({
+  mimetype,
+  filename: `evidencia-${index}.${mimetype.startsWith('video/') ? 'mp4' : 'png'}`,
+  originalname: `original-${index}.${mimetype.startsWith('video/') ? 'mp4' : 'png'}`,
+  size: 1024 + index,
+});
+
+const createRequest = (files = [], bodyOverrides = {}) => ({
+  user: { sub: 7 },
+  body: {
+    tipo_contaminacion: 'agua',
+    nivel_severidad: 'alto',
+    subcategoria: 'rio_contaminado',
+    titulo: 'Reporte con evidencias',
+    descripcion: 'Descripcion del reporte',
+    direccion: 'Calle 10',
+    municipio: 'Valledupar',
+    departamento: 'Cesar',
+    latitud: 10.45,
+    longitud: -73.25,
+    ...bodyOverrides,
+  },
+  files: {
+    files,
+  },
+});
+
+const mockSuccessfulCreate = (t) => {
+  t.mock.method(CategoriaRiesgoModel, 'esValido', async () => true);
+  t.mock.method(ReporteModel, 'create', async () => 15);
+  t.mock.method(ReporteModel, 'findById', async () => ({
+    id_reporte: 15,
+    tipo_contaminacion: 'agua',
+    subcategoria: 'rio_contaminado',
+    estado: 'pendiente',
+  }));
+  t.mock.method(ReporteModel, 'updateIaAnalysis', async () => true);
+  t.mock.method(EvidenciaModel, 'create', async () => 1);
+};
+
+test('createReporte guarda multiples imagenes con metadata y orden', async (t) => {
+  mockSuccessfulCreate(t);
+
+  const req = createRequest([createFile(0), createFile(1), createFile(2)]);
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await createReporte(req, res, next);
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(EvidenciaModel.create.mock.callCount(), 3);
+  assert.deepEqual(EvidenciaModel.create.mock.calls[1].arguments[0], {
+    id_reporte: 15,
+    id_usuario: 7,
+    tipo_archivo: 'imagen',
+    url_archivo: '/uploads/evidencia-1.png',
+    nombre_original: 'original-1.png',
+    mime_type: 'image/png',
+    tamano_bytes: 1025,
+    orden: 1,
+  });
+  assert.equal(ReporteModel.create.mock.calls[0].arguments[0].subcategoria, 'rio_contaminado');
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('createReporte permite hasta 10 archivos en files', async (t) => {
+  mockSuccessfulCreate(t);
+
+  const req = createRequest(Array.from({ length: 10 }, (_, index) => createFile(index)));
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await createReporte(req, res, next);
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(EvidenciaModel.create.mock.callCount(), 10);
+  assert.equal(EvidenciaModel.create.mock.calls[9].arguments[0].orden, 9);
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('createReporte rechaza mas de 10 evidencias antes de crear reporte', async (t) => {
+  t.mock.method(CategoriaRiesgoModel, 'esValido', async () => {
+    throw new Error('No debe validar categoria con mas de 10 evidencias');
+  });
+  t.mock.method(ReporteModel, 'create', async () => {
+    throw new Error('No debe insertar reportes con mas de 10 evidencias');
+  });
+  t.mock.method(EvidenciaModel, 'create', async () => {
+    throw new Error('No debe insertar evidencias con mas de 10 archivos');
+  });
+
+  const req = createRequest(Array.from({ length: 11 }, (_, index) => createFile(index)));
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await createReporte(req, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.message, 'Solo puedes adjuntar hasta 10 evidencias por reporte.');
+  assert.equal(ReporteModel.create.mock.callCount(), 0);
+  assert.equal(EvidenciaModel.create.mock.callCount(), 0);
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('createReporte permite un video por reporte', async (t) => {
+  mockSuccessfulCreate(t);
+
+  const req = createRequest([
+    createFile(0, 'image/webp'),
+    createFile(1, 'video/mp4'),
+  ]);
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await createReporte(req, res, next);
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(EvidenciaModel.create.mock.callCount(), 2);
+  assert.equal(EvidenciaModel.create.mock.calls[1].arguments[0].tipo_archivo, 'video');
+  assert.equal(EvidenciaModel.create.mock.calls[1].arguments[0].mime_type, 'video/mp4');
+});
+
+test('createReporte rechaza dos videos antes de crear reporte', async (t) => {
+  t.mock.method(CategoriaRiesgoModel, 'esValido', async () => {
+    throw new Error('No debe validar categoria con dos videos');
+  });
+  t.mock.method(ReporteModel, 'create', async () => {
+    throw new Error('No debe insertar reportes con dos videos');
+  });
+  t.mock.method(EvidenciaModel, 'create', async () => {
+    throw new Error('No debe insertar evidencias con dos videos');
+  });
+
+  const req = createRequest([
+    createFile(0, 'video/mp4'),
+    createFile(1, 'video/quicktime'),
+  ]);
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await createReporte(req, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.message, 'Solo puedes adjuntar un video por reporte.');
+  assert.equal(ReporteModel.create.mock.callCount(), 0);
+  assert.equal(EvidenciaModel.create.mock.callCount(), 0);
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('fileFilter rechaza mime invalido como error 400', () => {
+  let callbackError;
+  let accepted;
+
+  fileFilter(
+    {},
+    { mimetype: 'application/pdf' },
+    (error, value) => {
+      callbackError = error;
+      accepted = value;
+    }
+  );
+
+  assert.equal(callbackError.statusCode, 400);
+  assert.equal(callbackError.message, 'Tipo de archivo no permitido. Solo imagenes y videos.');
+  assert.equal(accepted, undefined);
+});
+</file>
+
+<file path="tests/unit/response.test.js">
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { errorResponse, successResponse } from '../../src/utils/response.js';
+
+const createMockResponse = () => {
+  const res = {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+
+  return res;
+};
+
+test('successResponse responde con estado success, mensaje y data', () => {
+  const res = createMockResponse();
+  const data = { id: 1 };
+
+  successResponse(res, data, 'creado', 201);
+
+  assert.equal(res.statusCode, 201);
+  assert.deepEqual(res.body, {
+    status: 'success',
+    message: 'creado',
+    data,
+  });
+});
+
+test('successResponse usa valores por defecto', () => {
+  const res = createMockResponse();
+
+  successResponse(res, { ok: true });
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body, {
+    status: 'success',
+    message: 'ok',
+    data: { ok: true },
+  });
+});
+
+test('errorResponse responde con estado error y mensaje', () => {
+  const res = createMockResponse();
+
+  errorResponse(res, 'no autorizado', 401);
+
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.body, {
+    status: 'error',
+    message: 'no autorizado',
+  });
+});
+
+test('errorResponse usa valores por defecto', () => {
+  const res = createMockResponse();
+
+  errorResponse(res);
+
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(res.body, {
+    status: 'error',
+    message: 'error',
+  });
+});
+</file>
+
+<file path="tests/unit/route-prefix.test.js">
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+
+process.env.API_PREFIX = '';
+
+const { default: pool } = await import('../../src/config/database.js');
+pool.query = async () => [[{ ok: 1 }], []];
+pool.execute = async (sql) => {
+  if (String(sql).includes('FROM reportes')) {
+    return [[{
+      total_reportes: 0,
+      reportes_este_mes: 0,
+      en_revision: 0,
+      resueltos: 0,
+      municipios_activos: 0,
+      con_seguimiento: 0,
+    }], []];
+  }
+
+  if (String(sql).includes('FROM usuarios')) {
+    return [[{ total_usuarios: 0 }], []];
+  }
+
+  return [[], []];
+};
+
+const { default: app } = await import('../../src/app.js');
+const { normalizeApiPrefix } = await import('../../src/config/api-prefix.config.js');
+
+const listen = () => new Promise((resolve) => {
+  const server = http.createServer(app);
+  server.listen(0, () => resolve(server));
+});
+
+const close = (server) => new Promise((resolve, reject) => {
+  server.close((error) => (error ? reject(error) : resolve()));
+});
+
+const request = async (server, path, options = {}) => {
+  const { port } = server.address();
+  return fetch(`http://127.0.0.1:${port}${path}`, options);
+};
+
+test('API_PREFIX por defecto monta rutas sin prefijo para el proxy de Vite', async () => {
+  const server = await listen();
+
+  try {
+    const health = await request(server, '/health');
+    const stats = await request(server, '/reportes/stats');
+    const login = await request(server, '/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    const prefixedHealth = await request(server, '/api/health');
+
+    assert.equal(health.status, 200);
+    assert.equal(stats.status, 200);
+    assert.equal(login.status, 400);
+    assert.equal(prefixedHealth.status, 404);
+  } finally {
+    await close(server);
+  }
+});
+
+test('normaliza API_PREFIX vacio, raiz o con barras sin forzar /api', () => {
+  assert.equal(normalizeApiPrefix(undefined), '');
+  assert.equal(normalizeApiPrefix(''), '');
+  assert.equal(normalizeApiPrefix('/'), '');
+  assert.equal(normalizeApiPrefix('api'), '/api');
+  assert.equal(normalizeApiPrefix('/api/'), '/api');
+});
+</file>
+
+<file path="tests/unit/security-middleware.test.js">
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+
+process.env.CORS_ORIGIN = 'http://localhost:5173';
+
+const { default: app } = await import('../../src/app.js');
+
+const listen = () => new Promise((resolve) => {
+  const server = http.createServer(app);
+  server.listen(0, () => resolve(server));
+});
+
+const close = (server) => new Promise((resolve, reject) => {
+  server.close((error) => (error ? reject(error) : resolve()));
+});
+
+const request = async (server, path, options = {}) => {
+  const { port } = server.address();
+  return fetch(`http://127.0.0.1:${port}${path}`, options);
+};
+
+test('Helmet agrega cabeceras de seguridad HTTP', async () => {
+  const server = await listen();
+
+  try {
+    const response = await request(server, '/api/no-existe');
+
+    assert.equal(response.headers.get('x-content-type-options'), 'nosniff');
+    assert.equal(response.headers.get('x-frame-options'), 'SAMEORIGIN');
+  } finally {
+    await close(server);
+  }
+});
+
+test('CORS permite el origen configurado en CORS_ORIGIN', async () => {
+  const server = await listen();
+
+  try {
+    const response = await request(server, '/api/no-existe', {
+      headers: {
+        Origin: 'http://localhost:5173',
+      },
+    });
+
+    assert.equal(response.headers.get('access-control-allow-origin'), 'http://localhost:5173');
+    assert.equal(response.headers.get('access-control-allow-credentials'), 'true');
+  } finally {
+    await close(server);
+  }
+});
+
+test('CORS no expone cabeceras para origen no permitido', async () => {
+  const server = await listen();
+
+  try {
+    const response = await request(server, '/api/no-existe', {
+      headers: {
+        Origin: 'https://malicious.example',
+      },
+    });
+
+    assert.equal(response.headers.get('access-control-allow-origin'), null);
+  } finally {
+    await close(server);
+  }
+});
+</file>
+
+<file path="tests/unit/upload-config.test.js">
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { getMaxFileSize, getUploadDir } from '../../src/config/upload.config.js';
+
+test.afterEach(() => {
+  delete process.env.UPLOAD_DIR;
+  delete process.env.MAX_FILE_SIZE;
+});
+
+test('getUploadDir usa ./uploads por defecto', () => {
+  assert.equal(getUploadDir(), path.resolve(process.cwd(), './uploads'));
+});
+
+test('getUploadDir usa UPLOAD_DIR desde entorno', () => {
+  process.env.UPLOAD_DIR = './custom-uploads';
+
+  assert.equal(getUploadDir(), path.resolve(process.cwd(), './custom-uploads'));
+});
+
+test('getMaxFileSize usa MAX_FILE_SIZE desde entorno', () => {
+  process.env.MAX_FILE_SIZE = '2048';
+
+  assert.equal(getMaxFileSize(), 2048);
+});
+
+test('getMaxFileSize usa fallback cuando MAX_FILE_SIZE es invalido', () => {
+  process.env.MAX_FILE_SIZE = 'invalid';
+
+  assert.equal(getMaxFileSize(), 10 * 1024 * 1024);
+});
+</file>
+
+<file path="tests/unit/validaciones.test.js">
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  validarNombreUsuario,
+  validarPassword,
+  validarTelefono,
+} from '../../src/utils/constantes-validacion.js';
+
+test('validarNombreUsuario acepta nombres validos con espacios externos', () => {
+  assert.equal(validarNombreUsuario('  Juan Diego  '), true);
+  assert.equal(validarNombreUsuario('Ana Maria'), true);
+});
+
+test('validarNombreUsuario rechaza valores vacios, cortos o peligrosos', () => {
+  assert.equal(validarNombreUsuario(''), false);
+  assert.equal(validarNombreUsuario(' A '), false);
+  assert.equal(validarNombreUsuario('Juan<script>'), false);
+  assert.equal(validarNombreUsuario(null), false);
+});
+
+test('validarTelefono permite telefonos opcionales y formatos comunes', () => {
+  assert.equal(validarTelefono(null), true);
+  assert.equal(validarTelefono(''), true);
+  assert.equal(validarTelefono('+57 300-123-4567'), true);
+  assert.equal(validarTelefono('(300) 123 4567'), true);
+});
+
+test('validarTelefono rechaza valores no telefonicos', () => {
+  assert.equal(validarTelefono('abc123'), false);
+  assert.equal(validarTelefono('123'), false);
+  assert.equal(validarTelefono({}), false);
+});
+
+test('validarPassword exige minimo ocho caracteres, letras y numeros', () => {
+  assert.equal(validarPassword('Clave123'), true);
+  assert.equal(validarPassword('12345678'), false);
+  assert.equal(validarPassword('abcdefgh'), false);
+  assert.equal(validarPassword('abc123'), false);
+  assert.equal(validarPassword(undefined), false);
+});
+</file>
+
+<file path="tests/unit/validate-id-middleware.test.js">
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { validatePositiveIdParam } from '../../middlewares/validate-id.middleware.js';
+
+const createResponse = () => ({
+  statusCode: null,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+});
+
+test('validatePositiveIdParam permite enteros positivos', () => {
+  const req = { params: { id: '42' } };
+  const res = createResponse();
+  let nextCalled = false;
+
+  validatePositiveIdParam('id')(req, res, () => {
+    nextCalled = true;
+  });
+
+  assert.equal(nextCalled, true);
+  assert.equal(req.params.id, '42');
+  assert.equal(res.statusCode, null);
+});
+
+test('validatePositiveIdParam rechaza IDs invalidos', () => {
+  const invalidIds = ['0', '-1', '1.5', 'abc', 'NaN', '', ' 1 '];
+
+  for (const id of invalidIds) {
+    const req = { params: { id } };
+    const res = createResponse();
+    let nextCalled = false;
+
+    validatePositiveIdParam('id')(req, res, () => {
+      nextCalled = true;
+    });
+
+    assert.equal(nextCalled, false);
+    assert.equal(res.statusCode, 400);
+    assert.deepEqual(res.body, {
+      status: 'error',
+      message: 'id invalido. Debe ser un entero positivo.',
+    });
+  }
+});
+</file>
+
+<file path="middlewares/auth.middleware.js">
+import jwt from 'jsonwebtoken';
+
+const getBearerToken = (req) => {
+  const authHeader = req.headers['authorization'];
+  const [scheme, token] = typeof authHeader === 'string' ? authHeader.split(' ') : [];
+
+  return scheme?.toLowerCase() === 'bearer' && token ? token : null;
+};
+
+// protege rutas privadas verificando el token bearer
+export const verifyToken = (req, res, next) => {
+  const token = getBearerToken(req);
+
+  if (!token) {
+    return res.status(401).json({
+      status: 'error',
+      message: 'acceso denegado. token no proporcionado.',
+    });
+  }
+
+  try {
+    req.user = jwt.verify(token, process.env.JWT_SECRET);
+    next();
+  } catch (error) {
+    return res.status(403).json({
+      status: 'error',
+      message: 'token inválido o expirado.',
+    });
+  }
+};
+
+export const optionalAuth = (req, _res, next) => {
+  const token = getBearerToken(req);
+
+  if (!token) {
+    delete req.user;
+    return next();
+  }
+
+  try {
+    req.user = jwt.verify(token, process.env.JWT_SECRET);
+  } catch {
+    delete req.user;
+  }
+
+  return next();
+};
+
+export const verifyTokenWhenAllDevicesLogout = (req, res, next) => {
+  if (req.body?.allDevices === true) {
+    return verifyToken(req, res, next);
+  }
+
+  return next();
+};
+
+// Debe usarse despues de verifyToken para asegurar req.user.
+export const requireRoles = (...roles) => (req, res, next) => {
+  if (!req.user) {
+    return res.status(401).json({
+      status: 'error',
+      message: 'acceso denegado. usuario no autenticado.',
+    });
+  }
+
+  if (!roles.includes(req.user.rol)) {
+    return res.status(403).json({
+      status: 'error',
+      message: 'acceso denegado. rol no autorizado.',
+    });
+  }
+
+  return next();
+};
+</file>
+
+<file path="middlewares/upload.middleware.js">
+import multer from 'multer';
+import path from 'path';
+import crypto from 'crypto';
+import fs from 'fs';
+import { getMaxFileSize, getUploadDir } from '../src/config/upload.config.js';
+
+const uploadsDir = getUploadDir();
+
+// Crear carpeta si no existe
+if (!fs.existsSync(uploadsDir)) fs.mkdirSync(uploadsDir, { recursive: true });
+
+const storage = multer.diskStorage({
+  destination: (_req, _file, cb) => cb(null, uploadsDir),
+  filename: (_req, file, cb) => {
+    const ext = path.extname(file.originalname).toLowerCase();
+    cb(null, crypto.randomUUID() + ext);
+  },
+});
+
+const ALLOWED_MIME = [
+  'image/jpeg', 'image/jpg', 'image/png', 'image/webp', 'image/gif',
+  'video/mp4', 'video/quicktime',
+];
+
+export const fileFilter = (_req, file, cb) => {
+  if (ALLOWED_MIME.includes(file.mimetype)) {
+    return cb(null, true);
+  }
+
+  const error = new Error('Tipo de archivo no permitido. Solo imagenes y videos.');
+  error.statusCode = 400;
+  return cb(error);
+};
+
+export const upload = multer({
+  storage,
+  limits: { fileSize: getMaxFileSize() },
+  fileFilter,
+});
+
+export const uploadMultiple = upload.fields([
+  { name: 'file', maxCount: 1 },
+  { name: 'files', maxCount: 10 },
+]);
+</file>
+
+<file path="migrations/009_create_reporte_likes.sql">
+-- Migracion: likes persistentes por usuario y reporte
+CREATE TABLE IF NOT EXISTS reporte_likes (
+  id_like BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  id_reporte BIGINT UNSIGNED NOT NULL,
+  id_usuario BIGINT UNSIGNED NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id_like),
+  UNIQUE KEY uk_reporte_likes_reporte_usuario (id_reporte, id_usuario),
+  KEY idx_reporte_likes_usuario (id_usuario),
+  CONSTRAINT fk_reporte_likes_reporte
+    FOREIGN KEY (id_reporte) REFERENCES reportes(id_reporte)
+    ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT fk_reporte_likes_usuario
+    FOREIGN KEY (id_usuario) REFERENCES usuarios(id_usuario)
+    ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+</file>
+
+<file path="migrations/010_create_reporte_vistas.sql">
+-- Migracion: vistas unicas persistentes para usuarios autenticados
+CREATE TABLE IF NOT EXISTS reporte_vistas (
+  id_vista BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  id_reporte BIGINT UNSIGNED NOT NULL,
+  id_usuario BIGINT UNSIGNED NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id_vista),
+  UNIQUE KEY uk_reporte_vistas_reporte_usuario (id_reporte, id_usuario),
+  KEY idx_reporte_vistas_usuario (id_usuario),
+  CONSTRAINT fk_reporte_vistas_reporte
+    FOREIGN KEY (id_reporte) REFERENCES reportes(id_reporte)
+    ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT fk_reporte_vistas_usuario
+    FOREIGN KEY (id_usuario) REFERENCES usuarios(id_usuario)
+    ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+</file>
+
+<file path="migrations/011_add_prediction_indexes.sql">
+-- Migracion: indices para prediccion de zonas de riesgo y alertas.
+-- Idempotente para poder aplicarse en bases existentes sin borrar datos.
+
+SET @schema_name = DATABASE();
+
+SET @index_exists = (
+  SELECT COUNT(*)
+  FROM information_schema.statistics
+  WHERE table_schema = @schema_name
+    AND table_name = 'reportes'
+    AND index_name = 'idx_reportes_estado_created_at'
+);
+SET @sql = IF(
+  @index_exists = 0,
+  'CREATE INDEX idx_reportes_estado_created_at ON reportes (estado, created_at)',
+  'SELECT ''idx_reportes_estado_created_at ya existe'' AS info'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @index_exists = (
+  SELECT COUNT(*)
+  FROM information_schema.statistics
+  WHERE table_schema = @schema_name
+    AND table_name = 'reportes'
+    AND index_name = 'idx_reportes_tipo_created_at'
+);
+SET @sql = IF(
+  @index_exists = 0,
+  'CREATE INDEX idx_reportes_tipo_created_at ON reportes (tipo_contaminacion, created_at)',
+  'SELECT ''idx_reportes_tipo_created_at ya existe'' AS info'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @index_exists = (
+  SELECT COUNT(*)
+  FROM information_schema.statistics
+  WHERE table_schema = @schema_name
+    AND table_name = 'reportes'
+    AND index_name = 'idx_reportes_latitud_longitud'
+);
+SET @sql = IF(
+  @index_exists = 0,
+  'CREATE INDEX idx_reportes_latitud_longitud ON reportes (latitud, longitud)',
+  'SELECT ''idx_reportes_latitud_longitud ya existe'' AS info'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+</file>
+
+<file path="routes/chatbot.routes.js">
+import { Router } from 'express';
+import {
+  enviarMensajeChatbot,
+  obtenerFaqsChatbot,
+} from '../src/controllers/chatbot.controller.js';
+import { optionalAuth } from '../middlewares/auth.middleware.js';
+
+const chatbotRouter = Router();
+
+chatbotRouter.post('/mensaje', optionalAuth, enviarMensajeChatbot);
+chatbotRouter.get('/faqs', obtenerFaqsChatbot);
+
+export default chatbotRouter;
+</file>
+
+<file path="src/controllers/chatbot.controller.js">
+import { generarRespuestaChatbot } from '../services/chatbot.service.js';
+import { FAQ_GROUPS } from '../services/chatbot-offline.js';
+import { successResponse, errorResponse } from '../utils/response.js';
+
+const MAX_MESSAGE_LENGTH = 500;
+const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const RATE_LIMIT_MAX = 20;
+const rateLimitStore = new Map();
+
+export const clearChatbotRateLimit = () => {
+  rateLimitStore.clear();
+};
+
+const getRateLimitKey = (req, sessionId) => (
+  sessionId || req.ip || req.socket?.remoteAddress || 'anonymous'
+);
+
+const isRateLimited = (key) => {
+  const now = Date.now();
+  const entry = rateLimitStore.get(key);
+
+  if (!entry || entry.resetAt <= now) {
+    rateLimitStore.set(key, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return false;
+  }
+
+  entry.count += 1;
+  return entry.count > RATE_LIMIT_MAX;
+};
+
+export const enviarMensajeChatbot = async (req, res, next) => {
+  const startedAt = Date.now();
+
+  try {
+    const { mensaje, sessionId, lat, lng } = req.body ?? {};
+    const cleanMessage = typeof mensaje === 'string' ? mensaje.trim() : '';
+
+    if (!cleanMessage) {
+      return errorResponse(res, 'El mensaje es requerido.', 400);
+    }
+
+    if (cleanMessage.length > MAX_MESSAGE_LENGTH) {
+      return errorResponse(res, 'El mensaje no puede superar 500 caracteres.', 400);
+    }
+
+    if (isRateLimited(getRateLimitKey(req, sessionId))) {
+      return errorResponse(res, 'Demasiados mensajes. Intenta nuevamente en un minuto.', 429);
+    }
+
+    const result = await generarRespuestaChatbot({
+      mensaje: cleanMessage,
+      sessionId,
+      user: req.user,
+      lat,
+      lng,
+    });
+
+    return successResponse(
+      res,
+      {
+        sessionId,
+        respuesta: result.respuesta,
+        intent: result.intent,
+        fuente: result.fuente,
+        sugerencias: result.sugerencias,
+        cards: result.cards,
+        estadoAmbiental: result.estadoAmbiental,
+        latencia_ms: Date.now() - startedAt,
+      },
+      'Respuesta generada correctamente.'
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const obtenerFaqsChatbot = async (_req, res, next) => {
+  try {
+    return successResponse(
+      res,
+      { grupos: FAQ_GROUPS },
+      'FAQs obtenidas correctamente.'
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+</file>
+
+<file path="src/models/refresh-token.model.js">
+import pool from '../config/database.js';
+import { tableExists } from '../config/schema-compat.js';
+import { UsuarioModel } from './usuario.model.js';
+
+const memoryTokens = new Map();
+
+const hasRefreshTokensTable = () => tableExists('refresh_tokens');
+
+export const RefreshTokenModel = {
+  create: async ({
+    id_usuario,
+    token_hash,
+    expires_at,
+    user_agent = null,
+    ip_address = null,
+  }) => {
+    if (!await hasRefreshTokensTable()) {
+      const id_refresh_token = memoryTokens.size + 1;
+      memoryTokens.set(token_hash, {
+        id_refresh_token,
+        id_usuario,
+        token_hash,
+        expires_at,
+        revoked_at: null,
+        user_agent,
+        ip_address,
+      });
+      return id_refresh_token;
+    }
+
+    const [result] = await pool.execute(
+      `INSERT INTO refresh_tokens
+         (id_usuario, token_hash, expires_at, user_agent, ip_address)
+       VALUES (?, ?, ?, ?, ?)`,
+      [id_usuario, token_hash, expires_at, user_agent, ip_address]
+    );
+
+    return result.insertId;
+  },
+
+  findActiveByHash: async (token_hash) => {
+    if (!await hasRefreshTokensTable()) {
+      const token = memoryTokens.get(token_hash);
+      if (!token || token.revoked_at || new Date(token.expires_at).getTime() <= Date.now()) {
+        return null;
+      }
+
+      const user = await UsuarioModel.findById(token.id_usuario);
+      if (!user) {
+        return null;
+      }
+
+      return {
+        ...token,
+        ...user,
+      };
+    }
+
+    const [rows] = await pool.execute(
+      `SELECT rt.id_refresh_token, rt.id_usuario, rt.token_hash, rt.expires_at,
+              u.uuid, u.nombre, u.apellido, u.email, u.rol, u.activo,
+              u.email_verificado, u.avatar_url, u.telefono, u.created_at
+       FROM refresh_tokens rt
+       INNER JOIN usuarios u ON u.id_usuario = rt.id_usuario
+       WHERE rt.token_hash = ?
+         AND rt.revoked_at IS NULL
+         AND rt.expires_at > NOW()
+         AND u.deleted_at IS NULL
+       LIMIT 1`,
+      [token_hash]
+    );
+
+    return rows[0] ?? null;
+  },
+
+  revokeByHash: async (token_hash) => {
+    if (!await hasRefreshTokensTable()) {
+      const token = memoryTokens.get(token_hash);
+      if (!token || token.revoked_at) {
+        return false;
+      }
+      token.revoked_at = new Date();
+      return true;
+    }
+
+    const [result] = await pool.execute(
+      `UPDATE refresh_tokens
+       SET revoked_at = NOW()
+       WHERE token_hash = ? AND revoked_at IS NULL`,
+      [token_hash]
+    );
+
+    return result.affectedRows > 0;
+  },
+
+  rotate: async ({
+    current_hash,
+    next_hash,
+    expires_at,
+    user_agent = null,
+    ip_address = null,
+  }) => {
+    if (!await hasRefreshTokensTable()) {
+      const current = memoryTokens.get(current_hash);
+      if (!current || current.revoked_at || new Date(current.expires_at).getTime() <= Date.now()) {
+        return null;
+      }
+
+      current.revoked_at = new Date();
+      const id_refresh_token = memoryTokens.size + 1;
+      memoryTokens.set(next_hash, {
+        id_refresh_token,
+        id_usuario: current.id_usuario,
+        token_hash: next_hash,
+        expires_at,
+        revoked_at: null,
+        user_agent,
+        ip_address,
+      });
+
+      return {
+        id_usuario: current.id_usuario,
+        id_refresh_token,
+      };
+    }
+
+    const connection = await pool.getConnection();
+
+    try {
+      await connection.beginTransaction();
+
+      const [rows] = await connection.execute(
+        `SELECT id_refresh_token, id_usuario
+         FROM refresh_tokens
+         WHERE token_hash = ?
+           AND revoked_at IS NULL
+           AND expires_at > NOW()
+         LIMIT 1
+         FOR UPDATE`,
+        [current_hash]
+      );
+
+      const current = rows[0] ?? null;
+      if (!current) {
+        await connection.rollback();
+        return null;
+      }
+
+      await connection.execute(
+        `UPDATE refresh_tokens
+         SET revoked_at = NOW()
+         WHERE id_refresh_token = ?`,
+        [current.id_refresh_token]
+      );
+
+      const [insertResult] = await connection.execute(
+        `INSERT INTO refresh_tokens
+           (id_usuario, token_hash, expires_at, user_agent, ip_address)
+         VALUES (?, ?, ?, ?, ?)`,
+        [current.id_usuario, next_hash, expires_at, user_agent, ip_address]
+      );
+
+      await connection.commit();
+      return {
+        id_usuario: current.id_usuario,
+        id_refresh_token: insertResult.insertId,
+      };
+    } catch (error) {
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  },
+
+  revokeAllForUser: async (id_usuario) => {
+    if (!await hasRefreshTokensTable()) {
+      let revoked = 0;
+      for (const token of memoryTokens.values()) {
+        if (Number(token.id_usuario) === Number(id_usuario) && !token.revoked_at) {
+          token.revoked_at = new Date();
+          revoked += 1;
+        }
+      }
+      return revoked;
+    }
+
+    const [result] = await pool.execute(
+      `UPDATE refresh_tokens
+       SET revoked_at = NOW()
+       WHERE id_usuario = ? AND revoked_at IS NULL`,
+      [id_usuario]
+    );
+
+    return result.affectedRows;
+  },
+};
+</file>
+
+<file path="src/services/chatbot-context.js">
+import { ReporteModel } from '../models/reporte.model.js';
+import {
+  calcularAlertasPredictivas,
+  parseAlertasParams,
+} from './prediccion.service.js';
+
+const toNumber = (value) => {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+};
+
+export const construirContextoChatbot = async ({ user, lat, lng } = {}) => {
+  const userId = user?.sub;
+  const latitude = toNumber(lat);
+  const longitude = toNumber(lng);
+  const hasLocation = latitude !== null && longitude !== null;
+
+  const [global, usuario, alertasPayload] = await Promise.all([
+    ReporteModel.getStats().catch(() => ({})),
+    userId
+      ? Promise.all([
+        ReporteModel.findByUsuario(userId, { limit: 5, offset: 0 }).catch(() => []),
+        ReporteModel.countByUsuario(userId).catch(() => 0),
+      ]).then(([reportes, total]) => ({ reportes, total_reportes: Number(total) || 0 }))
+      : Promise.resolve(null),
+    hasLocation
+      ? calcularAlertasPredictivas(parseAlertasParams({
+        lat: latitude,
+        lng: longitude,
+        radio_km: 25,
+        limite: 3,
+        min_score: 0,
+        nivel_min: 'medio',
+      })).catch(() => ({ alertas: [] }))
+      : Promise.resolve({ alertas: [] }),
+  ]);
+
+  return {
+    global,
+    usuario,
+    alertasZona: alertasPayload.alertas || [],
+  };
+};
+</file>
+
+<file path="tests/auth/refresh-flow.manual.ps1">
+$ErrorActionPreference = "Stop"
+
+$baseUrl = "http://localhost:3000"
+$email = "refresh-demo-$([DateTimeOffset]::UtcNow.ToUnixTimeSeconds())@example.com"
+$password = "Password123!"
+
+Write-Host "== GreenAlert refresh token flow ==" -ForegroundColor Cyan
+Write-Host "API: $baseUrl"
+Write-Host ""
+
+Write-Host "1. Health check" -ForegroundColor Yellow
+$health = Invoke-RestMethod -Uri "$baseUrl/health" -Method GET
+$health | ConvertTo-Json -Depth 5
+Write-Host ""
+
+Write-Host "2. Registro de usuario temporal" -ForegroundColor Yellow
+$registerBody = @{
+  nombre = "Refresh"
+  apellido = "Demo"
+  email = $email
+  password = $password
+  telefono = "3000000000"
+} | ConvertTo-Json
+
+$register = Invoke-RestMethod `
+  -Uri "$baseUrl/auth/register" `
+  -Method POST `
+  -ContentType "application/json" `
+  -Body $registerBody
+
+Write-Host "Usuario: $email"
+Write-Host "Access token recibido: $([bool]$register.data.accessToken)"
+Write-Host "Refresh token recibido: $([bool]$register.data.refreshToken)"
+Write-Host ""
+
+Write-Host "3. Renovar access token con refresh token" -ForegroundColor Yellow
+$oldRefreshToken = $register.data.refreshToken
+$refreshBody = @{ refreshToken = $oldRefreshToken } | ConvertTo-Json
+
+$refresh = Invoke-RestMethod `
+  -Uri "$baseUrl/auth/refresh" `
+  -Method POST `
+  -ContentType "application/json" `
+  -Body $refreshBody
+
+Write-Host "Refresh exitoso: $($refresh.status)"
+Write-Host "Nuevo access token recibido: $([bool]$refresh.data.accessToken)"
+Write-Host "Nuevo refresh token recibido: $([bool]$refresh.data.refreshToken)"
+Write-Host "Refresh token rotado: $($refresh.data.refreshToken -ne $oldRefreshToken)"
+Write-Host ""
+
+Write-Host "4. Reusar refresh token viejo debe fallar" -ForegroundColor Yellow
+try {
+  Invoke-RestMethod `
+    -Uri "$baseUrl/auth/refresh" `
+    -Method POST `
+    -ContentType "application/json" `
+    -Body $refreshBody | ConvertTo-Json -Depth 5
+} catch {
+  $_.ErrorDetails.Message
+}
+Write-Host ""
+
+Write-Host "5. Logout invalida el refresh token actual" -ForegroundColor Yellow
+$logoutBody = @{ refreshToken = $refresh.data.refreshToken } | ConvertTo-Json
+$logout = Invoke-RestMethod `
+  -Uri "$baseUrl/auth/logout" `
+  -Method POST `
+  -ContentType "application/json" `
+  -Body $logoutBody
+
+$logout | ConvertTo-Json -Depth 5
+Write-Host ""
+
+Write-Host "6. Usar refresh token despues de logout debe fallar" -ForegroundColor Yellow
+try {
+  Invoke-RestMethod `
+    -Uri "$baseUrl/auth/refresh" `
+    -Method POST `
+    -ContentType "application/json" `
+    -Body $logoutBody | ConvertTo-Json -Depth 5
+} catch {
+  $_.ErrorDetails.Message
+}
+Write-Host ""
+
+Write-Host "Prueba finalizada." -ForegroundColor Green
+</file>
+
+<file path="tests/unit/categoria-riesgo.test.js">
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { CategoriaRiesgoModel } from '../../src/models/categoria-riesgo.model.js';
+
+test('CategoriaRiesgoModel.esValido retorna true cuando la categoria existe y esta activa', async (t) => {
+  t.mock.method(CategoriaRiesgoModel, 'findByCodigo', async (codigo) => ({
+    codigo,
+    activo: 1,
+  }));
+
+  assert.equal(await CategoriaRiesgoModel.esValido('inundacion'), true);
+  assert.equal(CategoriaRiesgoModel.findByCodigo.mock.callCount(), 1);
+});
+
+test('CategoriaRiesgoModel.esValido retorna false cuando la categoria no existe o esta inactiva', async (t) => {
+  t.mock.method(CategoriaRiesgoModel, 'findByCodigo', async () => null);
+
+  assert.equal(await CategoriaRiesgoModel.esValido('categoria_inexistente'), false);
+});
+
+test('CategoriaRiesgoModel.esValido retorna false cuando findByCodigo devuelve categoria inactiva', async (t) => {
+  t.mock.method(CategoriaRiesgoModel, 'findByCodigo', async (codigo) => ({
+    codigo,
+    activo: 0,
+  }));
+
+  assert.equal(await CategoriaRiesgoModel.esValido('inundacion'), false);
+});
+
+test('CategoriaRiesgoModel.findByCodigo consulta solo categorias activas', () => {
+  const source = CategoriaRiesgoModel.findByCodigo.toString();
+
+  assert.match(source, /WHERE cr\.codigo = \? AND cr\.activo = 1/);
+});
+</file>
+
+<file path="tests/unit/evidencia-soft-delete.test.js">
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const backendRoot = path.resolve(path.dirname(__filename), '../..');
+
+const readBackendFile = (relativePath) => {
+  return fs.readFileSync(path.join(backendRoot, relativePath), 'utf8');
+};
+
+test('EvidenciaModel.findByReporte filtra evidencias eliminadas logicamente', () => {
+  const model = readBackendFile('src/models/evidencia.model.js');
+  const findStart = model.indexOf('findByReporte: async');
+  const createStart = model.indexOf('create: async', findStart);
+  const findSection = model.slice(findStart, createStart);
+
+  assert.match(findSection, /WHERE id_reporte = \? AND deleted_at IS NULL/);
+});
+
+test('EvidenciaModel.create no marca evidencias como eliminadas', () => {
+  const model = readBackendFile('src/models/evidencia.model.js');
+  const createStart = model.indexOf('create: async');
+  const removeStart = model.indexOf('remove: async', createStart);
+  const createSection = model.slice(createStart, removeStart);
+
+  assert.doesNotMatch(createSection, /deleted_at/);
+});
+</file>
+
+<file path="tests/unit/frontend-api-contract.test.js">
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const backendDir = path.resolve(path.dirname(__filename), '../..');
+const repoDir = path.resolve(backendDir, '..');
+const frontendApiPath = path.join(repoDir, 'Frontend', 'src', 'services', 'api.js');
+
+const expectedFrontendContracts = [
+  { method: 'get', path: '/health' },
+  { method: 'post', path: '/auth/login' },
+  { method: 'post', path: '/auth/register' },
+  { method: 'post', path: '/auth/google' },
+  { method: 'post', path: '/auth/facebook' },
+  { method: 'get', path: '/categorias' },
+  { method: 'get', path: '/categorias/${codigo}' },
+  { method: 'get', path: '/reportes/stats' },
+  { method: 'get', path: '/reportes/stats/categoria' },
+  { method: 'get', path: '/reportes/stats/timeline' },
+  { method: 'get', path: '/reportes/stats/heatmap' },
+  { method: 'get', path: '/reportes/stats/ia' },
+  { method: 'post', path: '/reportes' },
+  { method: 'get', path: '/reportes' },
+  { method: 'get', path: '/reportes/${id}' },
+  { method: 'post', path: '/reportes/analizar-imagen' },
+  { method: 'patch', path: '/reportes/${id}' },
+  { method: 'delete', path: '/reportes/${id}' },
+  { method: 'get', path: '/reportes/export' },
+  { method: 'post', path: '/reportes/${id}/like' },
+  { method: 'get', path: '/reportes/trending' },
+  { method: 'get', path: '/reportes/zonas-riesgo' },
+  { method: 'get', path: '/reportes/alertas-predictivas' },
+  { method: 'get', path: '/auth/perfil' },
+  { method: 'patch', path: '/auth/perfil' },
+  { method: 'patch', path: '/auth/avatar' },
+  { method: 'patch', path: '/auth/cambiar-contrasena' },
+  { method: 'patch', path: '/auth/notificaciones' },
+  { method: 'get', path: '/reportes/mis-reportes' },
+  { method: 'post', path: '/auth/forgot-password' },
+  { method: 'post', path: '/auth/reset-password' },
+  { method: 'post', path: '/auth/enviar-verificacion' },
+  { method: 'post', path: '/auth/verificar-email' },
+  { method: 'get', path: '/admin/usuarios/stats' },
+  { method: 'get', path: '/admin/usuarios' },
+  { method: 'get', path: '/admin/usuarios/${id}' },
+  { method: 'patch', path: '/admin/usuarios/${id}/rol' },
+  { method: 'patch', path: '/admin/usuarios/${id}/estado' },
+  { method: 'delete', path: '/admin/usuarios/${id}' },
+  { method: 'post', path: '/chatbot/mensaje' },
+  { method: 'get', path: '/chatbot/faqs' },
+  { method: 'get', path: '/notificaciones' },
+  { method: 'get', path: '/notificaciones/contador' },
+  { method: 'post', path: '/notificaciones/fcm-token' },
+  { method: 'patch', path: '/notificaciones/${uuid}/leida' },
+  { method: 'patch', path: '/notificaciones/marcar-todas' },
+  { method: 'delete', path: '/notificaciones/${uuid}' },
+];
+
+const normalizeTemplate = (value) => value
+  .replace(/\$\{uuid\}/g, '__UUID__')
+  .replace(/\$\{codigo\}/g, '__CODIGO__')
+  .replace(/\$\{[^}]+\}/g, '${id}')
+  .replace(/__UUID__/g, '${uuid}')
+  .replace(/__CODIGO__/g, '${codigo}');
+
+const extractContracts = (source) => {
+  const contracts = [];
+  const regex = /api\.(get|post|patch|delete)\((`[^`]+`|'[^']+'|"[^"]+")/g;
+  let match;
+
+  while ((match = regex.exec(source)) !== null) {
+    contracts.push({
+      method: match[1],
+      path: normalizeTemplate(match[2].slice(1, -1)),
+    });
+  }
+
+  return contracts;
+};
+
+test('frontend usa baseURL /api para que Vite haga proxy al backend sin prefijo interno', async () => {
+  const source = await fs.readFile(frontendApiPath, 'utf8');
+
+  assert.match(source, /baseURL:\s*'\/api'/);
+});
+
+test('endpoints consumidos por Frontend/src/services/api.js estan registrados en el contrato esperado', async () => {
+  const source = await fs.readFile(frontendApiPath, 'utf8');
+  const actual = extractContracts(source);
+  const expectedKeys = new Set(expectedFrontendContracts.map((item) => `${item.method} ${item.path}`));
+  const actualKeys = actual.map((item) => `${item.method} ${item.path}`);
+  const missingFromExpected = actualKeys.filter((key) => !expectedKeys.has(key));
+  const notUsedByFrontend = [...expectedKeys].filter((key) => !actualKeys.includes(key));
+
+  assert.deepEqual(missingFromExpected, []);
+  assert.deepEqual(notUsedByFrontend, []);
+});
+
+test('contrato de frontend cubre modulos principales verificados por la suite', () => {
+  const prefixes = new Set(expectedFrontendContracts.map(({ path: routePath }) => routePath.split('/')[1]));
+
+  assert.deepEqual([...prefixes].sort(), [
+    'admin',
+    'auth',
+    'categorias',
+    'chatbot',
+    'health',
+    'notificaciones',
+    'reportes',
+  ]);
+});
+</file>
+
+<file path="tests/unit/optional-auth.test.js">
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import jwt from 'jsonwebtoken';
+import { optionalAuth } from '../../middlewares/auth.middleware.js';
+import { LikeModel } from '../../src/models/like.model.js';
+import { ReporteModel } from '../../src/models/reporte.model.js';
+
+process.env.API_PREFIX = '';
+process.env.JWT_SECRET = 'optional-auth-test-secret';
+
+const createResponse = () => ({
+  statusCode: null,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+});
+
+const listen = async () => {
+  const { default: app } = await import('../../src/app.js');
+
+  return new Promise((resolve) => {
+    const server = http.createServer(app);
+    server.listen(0, () => resolve(server));
+  });
+};
+
+const close = (server) => new Promise((resolve, reject) => {
+  server.close((error) => (error ? reject(error) : resolve()));
+});
+
+const request = async (server, path, options = {}) => {
+  const { port } = server.address();
+  return fetch(`http://127.0.0.1:${port}${path}`, options);
+};
+
+test('optionalAuth permite continuar sin token como anonimo', () => {
+  const req = { headers: {} };
+  const res = createResponse();
+  let nextCalled = false;
+
+  optionalAuth(req, res, () => {
+    nextCalled = true;
+  });
+
+  assert.equal(nextCalled, true);
+  assert.equal(req.user, undefined);
+  assert.equal(res.statusCode, null);
+});
+
+test('optionalAuth llena req.user con token valido', () => {
+  const token = jwt.sign(
+    { sub: 21, email: 'user@example.com', rol: 'ciudadano' },
+    process.env.JWT_SECRET
+  );
+  const req = {
+    headers: {
+      authorization: `Bearer ${token}`,
+    },
+  };
+  const res = createResponse();
+  let nextCalled = false;
+
+  optionalAuth(req, res, () => {
+    nextCalled = true;
+  });
+
+  assert.equal(nextCalled, true);
+  assert.equal(req.user.sub, 21);
+  assert.equal(res.statusCode, null);
+});
+
+test('optionalAuth ignora token invalido y continua como anonimo', () => {
+  const req = {
+    headers: {
+      authorization: 'Bearer token-invalido',
+    },
+    user: { sub: 99 },
+  };
+  const res = createResponse();
+  let nextCalled = false;
+
+  optionalAuth(req, res, () => {
+    nextCalled = true;
+  });
+
+  assert.equal(nextCalled, true);
+  assert.equal(req.user, undefined);
+  assert.equal(res.statusCode, null);
+});
+
+test('GET /reportes responde anonimo y enriquece liked_by_me con token valido', async (t) => {
+  const reportes = [
+    { id_reporte: 10, titulo: 'Reporte 10' },
+    { id_reporte: 11, titulo: 'Reporte 11' },
+  ];
+  t.mock.method(ReporteModel, 'findAll', async () => reportes);
+  t.mock.method(ReporteModel, 'countAll', async () => 2);
+  t.mock.method(LikeModel, 'likedSet', async (_ids, idUsuario) => (
+    Number(idUsuario) === 21 ? new Set([10]) : new Set()
+  ));
+
+  const server = await listen();
+
+  try {
+    const anon = await request(server, '/reportes');
+    const anonBody = await anon.json();
+
+    assert.equal(anon.status, 200);
+    assert.equal(anonBody.data.reportes[0].liked_by_me, undefined);
+
+    const token = jwt.sign(
+      { sub: 21, email: 'user@example.com', rol: 'ciudadano' },
+      process.env.JWT_SECRET
+    );
+    const authenticated = await request(server, '/reportes', {
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    });
+    const authenticatedBody = await authenticated.json();
+
+    assert.equal(authenticated.status, 200);
+    assert.equal(authenticatedBody.data.reportes[0].liked_by_me, true);
+    assert.equal(authenticatedBody.data.reportes[1].liked_by_me, false);
+
+    const invalid = await request(server, '/reportes', {
+      headers: {
+        authorization: 'Bearer token-invalido',
+      },
+    });
+    const invalidBody = await invalid.json();
+
+    assert.equal(invalid.status, 200);
+    assert.equal(invalidBody.data.reportes[0].liked_by_me, undefined);
+  } finally {
+    await close(server);
+  }
+});
+
+test('POST /chatbot/mensaje ignora token invalido y responde como anonimo', async (t) => {
+  t.mock.method(ReporteModel, 'getStats', async () => ({
+    total_reportes: 0,
+    municipios_activos: 0,
+  }));
+  t.mock.method(ReporteModel, 'getAlertasPredictivas', async () => []);
+
+  const server = await listen();
+
+  try {
+    const response = await request(server, '/chatbot/mensaje', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: 'Bearer token-invalido',
+      },
+      body: JSON.stringify({ mensaje: 'Como crear un reporte?' }),
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.status, 'success');
+    assert.equal(body.data.intent, 'reportes');
+  } finally {
+    await close(server);
+  }
+});
+</file>
+
+<file path="tests/unit/reporte-enum-validacion.test.js">
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { updateReporte } from '../../src/controllers/reporte.controller.js';
+import { NotificacionModel } from '../../src/models/notificacion.model.js';
+import { ReporteModel } from '../../src/models/reporte.model.js';
+
+const createResponse = () => ({
+  statusCode: null,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+});
+
+const createModeratorRequest = (body) => ({
+  params: { id: '15' },
+  user: { sub: 9, rol: 'moderador' },
+  body,
+});
+
+test('updateReporte acepta estado y nivel_severidad validos normalizados', async (t) => {
+  t.mock.method(ReporteModel, 'findById', async () => ({
+    id_reporte: 15,
+    id_usuario: 7,
+    estado: 'pendiente',
+  }));
+  t.mock.method(ReporteModel, 'update', async () => true);
+  t.mock.method(NotificacionModel, 'create', async () => ({ id_notificacion: 1, uuid: 'notif-1' }));
+
+  const req = createModeratorRequest({
+    estado: ' En_Revision ',
+    nivel_severidad: ' Critico ',
+  });
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await updateReporte(req, res, next);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(ReporteModel.update.mock.callCount(), 1);
+  assert.deepEqual(ReporteModel.update.mock.calls[0].arguments[1], {
+    estado: 'en_revision',
+    nivel_severidad: 'critico',
+  });
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('updateReporte rechaza estado invalido antes de actualizar', async (t) => {
+  t.mock.method(ReporteModel, 'findById', async () => ({
+    id_reporte: 15,
+    id_usuario: 7,
+    estado: 'pendiente',
+  }));
+  t.mock.method(ReporteModel, 'update', async () => {
+    throw new Error('No debe actualizar reportes con estado invalido');
+  });
+
+  const req = createModeratorRequest({ estado: 'cerrado' });
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await updateReporte(req, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.message, 'El estado debe ser uno de: pendiente, en_revision, verificado, en_proceso, rechazado, resuelto.');
+  assert.equal(ReporteModel.update.mock.callCount(), 0);
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('updateReporte rechaza nivel_severidad invalido antes de actualizar', async (t) => {
+  t.mock.method(ReporteModel, 'findById', async () => ({
+    id_reporte: 15,
+    id_usuario: 7,
+    estado: 'pendiente',
+  }));
+  t.mock.method(ReporteModel, 'update', async () => {
+    throw new Error('No debe actualizar reportes con severidad invalida');
+  });
+
+  const req = createModeratorRequest({ nivel_severidad: 'extremo' });
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await updateReporte(req, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.message, 'El nivel de severidad debe ser uno de: bajo, medio, alto, critico.');
+  assert.equal(ReporteModel.update.mock.callCount(), 0);
+  assert.equal(next.mock.callCount(), 0);
+});
+</file>
+
+<file path="src/controllers/categoria-riesgo.controller.js">
+import { CategoriaRiesgoModel } from '../models/categoria-riesgo.model.js';
+import { ReporteModel } from '../models/reporte.model.js';
+import { successResponse, errorResponse } from '../utils/response.js';
+
+const CODIGO_REGEX = /^[a-z0-9_]+$/;
+const COLOR_HEX_REGEX = /^#[0-9a-fA-F]{6}$/;
+
+const normalizeCodigo = (codigo) => (
+  typeof codigo === 'string' ? codigo.trim().toLowerCase() : ''
+);
+
+const normalizeOptionalText = (value) => (
+  typeof value === 'string' ? (value.trim() || null) : null
+);
+
+const parseActivo = (value) => {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return value === 1 ? true : value === 0 ? false : null;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'true' || normalized === '1') return true;
+    if (normalized === 'false' || normalized === '0') return false;
+  }
+  return null;
+};
+
+const parseNivelPrioridad = (value) => {
+  if (value === undefined || value === null || value === '') return null;
+
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : undefined;
+};
+
+const validateCodigo = (codigo) => {
+  if (!codigo) return 'El codigo de categoria es requerido.';
+  if (!CODIGO_REGEX.test(codigo)) {
+    return 'El codigo solo puede contener letras minusculas, numeros y guion bajo.';
+  }
+  return null;
+};
+
+const buildCategoryPayload = ({ requireAll = false, body = {} } = {}) => {
+  const payload = {};
+
+  if (Object.prototype.hasOwnProperty.call(body, 'nombre') || requireAll) {
+    const nombre = typeof body.nombre === 'string' ? body.nombre.trim() : '';
+    if (!nombre || nombre.length < 3) {
+      return { error: 'El nombre debe tener al menos 3 caracteres.' };
+    }
+    payload.nombre = nombre;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(body, 'descripcion')) {
+    payload.descripcion = normalizeOptionalText(body.descripcion);
+  }
+
+  if (Object.prototype.hasOwnProperty.call(body, 'icono')) {
+    payload.icono = normalizeOptionalText(body.icono);
+  }
+
+  if (Object.prototype.hasOwnProperty.call(body, 'color_hex')) {
+    const colorHex = normalizeOptionalText(body.color_hex);
+    if (colorHex && !COLOR_HEX_REGEX.test(colorHex)) {
+      return { error: 'El color_hex debe tener formato hexadecimal, por ejemplo #16a34a.' };
+    }
+    payload.color_hex = colorHex;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(body, 'nivel_prioridad_default')) {
+    const nivel = parseNivelPrioridad(body.nivel_prioridad_default);
+    if (nivel === undefined) {
+      return { error: 'El nivel_prioridad_default debe ser un entero positivo o cero.' };
+    }
+    payload.nivel_prioridad_default = nivel;
+  }
+
+  return { payload };
+};
+
+/**
+ * Controlador para gestionar categorías de riesgo ambiental
+ * 
+ * Proporciona endpoints para:
+ * - Listar todas las categorías con estadísticas
+ * - Obtener detalles de una categoría específica
+ * - Filtrar reportes por categoría
+ * - Ver estadísticas de reportes por categoría
+ */
+
+/**
+ * GET /api/categorias
+ * Obtiene todas las categorías activas con estadísticas
+ */
+export const obtenerTodasLasCategorias = async (req, res, next) => {
+  try {
+    const categorias = await CategoriaRiesgoModel.findAll(true);
+    
+    if (!categorias || categorias.length === 0) {
+      return successResponse(res, { categorias: [] }, 'No hay categorías disponibles.');
+    }
+
+    return successResponse(
+      res, 
+      { 
+        categorias,
+        total: categorias.length 
+      }, 
+      'Categorías obtenidas correctamente.'
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const crearCategoria = async (req, res, next) => {
+  try {
+    const codigo = normalizeCodigo(req.body?.codigo);
+    const codigoError = validateCodigo(codigo);
+
+    if (codigoError) {
+      return errorResponse(res, codigoError, 400);
+    }
+
+    const { payload, error } = buildCategoryPayload({
+      requireAll: true,
+      body: req.body,
+    });
+
+    if (error) {
+      return errorResponse(res, error, 400);
+    }
+
+    const existing = await CategoriaRiesgoModel.findByCodigoIncludingInactive(codigo);
+    if (existing) {
+      return errorResponse(res, 'Ya existe una categoria con ese codigo.', 409);
+    }
+
+    const activo = Object.prototype.hasOwnProperty.call(req.body ?? {}, 'activo')
+      ? parseActivo(req.body.activo)
+      : true;
+
+    if (activo === null) {
+      return errorResponse(res, 'El campo activo debe ser booleano.', 400);
+    }
+
+    await CategoriaRiesgoModel.create({
+      codigo,
+      ...payload,
+      activo,
+    });
+
+    const categoria = await CategoriaRiesgoModel.findByCodigoIncludingInactive(codigo);
+
+    return successResponse(
+      res,
+      { categoria },
+      'Categoria creada correctamente.',
+      201
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const actualizarCategoria = async (req, res, next) => {
+  try {
+    const codigo = normalizeCodigo(req.params.codigo);
+    const codigoError = validateCodigo(codigo);
+
+    if (codigoError) {
+      return errorResponse(res, codigoError, 400);
+    }
+
+    const existing = await CategoriaRiesgoModel.findByCodigoIncludingInactive(codigo);
+    if (!existing) {
+      return errorResponse(res, 'Categoria no encontrada.', 404);
+    }
+
+    const { payload, error } = buildCategoryPayload({ body: req.body });
+    if (error) {
+      return errorResponse(res, error, 400);
+    }
+
+    if (Object.keys(payload).length === 0) {
+      return errorResponse(res, 'No se enviaron campos validos para actualizar.', 400);
+    }
+
+    await CategoriaRiesgoModel.updateByCodigo(codigo, payload);
+    const categoria = await CategoriaRiesgoModel.findByCodigoIncludingInactive(codigo);
+
+    return successResponse(
+      res,
+      { categoria },
+      'Categoria actualizada correctamente.'
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const cambiarEstadoCategoria = async (req, res, next) => {
+  try {
+    const codigo = normalizeCodigo(req.params.codigo);
+    const codigoError = validateCodigo(codigo);
+
+    if (codigoError) {
+      return errorResponse(res, codigoError, 400);
+    }
+
+    const activo = parseActivo(req.body?.activo);
+    if (activo === null) {
+      return errorResponse(res, 'El campo activo debe ser booleano.', 400);
+    }
+
+    const existing = await CategoriaRiesgoModel.findByCodigoIncludingInactive(codigo);
+    if (!existing) {
+      return errorResponse(res, 'Categoria no encontrada.', 404);
+    }
+
+    await CategoriaRiesgoModel.updateActivoByCodigo(codigo, activo);
+    const categoria = await CategoriaRiesgoModel.findByCodigoIncludingInactive(codigo);
+
+    return successResponse(
+      res,
+      { categoria },
+      'Estado de categoria actualizado correctamente.'
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+/**
+ * GET /api/categorias/:codigo
+ * Obtiene detalles de una categoría específica
+ */
+export const obtenerCategoriaPorCodigo = async (req, res, next) => {
+  try {
+    const { codigo } = req.params;
+
+    if (!codigo || !codigo.trim()) {
+      return errorResponse(res, 'El código de categoría es requerido.', 400);
+    }
+
+    const categoria = await CategoriaRiesgoModel.findByCodigo(codigo.toLowerCase());
+
+    if (!categoria) {
+      return errorResponse(res, 'Categoría no encontrada.', 404);
+    }
+
+    return successResponse(
+      res, 
+      { categoria }, 
+      'Categoría obtenida correctamente.'
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+/**
+ * GET /api/categorias/:codigo/reportes
+ * Obtiene todos los reportes de una categoría específica con paginación
+ */
+export const obtenerReportesPorCategoria = async (req, res, next) => {
+  try {
+    const { codigo } = req.params;
+    const { estado, nivel_severidad, municipio, limit = 20, offset = 0 } = req.query;
+
+    if (!codigo || !codigo.trim()) {
+      return errorResponse(res, 'El código de categoría es requerido.', 400);
+    }
+
+    // Verificar que la categoría exista
+    const categoria = await CategoriaRiesgoModel.findByCodigo(codigo.toLowerCase());
+    if (!categoria) {
+      return errorResponse(res, 'Categoría no encontrada.', 404);
+    }
+
+    // Obtener reportes de esta categoría con filtros opcionales
+    const reportes = await ReporteModel.findAll({
+      tipo_contaminacion: codigo.toLowerCase(),
+      estado: estado ? estado.toLowerCase() : undefined,
+      nivel_severidad: nivel_severidad ? nivel_severidad.toLowerCase() : undefined,
+      municipio: municipio ? municipio.toLowerCase() : undefined,
+      limit: Math.max(1, Math.min(100, parseInt(limit, 10) || 20)),
+      offset: Math.max(0, parseInt(offset, 10) || 0),
+    });
+
+    return successResponse(
+      res, 
+      { 
+        categoria,
+        reportes,
+        total: reportes.length,
+        paginacion: {
+          limit: parseInt(limit, 10),
+          offset: parseInt(offset, 10)
+        }
+      }, 
+      `${reportes.length} reportes encontrados para la categoría "${categoria.nombre}".`
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+/**
+ * GET /api/categorias/estadisticas/resumen
+ * Obtiene estadísticas agregadas de reportes por categoría
+ * Útil para mostrar en dashboards
+ */
+export const obtenerEstadisticasCategorias = async (req, res, next) => {
+  try {
+    const estadisticas = await CategoriaRiesgoModel.getEstadisticasPorCategoria();
+
+    if (!estadisticas || estadisticas.length === 0) {
+      return successResponse(
+        res, 
+        { estadisticas: [] }, 
+        'No hay reportes disponibles.'
+      );
+    }
+
+    // Calcular totales
+    const totales = {
+      total_reportes: 0,
+      pendientes: 0,
+      en_revision: 0,
+      verificados: 0,
+      resueltos: 0,
+      criticos: 0
+    };
+
+    estadisticas.forEach(cat => {
+      totales.total_reportes += cat.total_reportes || 0;
+      totales.pendientes += cat.pendientes || 0;
+      totales.en_revision += cat.en_revision || 0;
+      totales.verificados += cat.verificados || 0;
+      totales.resueltos += cat.resueltos || 0;
+      totales.criticos += cat.criticos || 0;
+    });
+
+    return successResponse(
+      res, 
+      { 
+        estadisticas,
+        totales,
+        cantidad_categorias: estadisticas.length
+      }, 
+      'Estadísticas de categorías obtenidas correctamente.'
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+/**
+ * GET /api/categorias/estadisticas/por-severidad
+ * Obtiene estadísticas de reportes agrupadas por categoría y severidad
+ * Útil para análisis de riesgos
+ */
+export const obtenerEstadisticasSeveridad = async (req, res, next) => {
+  try {
+    // Obtener todas las categorías
+    const estadisticas = await CategoriaRiesgoModel.getEstadisticasPorSeveridad();
+
+    const estadisticasPorSeveridad = {};
+
+    // Para cada categoría, contar por severidad
+    for (const categoria of estadisticas) {
+      estadisticasPorSeveridad[categoria.codigo] = {
+        nombre_categoria: categoria.nombre,
+        icono: categoria.icono,
+        color: categoria.color_hex,
+        por_severidad: {
+          bajo: Number(categoria.bajo) || 0,
+          medio: Number(categoria.medio) || 0,
+          alto: Number(categoria.alto) || 0,
+          critico: Number(categoria.critico) || 0
+        }
+      };
+    }
+
+    return successResponse(
+      res, 
+      { estadisticasPorSeveridad }, 
+      'Estadísticas por severidad obtenidas correctamente.'
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+</file>
+
+<file path="src/models/evidencia.model.js">
+import pool from '../config/database.js';
+import { columnExists } from '../config/schema-compat.js';
+import { randomUUID } from 'crypto';
+
+export const EvidenciaModel = {
+  
+    // Trae todas las evidencias de un reporten 
+   
+  findByReporte: async (id_reporte) => {
+    const hasDeletedAt = await columnExists('evidencias', 'deleted_at');
+    // En esquemas con borrado logico se aplica: WHERE id_reporte = ? AND deleted_at IS NULL
+    const deletedFilter = hasDeletedAt ? 'AND deleted_at IS NULL' : '';
+
+    const [rows] = await pool.execute(
+      `SELECT id_evidencia, uuid, id_usuario, tipo_archivo,
+              url_archivo, nombre_original, mime_type, tamano_bytes,
+              hash_sha256, verificado, orden, created_at
+       FROM evidencias
+       WHERE id_reporte = ? ${deletedFilter}
+       ORDER BY orden ASC, created_at ASC`,
+      [id_reporte]
+    );
+    return rows;
+  },
+
+  findById: async (id_evidencia) => {
+    const hasDeletedAt = await columnExists('evidencias', 'deleted_at');
+    const deletedFilter = hasDeletedAt ? 'AND deleted_at IS NULL' : '';
+
+    const [rows] = await pool.execute(
+      `SELECT id_evidencia, uuid, id_reporte, id_usuario, tipo_archivo,
+              url_archivo, nombre_original, mime_type, tamano_bytes,
+              hash_sha256, verificado, orden, created_at
+       FROM evidencias
+       WHERE id_evidencia = ? ${deletedFilter}
+       LIMIT 1`,
+      [id_evidencia]
+    );
+
+    return rows[0] ?? null;
+  },
+
+  
+    // Registra una nueva evidencia asociada a un reporte
+   
+  create: async ({
+    id_reporte,
+    id_usuario,
+    tipo_archivo,
+    url_archivo,
+    nombre_original,
+    mime_type,
+    tamano_bytes,
+    hash_sha256 = null,
+    orden = 0,
+  }) => {
+    const uuid = randomUUID();
+    const [result] = await pool.execute(
+      `INSERT INTO evidencias
+         (uuid, id_reporte, id_usuario, tipo_archivo, url_archivo, nombre_original,
+          mime_type, tamano_bytes, hash_sha256, orden)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        uuid,
+        id_reporte, id_usuario, tipo_archivo, url_archivo, nombre_original,
+        mime_type, tamano_bytes, hash_sha256, orden,
+      ]
+    );
+    return result.insertId;
+  },
+
+  remove: async (id_evidencia) => {
+    if (!await columnExists('evidencias', 'deleted_at')) {
+      const [result] = await pool.execute(
+        `DELETE FROM evidencias
+         WHERE id_evidencia = ?`,
+        [id_evidencia]
+      );
+
+      return result.affectedRows > 0;
+    }
+
+    const [result] = await pool.execute(
+      `UPDATE evidencias
+       SET deleted_at = NOW()
+       WHERE id_evidencia = ? AND deleted_at IS NULL`,
+      [id_evidencia]
+    );
+
+    return result.affectedRows > 0;
+  },
+
+};
+</file>
+
+<file path="src/services/email.service.js">
+import { getEmailConfig } from '../config/email.config.js';
+
+let cachedTransporter = null;
+
+const getTransporter = async () => {
+  if (!cachedTransporter) {
+    const { default: nodemailer } = await import('nodemailer');
+    const { host, port, user, pass } = getEmailConfig();
+
+    if (process.env.EMAIL_TRANSPORT === 'json') {
+      cachedTransporter = nodemailer.createTransport({ jsonTransport: true });
+    } else {
+      cachedTransporter = nodemailer.createTransport({
+        host,
+        port,
+        secure: port === 465,
+        auth: {
+          user,
+          pass,
+        },
+      });
+    }
+  }
+
+  return cachedTransporter;
+};
+
+const escapeHtml = (value = '') =>
+  String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+
+export const generarTemplateBaseCorreo = ({
+  title,
+  subtitle = '',
+  previewText = '',
+  content,
+  actionUrl,
+  actionText,
+}) => {
+  const appName = process.env.APP_NAME || 'GreenAlert';
+  const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:5173';
+  const year = new Date().getFullYear();
+
+  const actionHtml = actionUrl && actionText
+    ? `
+      <p style="text-align:center; margin: 28px 0;">
+        <a href="${escapeHtml(actionUrl)}" style="display:inline-block;background:#059669;color:#ffffff;padding:12px 20px;border-radius:8px;font-weight:600;text-decoration:none;">
+          ${escapeHtml(actionText)}
+        </a>
+      </p>
+    `
+    : '';
+
+  return `
+    <!DOCTYPE html>
+    <html lang="es">
+    <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <title>${escapeHtml(title || appName)}</title>
+      <style>
+        body {
+          margin: 0;
+          padding: 24px 12px;
+          font-family: Arial, Helvetica, sans-serif;
+          line-height: 1.6;
+          color: #333333;
+          background-color: #f5f7f5;
+        }
+        .container {
+          max-width: 600px;
+          margin: 0 auto;
+          background-color: #ffffff;
+          border-radius: 8px;
+          box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+          overflow: hidden;
+        }
+        .header {
+          background: #059669;
+          color: #ffffff;
+          padding: 28px 20px;
+          text-align: center;
+        }
+        .header h1 {
+          margin: 0;
+          font-size: 28px;
+          font-weight: 700;
+        }
+        .content {
+          padding: 30px 22px;
+        }
+        .content h2 {
+          margin: 0 0 18px;
+          color: #111827;
+          font-size: 22px;
+        }
+        .message {
+          color: #4b5563;
+          margin-bottom: 18px;
+        }
+        .panel {
+          background-color: #f0fdf4;
+          border-left: 4px solid #10b981;
+          padding: 15px 18px;
+          margin: 20px 0;
+          border-radius: 4px;
+        }
+        .panel h3 {
+          margin: 0 0 10px;
+          color: #047857;
+          font-size: 16px;
+        }
+        .panel ul {
+          padding-left: 20px;
+          margin: 0;
+        }
+        .footer {
+          background-color: #f9fafb;
+          padding: 18px 20px;
+          text-align: center;
+          border-top: 1px solid #e5e7eb;
+          font-size: 13px;
+          color: #6b7280;
+        }
+        .footer p {
+          margin: 5px 0;
+        }
+        a {
+          color: #059669;
+        }
+      </style>
+    </head>
+    <body>
+      <span style="display:none;visibility:hidden;opacity:0;color:transparent;height:0;width:0;overflow:hidden;">
+        ${escapeHtml(previewText)}
+      </span>
+      <div class="container">
+        <div class="header">
+          <h1>${escapeHtml(appName)}</h1>
+          ${subtitle ? `<p style="margin: 10px 0 0 0; opacity: 0.92;">${escapeHtml(subtitle)}</p>` : ''}
+        </div>
+        <div class="content">
+          <h2>${escapeHtml(title || appName)}</h2>
+          ${content}
+          ${actionHtml}
+        </div>
+        <div class="footer">
+          <p>&copy; ${year} ${escapeHtml(appName)}. Todos los derechos reservados.</p>
+          <p>Este correo fue enviado automaticamente por ${escapeHtml(appName)}.</p>
+          <p><a href="${escapeHtml(frontendUrl)}">Ir a ${escapeHtml(appName)}</a></p>
+        </div>
+      </div>
+    </body>
+    </html>
+  `;
+};
+
+const generarTemplateBienvenida = (nombre, apellido) => {
+  const appName = process.env.APP_NAME || 'GreenAlert';
+  const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:5173';
+
+  return generarTemplateBaseCorreo({
+    title: `Hola ${nombre} ${apellido}`,
+    subtitle: 'Bienvenido a nuestra comunidad',
+    previewText: `Tu cuenta en ${appName} fue creada correctamente.`,
+    actionUrl: frontendUrl,
+    actionText: `Ir a ${appName}`,
+    content: `
+      <div class="message">
+        Tu cuenta ha sido creada correctamente. Ahora eres parte de ${escapeHtml(appName)}, una plataforma dedicada a reportar y monitorear riesgos ambientales en tu comunidad.
+      </div>
+      <div class="panel">
+        <h3>Que puedes hacer ahora</h3>
+        <ul>
+          <li>Reportar riesgos ambientales en tu zona</li>
+          <li>Visualizar reportes en el mapa interactivo</li>
+          <li>Consultar el estado de tus reportes</li>
+          <li>Acceder a tu panel de usuario</li>
+        </ul>
+      </div>
+      <div class="message">
+        Si tienes algun problema o pregunta, contacta al equipo de soporte.
+      </div>
+    `,
+  });
+};
+
+export const enviarCorreo = async (to, subject, html) => {
+  try {
+    const transporter = await getTransporter();
+    const { from } = getEmailConfig();
+
+    return transporter.sendMail({
+      from,
+      to,
+      subject,
+      html,
+    });
+  } catch (error) {
+    console.error('Error enviando correo:', error);
+    throw error;
+  }
+};
+
+export const verificarConexionSmtp = async () => {
+  const transporter = await getTransporter();
+  return transporter.verify();
+};
+
+export const enviarCorreoBienvenida = async (email, nombre, apellido) => {
+  try {
+    const html = generarTemplateBienvenida(nombre, apellido);
+    await enviarCorreo(email, 'Bienvenido a GreenAlert', html);
+    return true;
+  } catch (error) {
+    console.error('Error enviando correo de bienvenida:', error);
+    return false;
+  }
+};
+</file>
+
+<file path="tests/unit/reporte-categoria-validacion.test.js">
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createReporte } from '../../src/controllers/reporte.controller.js';
+import { CategoriaRiesgoModel } from '../../src/models/categoria-riesgo.model.js';
+import { ReporteModel } from '../../src/models/reporte.model.js';
+
+const createMockResponse = () => ({
+  statusCode: null,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+});
+
+const createValidRequest = (overrides = {}) => ({
+  user: { sub: 7 },
+  body: {
+    tipo_contaminacion: ' Inundacion ',
+    nivel_severidad: 'alto',
+    titulo: 'Reporte de inundacion',
+    descripcion: 'Nivel alto de agua en la zona',
+    direccion: 'Calle 10',
+    municipio: 'Valledupar',
+    departamento: 'Cesar',
+    latitud: 10.45,
+    longitud: -73.25,
+    ...overrides,
+  },
+});
+
+test('createReporte rechaza categoria inexistente o inactiva antes de insertar', async (t) => {
+  t.mock.method(CategoriaRiesgoModel, 'esValido', async () => false);
+  t.mock.method(ReporteModel, 'create', async () => {
+    throw new Error('No debe insertar reportes con categoria invalida');
+  });
+
+  const req = createValidRequest({ tipo_contaminacion: 'categoria_inexistente' });
+  const res = createMockResponse();
+  const next = t.mock.fn();
+
+  await createReporte(req, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.status, 'error');
+  assert.equal(res.body.message, 'La categoría de contaminación no existe o está inactiva.');
+  assert.equal(ReporteModel.create.mock.callCount(), 0);
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('createReporte crea reporte cuando la categoria existe y esta activa', async (t) => {
+  t.mock.method(CategoriaRiesgoModel, 'esValido', async () => true);
+  t.mock.method(ReporteModel, 'create', async () => 15);
+  t.mock.method(ReporteModel, 'findById', async () => ({
+    id_reporte: 15,
+    tipo_contaminacion: 'inundacion',
+    estado: 'pendiente',
+  }));
+  t.mock.method(ReporteModel, 'updateIaAnalysis', async () => true);
+
+  const req = createValidRequest();
+  const res = createMockResponse();
+  const next = t.mock.fn();
+
+  await createReporte(req, res, next);
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(res.body.status, 'success');
+  assert.equal(res.body.data.reporte.tipo_contaminacion, 'inundacion');
+  assert.equal(ReporteModel.create.mock.calls[0].arguments[0].tipo_contaminacion, 'inundacion');
+  assert.equal(ReporteModel.create.mock.calls[0].arguments[0].latitud, 10.45);
+  assert.equal(ReporteModel.create.mock.calls[0].arguments[0].longitud, -73.25);
+  assert.equal(ReporteModel.updateIaAnalysis.mock.callCount(), 1);
+  assert.deepEqual(
+    ReporteModel.updateIaAnalysis.mock.calls[0].arguments[1].procesado,
+    true
+  );
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('createReporte rechaza nivel de severidad invalido antes de insertar', async (t) => {
+  t.mock.method(CategoriaRiesgoModel, 'esValido', async () => {
+    throw new Error('No debe validar categoria si la severidad es invalida');
+  });
+  t.mock.method(ReporteModel, 'create', async () => {
+    throw new Error('No debe insertar reportes con severidad invalida');
+  });
+
+  const req = createValidRequest({ nivel_severidad: 'urgente' });
+  const res = createMockResponse();
+  const next = t.mock.fn();
+
+  await createReporte(req, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.status, 'error');
+  assert.equal(res.body.message, 'El nivel de severidad debe ser uno de: bajo, medio, alto, critico.');
+  assert.equal(CategoriaRiesgoModel.esValido.mock.callCount(), 0);
+  assert.equal(ReporteModel.create.mock.callCount(), 0);
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('createReporte rechaza latitud fuera de rango', async (t) => {
+  t.mock.method(CategoriaRiesgoModel, 'esValido', async () => true);
+  t.mock.method(ReporteModel, 'create', async () => {
+    throw new Error('No debe insertar reportes con latitud invalida');
+  });
+
+  const req = createValidRequest({ latitud: 91 });
+  const res = createMockResponse();
+  const next = t.mock.fn();
+
+  await createReporte(req, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.status, 'error');
+  assert.equal(res.body.message, 'La latitud debe estar entre -90 y 90.');
+  assert.equal(ReporteModel.create.mock.callCount(), 0);
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('createReporte rechaza longitud fuera de rango', async (t) => {
+  t.mock.method(CategoriaRiesgoModel, 'esValido', async () => true);
+  t.mock.method(ReporteModel, 'create', async () => {
+    throw new Error('No debe insertar reportes con longitud invalida');
+  });
+
+  const req = createValidRequest({ longitud: -181 });
+  const res = createMockResponse();
+  const next = t.mock.fn();
+
+  await createReporte(req, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.status, 'error');
+  assert.equal(res.body.message, 'La longitud debe estar entre -180 y 180.');
+  assert.equal(ReporteModel.create.mock.callCount(), 0);
+  assert.equal(next.mock.callCount(), 0);
+});
+</file>
+
+<file path="DATABASE_SCHEMA_COMPLETE.sql">
+-- ============================================================================
+-- Green Alert Database - Complete Schema
+-- ============================================================================
+-- This schema reflects the actual field usage in the codebase
+-- Generated from: models, controllers, and migration files
+-- Date: May 18, 2026
+-- ============================================================================
+
+-- Drop existing tables (use with caution!)
+-- DROP TABLE IF EXISTS notificaciones;
+-- DROP TABLE IF EXISTS reporte_vistas;
+-- DROP TABLE IF EXISTS reporte_likes;
+-- DROP TABLE IF EXISTS refresh_tokens;
+-- DROP TABLE IF EXISTS evidencias;
+-- DROP TABLE IF EXISTS reportes;
+-- DROP TABLE IF EXISTS categorias_riesgo;
+-- DROP TABLE IF EXISTS usuarios;
+
+-- ============================================================================
+-- TABLE: usuarios
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS usuarios (
+  id_usuario BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  uuid VARCHAR(36) UNIQUE NOT NULL,
+  google_id VARCHAR(255) UNIQUE NULL,
+  facebook_id VARCHAR(255) UNIQUE NULL,
+  nombre VARCHAR(100) NOT NULL,
+  apellido VARCHAR(100) NOT NULL,
+  email VARCHAR(100) NOT NULL UNIQUE,
+  password_hash VARCHAR(255) NULL,
+  rol ENUM('ciudadano', 'moderador', 'admin') DEFAULT 'ciudadano',
+  activo BOOLEAN DEFAULT TRUE,
+  email_verificado BOOLEAN DEFAULT FALSE,
+  avatar_url VARCHAR(255) NULL,
+  telefono VARCHAR(20) NULL,
+  notification_preferences JSON NULL,
+  ultimo_acceso DATETIME NULL,
+  token_reset VARCHAR(64) NULL,
+  token_reset_exp DATETIME NULL,
+  email_verification_token VARCHAR(64) NULL,
+  email_verification_exp DATETIME NULL,
+  otp_code_hash VARCHAR(64) NULL,
+  otp_exp DATETIME NULL,
+  otp_attempts INT DEFAULT 0,
+  otp_last_request DATETIME NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  deleted_at DATETIME NULL,
+  
+  -- Indexes
+  INDEX idx_email (email),
+  INDEX idx_uuid (uuid),
+  INDEX idx_google_id (google_id),
+  INDEX idx_facebook_id (facebook_id),
+  INDEX idx_email_verification_token (email_verification_token),
+  INDEX idx_email_verification_exp (email_verification_exp),
+  INDEX idx_otp_code_hash (otp_code_hash),
+  INDEX idx_otp_exp (otp_exp),
+  INDEX idx_deleted_at (deleted_at),
+  INDEX idx_rol (rol)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ============================================================================
+-- TABLE: categorias_riesgo
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS categorias_riesgo (
+  id_categoria INT AUTO_INCREMENT PRIMARY KEY,
+  codigo VARCHAR(50) UNIQUE NOT NULL,
+  nombre VARCHAR(100) NOT NULL,
+  descripcion TEXT NULL,
+  icono VARCHAR(255) NULL,
+  color_hex VARCHAR(7) NULL,
+  nivel_prioridad_default INT NULL,
+  activo BOOLEAN DEFAULT TRUE,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  deleted_at DATETIME NULL,
+  
+  -- Indexes
+  INDEX idx_codigo (codigo),
+  INDEX idx_activo (activo),
+  INDEX idx_deleted_at (deleted_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ============================================================================
+-- TABLE: reportes
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS reportes (
+  id_reporte BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  uuid VARCHAR(36) UNIQUE NOT NULL,
+  id_usuario BIGINT UNSIGNED NOT NULL,
+  tipo_contaminacion VARCHAR(50) NOT NULL,
+  subcategoria VARCHAR(100) NULL,
+  estado ENUM('pendiente', 'en_revision', 'verificado', 'en_proceso', 'rechazado', 'resuelto') DEFAULT 'pendiente',
+  nivel_severidad ENUM('bajo', 'medio', 'alto', 'critico') DEFAULT 'medio',
+  titulo VARCHAR(255) NOT NULL,
+  descripcion TEXT NULL,
+  latitud DECIMAL(10, 8) NULL,
+  longitud DECIMAL(11, 8) NULL,
+  punto_geo POINT SRID 4326 NULL,
+  direccion VARCHAR(255) NULL,
+  municipio VARCHAR(100) NULL,
+  departamento VARCHAR(100) NULL,
+  votos_relevancia INT DEFAULT 0,
+  vistas INT DEFAULT 0,
+  ia_etiquetas JSON NULL,
+  ia_confianza DECIMAL(5, 2) NULL,
+  ia_procesado BOOLEAN DEFAULT FALSE,
+  comentario_moderacion TEXT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  deleted_at DATETIME NULL,
+  
+  -- Foreign Keys
+  CONSTRAINT fk_reportes_usuario FOREIGN KEY (id_usuario) 
+    REFERENCES usuarios(id_usuario) ON DELETE RESTRICT ON UPDATE CASCADE,
+  
+  -- Indexes
+  INDEX idx_uuid (uuid),
+  INDEX idx_usuario (id_usuario),
+  INDEX idx_estado (estado),
+  INDEX idx_tipo_contaminacion (tipo_contaminacion),
+  INDEX idx_nivel_severidad (nivel_severidad),
+  INDEX idx_municipio (municipio),
+  INDEX idx_created_at (created_at),
+  INDEX idx_comentario_moderacion (comentario_moderacion(100)),
+  INDEX idx_deleted_at (deleted_at),
+  INDEX idx_reportes_estado_created_at (estado, created_at),
+  INDEX idx_reportes_tipo_created_at (tipo_contaminacion, created_at),
+  INDEX idx_reportes_latitud_longitud (latitud, longitud),
+  SPATIAL INDEX idx_punto_geo (punto_geo)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ============================================================================
+-- TABLE: evidencias
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS evidencias (
+  id_evidencia BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  uuid VARCHAR(36) UNIQUE NOT NULL,
+  id_reporte BIGINT UNSIGNED NOT NULL,
+  id_usuario BIGINT UNSIGNED NOT NULL,
+  tipo_archivo VARCHAR(50) NULL,
+  url_archivo VARCHAR(255) NOT NULL,
+  nombre_original VARCHAR(255) NULL,
+  mime_type VARCHAR(100) NULL,
+  tamano_bytes BIGINT NULL,
+  hash_sha256 VARCHAR(64) NULL,
+  metadatos_exif JSON NULL,
+  ia_analisis TEXT NULL,
+  ia_procesado BOOLEAN DEFAULT FALSE,
+  verificado BOOLEAN DEFAULT FALSE,
+  orden INT DEFAULT 0,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  deleted_at DATETIME NULL,
+  
+  -- Foreign Keys
+  CONSTRAINT fk_evidencias_reporte FOREIGN KEY (id_reporte) 
+    REFERENCES reportes(id_reporte) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT fk_evidencias_usuario FOREIGN KEY (id_usuario) 
+    REFERENCES usuarios(id_usuario) ON DELETE RESTRICT ON UPDATE CASCADE,
+  
+  -- Indexes
+  INDEX idx_uuid (uuid),
+  INDEX idx_reporte (id_reporte),
+  INDEX idx_usuario (id_usuario),
+  INDEX idx_hash_sha256 (hash_sha256),
+  INDEX idx_created_at (created_at),
+  INDEX idx_orden (orden),
+  INDEX idx_deleted_at (deleted_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ============================================================================
+-- TABLE: refresh_tokens
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS refresh_tokens (
+  id_refresh_token BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  id_usuario BIGINT UNSIGNED NOT NULL,
+  token_hash VARCHAR(64) NOT NULL UNIQUE,
+  expires_at DATETIME NOT NULL,
+  revoked_at DATETIME NULL,
+  user_agent VARCHAR(255) NULL,
+  ip_address VARCHAR(45) NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT fk_refresh_tokens_usuario FOREIGN KEY (id_usuario)
+    REFERENCES usuarios(id_usuario) ON DELETE CASCADE ON UPDATE CASCADE,
+
+  INDEX idx_refresh_token_hash (token_hash),
+  INDEX idx_refresh_usuario (id_usuario),
+  INDEX idx_refresh_expires_at (expires_at),
+  INDEX idx_refresh_revoked_at (revoked_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ============================================================================
+-- TABLE: reporte_likes
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS reporte_likes (
+  id_like BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  id_reporte BIGINT UNSIGNED NOT NULL,
+  id_usuario BIGINT UNSIGNED NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT fk_reporte_likes_reporte FOREIGN KEY (id_reporte)
+    REFERENCES reportes(id_reporte) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT fk_reporte_likes_usuario FOREIGN KEY (id_usuario)
+    REFERENCES usuarios(id_usuario) ON DELETE CASCADE ON UPDATE CASCADE,
+
+  UNIQUE KEY uk_reporte_likes_reporte_usuario (id_reporte, id_usuario),
+  INDEX idx_reporte_likes_usuario (id_usuario),
+  INDEX idx_reporte_likes_created_at (created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ============================================================================
+-- TABLE: reporte_vistas
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS reporte_vistas (
+  id_vista BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  id_reporte BIGINT UNSIGNED NOT NULL,
+  id_usuario BIGINT UNSIGNED NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT fk_reporte_vistas_reporte FOREIGN KEY (id_reporte)
+    REFERENCES reportes(id_reporte) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT fk_reporte_vistas_usuario FOREIGN KEY (id_usuario)
+    REFERENCES usuarios(id_usuario) ON DELETE CASCADE ON UPDATE CASCADE,
+
+  UNIQUE KEY uk_reporte_vistas_reporte_usuario (id_reporte, id_usuario),
+  INDEX idx_reporte_vistas_usuario (id_usuario),
+  INDEX idx_reporte_vistas_created_at (created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ============================================================================
+-- TABLE: notificaciones
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS notificaciones (
+  id_notificacion BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  uuid VARCHAR(36) UNIQUE NOT NULL,
+  id_usuario BIGINT UNSIGNED NOT NULL,
+  tipo ENUM('reporte_estado', 'reporte_comentario', 'reporte_creado', 'alerta_zona', 'sistema') NOT NULL,
+  titulo VARCHAR(150) NOT NULL,
+  mensaje TEXT NOT NULL,
+  referencia_tipo VARCHAR(30) NULL,
+  referencia_uuid VARCHAR(36) NULL,
+  link VARCHAR(255) NULL,
+  leida BOOLEAN DEFAULT FALSE,
+  leida_at DATETIME NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT fk_notificaciones_usuario FOREIGN KEY (id_usuario)
+    REFERENCES usuarios(id_usuario) ON DELETE CASCADE ON UPDATE CASCADE,
+
+  INDEX idx_notificaciones_usuario_leida (id_usuario, leida, created_at),
+  INDEX idx_notificaciones_uuid (uuid),
+  INDEX idx_notificaciones_referencia (referencia_tipo, referencia_uuid)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ============================================================================
+-- VIEWS (Optional, for common queries)
+-- ============================================================================
+
+-- Active usuarios only
+CREATE OR REPLACE VIEW v_usuarios_activos AS
+SELECT * FROM usuarios 
+WHERE deleted_at IS NULL AND activo = TRUE;
+
+-- Reports with author information
+CREATE OR REPLACE VIEW v_reportes_con_autor AS
+SELECT 
+  r.*,
+  u.nombre AS autor_nombre,
+  u.apellido AS autor_apellido,
+  u.email AS autor_email,
+  u.rol AS autor_rol
+FROM reportes r
+LEFT JOIN usuarios u ON u.id_usuario = r.id_usuario
+WHERE r.deleted_at IS NULL;
+
+-- Reports with evidence count
+CREATE OR REPLACE VIEW v_reportes_con_evidencias AS
+SELECT 
+  r.id_reporte,
+  r.uuid,
+  r.titulo,
+  r.estado,
+  r.municipio,
+  COUNT(e.id_evidencia) AS evidencia_count
+FROM reportes r
+LEFT JOIN evidencias e ON e.id_reporte = r.id_reporte AND e.deleted_at IS NULL
+WHERE r.deleted_at IS NULL
+GROUP BY r.id_reporte, r.uuid, r.titulo, r.estado, r.municipio;
+
+-- ============================================================================
+-- SEED DATA (Sample categories)
+-- ============================================================================
+
+INSERT IGNORE INTO categorias_riesgo 
+(id_categoria, codigo, nombre, descripcion, icono, color_hex, nivel_prioridad_default, activo) 
+VALUES 
+(1, 'inundacion', 'Inundación', 'Riesgo de inundación o anegamiento', '🌊', '#0066FF', 3, TRUE),
+(3, 'incendio', 'Incendio', 'Riesgo de incendio forestal o urbano', '🔥', '#FF0000', 1, TRUE),
+(4, 'contaminacion_aire', 'Contaminación de Aire', 'Contaminación atmosférica', '💨', '#9933FF', 2, TRUE),
+(5, 'contaminacion_agua', 'Contaminación de Agua', 'Contaminación de ríos, lagos o acuíferos', '💧', '#3399FF', 2, TRUE),
+(6, 'deforestacion', 'Deforestación', 'Tala ilegal o pérdida de cobertura forestal', '🌳', '#00AA44', 2, TRUE),
+(7, 'contaminacion_suelo', 'Contaminación de Suelo', 'Degradación o contaminación del suelo', '⛰️', '#996633', 2, TRUE),
+(8, 'basura', 'Gestión de Residuos', 'Acumulación de basura o residuos', '🗑️', '#666666', 1, TRUE);
+
+-- ============================================================================
+-- STORED PROCEDURES (Optional, for common operations)
+-- ============================================================================
+
+-- Get reports by geographic radius
+DELIMITER //
+CREATE PROCEDURE sp_reportes_por_radio(
+  IN p_latitude DECIMAL(10, 8),
+  IN p_longitude DECIMAL(11, 8),
+  IN p_radio_km INT
+)
+BEGIN
+  SELECT 
+    r.id_reporte,
+    r.uuid,
+    r.titulo,
+    r.estado,
+    r.latitud,
+    r.longitud,
+    r.municipio,
+    u.nombre,
+    u.apellido,
+    ST_Distance_Sphere(r.punto_geo, 
+      ST_GeomFromText(CONCAT('POINT(', p_longitude, ' ', p_latitude, ')'), 4326)
+    ) / 1000 AS distancia_km
+  FROM reportes r
+  LEFT JOIN usuarios u ON u.id_usuario = r.id_usuario
+  WHERE r.deleted_at IS NULL
+    AND ST_Distance_Sphere(r.punto_geo, 
+      ST_GeomFromText(CONCAT('POINT(', p_longitude, ' ', p_latitude, ')'), 4326)
+    ) / 1000 <= p_radio_km
+  ORDER BY distancia_km ASC;
+END//
+DELIMITER ;
+
+-- Get user statistics
+DELIMITER //
+CREATE PROCEDURE sp_estadisticas_usuarios()
+BEGIN
+  SELECT 
+    COUNT(*) AS total,
+    SUM(CASE WHEN rol = 'ciudadano' THEN 1 ELSE 0 END) AS ciudadanos,
+    SUM(CASE WHEN rol = 'moderador' THEN 1 ELSE 0 END) AS moderadores,
+    SUM(CASE WHEN rol = 'admin' THEN 1 ELSE 0 END) AS admins,
+    SUM(CASE WHEN activo = TRUE THEN 1 ELSE 0 END) AS activos,
+    SUM(CASE WHEN activo = FALSE THEN 1 ELSE 0 END) AS inactivos
+  FROM usuarios
+  WHERE deleted_at IS NULL;
+END//
+DELIMITER ;
+
+-- ============================================================================
+-- NOTES
+-- ============================================================================
+/*
+1. UUID Generation:
+   - Generate UUID v4 on application side before INSERT
+   - Example in Node.js: const uuid = require('uuid').v4();
+
+2. Password Hashing:
+   - Use crypto.scryptSync for password hashing
+   - Format: salt:derivedKey (both hex encoded)
+   - Example: '8a5c3f....:ab2d9e....'
+
+3. OTP Hashing:
+   - Hash 6-digit OTP code with SHA-256
+   - Store hash in otp_code_hash
+   - Example: crypto.createHash('sha256').update(otpCode).digest('hex')
+
+4. Token Hashing (Reset, Verification):
+   - Hash tokens with SHA-256 before storage
+   - Store expiration times in UTC
+
+5. Geographic Data:
+   - Store both lat/lon and POINT geometry
+   - POINT format must be: ST_GeomFromText('POINT(longitude latitude)', 4326)
+   - Note: longitude comes FIRST in POINT format
+
+6. Soft Deletes:
+   - Always filter with: WHERE deleted_at IS NULL
+   - Never physically delete user data
+
+7. Pagination:
+   - Use LIMIT and OFFSET for large result sets
+   - Recommended: limit=20, offset=0
+
+8. Indexes:
+   - Added for frequently searched columns
+   - Consider performance for SPATIAL queries
+*/
+</file>
+
+<file path="routes/auth.routes.js">
+import { Router } from 'express';
+import { verifyToken, verifyTokenWhenAllDevicesLogout } from '../middlewares/auth.middleware.js';
+import { upload } from '../middlewares/upload.middleware.js';
+import {
+	authRateLimit,
+	loginRateLimit,
+	passwordResetRateLimit,
+} from '../middlewares/rateLimit.middleware.js';
+import {
+	register,
+	login,
+	refreshAccessToken,
+	exchangeOAuthCallbackCode,
+	logout,
+	forgotPassword,
+	resetPassword,
+	verifyEmail,
+	getPerfil,
+	updatePerfil,
+	updateAvatar,
+	changePassword,
+	sendVerificationOtp,
+	verifyEmailOtp,
+	updateNotifications,
+	googleLogin,
+	googleAccessTokenLogin,
+	googleCallback,
+	getGoogleAuthUrl,
+	facebookLogin,
+	facebookCallback,
+	getFacebookAuthUrl,
+} from '../src/controllers/auth.controller.js';
+
+const authRouter = Router();
+
+authRouter.post('/register', authRateLimit, register);
+authRouter.post('/login', loginRateLimit, login);
+authRouter.post('/refresh', authRateLimit, refreshAccessToken);
+authRouter.post('/oauth/exchange', authRateLimit, exchangeOAuthCallbackCode);
+authRouter.post('/logout', authRateLimit, verifyTokenWhenAllDevicesLogout, logout);
+authRouter.get('/verify-email', authRateLimit, verifyEmail);
+authRouter.post('/forgot-password', passwordResetRateLimit, forgotPassword);
+authRouter.post('/reset-password', passwordResetRateLimit, resetPassword);
+authRouter.get('/perfil', verifyToken, getPerfil);
+authRouter.patch('/perfil', verifyToken, updatePerfil);
+authRouter.patch('/avatar', verifyToken, upload.single('avatar'), updateAvatar);
+authRouter.patch('/cambiar-contrasena', passwordResetRateLimit, verifyToken, changePassword);
+authRouter.patch('/notificaciones', verifyToken, updateNotifications);
+
+// Rutas para verificación de email con OTP
+authRouter.post('/enviar-verificacion', authRateLimit, verifyToken, sendVerificationOtp);
+authRouter.post('/verificar-email', authRateLimit, verifyToken, verifyEmailOtp);
+
+// Rutas para autenticación con Google OAuth
+authRouter.get('/google/url', getGoogleAuthUrl);
+authRouter.post('/google', authRateLimit, googleAccessTokenLogin);
+authRouter.post('/google/login', authRateLimit, googleLogin);
+authRouter.get('/google/callback', googleCallback);
+
+// Rutas para autenticacion con Facebook OAuth (Authorization Code Flow)
+authRouter.get('/facebook/url', getFacebookAuthUrl);
+authRouter.post('/facebook', authRateLimit, facebookLogin);
+authRouter.get('/facebook/callback', facebookCallback);
+
+export default authRouter;
+</file>
+
+<file path="src/app.js">
+import express from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
+import { notFoundHandler, errorHandler } from '../middlewares/errorHandler.js';
+import healthRouter from '../routes/health.routes.js';
+import authRouter from '../routes/auth.routes.js';
+import reporteRouter from '../routes/reporte.routes.js';
+import categoriaRouter from '../routes/categoria-riesgo.routes.js';
+import adminRouter from '../routes/admin.routes.js';
+import chatbotRouter from '../routes/chatbot.routes.js';
+import notificacionRouter from '../routes/notificacion.routes.js';
+import { getCorsOptions, getHelmetOptions } from './config/security.config.js';
+import { getUploadDir } from './config/upload.config.js';
+import { getApiPrefix } from './config/api-prefix.config.js';
+
+const app = express();
+const apiPrefix = getApiPrefix();
+
+app.use(helmet(getHelmetOptions()));
+app.use(cors(getCorsOptions()));
+app.options('*', cors(getCorsOptions()));
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+
+// Archivos subidos por los usuarios
+app.use('/uploads', express.static(getUploadDir()));
+
+// rutas de la API
+app.use(`${apiPrefix}/health`, healthRouter);
+app.use(`${apiPrefix}/auth`, authRouter);
+app.use(`${apiPrefix}/reportes`, reporteRouter);
+app.use(`${apiPrefix}/categorias`, categoriaRouter);
+app.use(`${apiPrefix}/admin`, adminRouter);
+app.use(`${apiPrefix}/chatbot`, chatbotRouter);
+app.use(`${apiPrefix}/notificaciones`, notificacionRouter);
+
+ 
+app.use(notFoundHandler);
+app.use(errorHandler);
+
+export default app;
+</file>
+
+<file path="src/models/categoria-riesgo.model.js">
+import pool from '../config/database.js';
+import { tableExists } from '../config/schema-compat.js';
+
+export const CATEGORIAS_FALLBACK = [
+  {
+    id_categoria: 1,
+    codigo: 'agua',
+    nombre: 'Contaminacion de Agua',
+    descripcion: 'Contaminacion del recurso hidrico',
+    icono: 'droplet',
+    color_hex: '#3B82F6',
+    nivel_prioridad_default: 3,
+    activo: 1,
+  },
+  {
+    id_categoria: 2,
+    codigo: 'aire',
+    nombre: 'Contaminacion del Aire',
+    descripcion: 'Presencia de contaminantes atmosfericos',
+    icono: 'wind',
+    color_hex: '#6B7280',
+    nivel_prioridad_default: 2,
+    activo: 1,
+  },
+  {
+    id_categoria: 3,
+    codigo: 'suelo',
+    nombre: 'Contaminacion del Suelo',
+    descripcion: 'Degradacion o contaminacion del suelo',
+    icono: 'leaf',
+    color_hex: '#84CC16',
+    nivel_prioridad_default: 2,
+    activo: 1,
+  },
+  {
+    id_categoria: 4,
+    codigo: 'ruido',
+    nombre: 'Contaminacion por Ruido',
+    descripcion: 'Exceso de ruido ambiental',
+    icono: 'volume2',
+    color_hex: '#A855F7',
+    nivel_prioridad_default: 2,
+    activo: 1,
+  },
+  {
+    id_categoria: 5,
+    codigo: 'residuos',
+    nombre: 'Residuos y Desechos',
+    descripcion: 'Acumulacion o disposicion incorrecta de basura',
+    icono: 'trash2',
+    color_hex: '#EF4444',
+    nivel_prioridad_default: 2,
+    activo: 1,
+  },
+  {
+    id_categoria: 6,
+    codigo: 'luminica',
+    nombre: 'Contaminacion Luminica',
+    descripcion: 'Exceso de iluminacion artificial',
+    icono: 'lightbulb',
+    color_hex: '#F59E0B',
+    nivel_prioridad_default: 1,
+    activo: 1,
+  },
+  {
+    id_categoria: 7,
+    codigo: 'deforestacion',
+    nombre: 'Deforestacion',
+    descripcion: 'Tala o perdida de cobertura forestal',
+    icono: 'trees',
+    color_hex: '#22C55E',
+    nivel_prioridad_default: 3,
+    activo: 1,
+  },
+  {
+    id_categoria: 8,
+    codigo: 'incendios_forestales',
+    nombre: 'Incendios Forestales',
+    descripcion: 'Fuegos descontrolados en bosques o vegetacion',
+    icono: 'flame',
+    color_hex: '#DC2626',
+    nivel_prioridad_default: 4,
+    activo: 1,
+  },
+  {
+    id_categoria: 9,
+    codigo: 'deslizamientos',
+    nombre: 'Deslizamientos',
+    descripcion: 'Movimientos de masa en laderas o taludes',
+    icono: 'mountain',
+    color_hex: '#92400E',
+    nivel_prioridad_default: 4,
+    activo: 1,
+  },
+  {
+    id_categoria: 10,
+    codigo: 'avalanchas_fluviotorrenciales',
+    nombre: 'Avalanchas Fluviotorrenciales',
+    descripcion: 'Crecidas subitas de rios, quebradas o arroyos',
+    icono: 'waves',
+    color_hex: '#0EA5E9',
+    nivel_prioridad_default: 4,
+    activo: 1,
+  },
+  {
+    id_categoria: 11,
+    codigo: 'otro',
+    nombre: 'Otro',
+    descripcion: 'Otros tipos de riesgo ambiental',
+    icono: 'helpCircle',
+    color_hex: '#8B5CF6',
+    nivel_prioridad_default: 2,
+    activo: 1,
+  },
+];
+
+const hasCategoriasTable = () => tableExists('categorias_riesgo');
+
+const withReportStats = async (categorias) => {
+  const [rows] = await pool.execute(
+    `SELECT tipo_contaminacion AS codigo,
+            COUNT(*) AS total_reportes,
+            SUM(CASE WHEN estado = 'pendiente' THEN 1 ELSE 0 END) AS pendientes,
+            SUM(CASE WHEN estado = 'en_revision' THEN 1 ELSE 0 END) AS en_revision,
+            SUM(CASE WHEN estado = 'verificado' THEN 1 ELSE 0 END) AS verificados,
+            SUM(CASE WHEN estado = 'en_proceso' THEN 1 ELSE 0 END) AS en_proceso,
+            SUM(CASE WHEN estado = 'resuelto' THEN 1 ELSE 0 END) AS resueltos,
+            SUM(CASE WHEN estado = 'rechazado' THEN 1 ELSE 0 END) AS rechazados,
+            SUM(CASE WHEN nivel_severidad = 'bajo' THEN 1 ELSE 0 END) AS bajo,
+            SUM(CASE WHEN nivel_severidad = 'medio' THEN 1 ELSE 0 END) AS medio,
+            SUM(CASE WHEN nivel_severidad = 'alto' THEN 1 ELSE 0 END) AS alto,
+            SUM(CASE WHEN nivel_severidad = 'critico' THEN 1 ELSE 0 END) AS critico
+     FROM reportes
+     WHERE deleted_at IS NULL
+     GROUP BY tipo_contaminacion`
+  );
+
+  const statsByCodigo = new Map(rows.map((row) => [row.codigo, row]));
+
+  return categorias.map((categoria) => ({
+    ...categoria,
+    total_reportes: 0,
+    pendientes: 0,
+    en_revision: 0,
+    verificados: 0,
+    en_proceso: 0,
+    resueltos: 0,
+    rechazados: 0,
+    bajo: 0,
+    medio: 0,
+    alto: 0,
+    critico: 0,
+    ...(statsByCodigo.get(categoria.codigo) ?? {}),
+  }));
+};
+
+/**
+ * Modelo para gestionar categorías de riesgo ambiental
+ * 
+ * Esta tabla almacena la metadata de cada categoría de reporte,
+ * permitiendo gestionar información adicional como iconos, colores,
+ * niveles de prioridad por defecto, etc.
+ */
+
+export const CategoriaRiesgoModel = {
+  /**
+   * Obtiene todas las categorías activas
+   * @param {boolean} activas - Si es true, solo retorna categorías activas
+   * @returns {Promise<Array>} Array de categorías
+   */
+  findAll: async (activas = true) => {
+    try {
+      if (!await hasCategoriasTable()) {
+        const categorias = activas
+          ? CATEGORIAS_FALLBACK.filter((categoria) => categoria.activo)
+          : CATEGORIAS_FALLBACK;
+
+        return withReportStats(categorias);
+      }
+
+      const whereClause = activas ? ' WHERE cr.activo = 1' : '';
+      
+      const [rows] = await pool.execute(
+        `SELECT 
+          cr.id_categoria,
+          cr.codigo,
+          cr.nombre,
+          cr.descripcion,
+          cr.icono,
+          cr.color_hex,
+          cr.nivel_prioridad_default,
+          cr.activo,
+          COUNT(r.id_reporte) as total_reportes
+         FROM categorias_riesgo cr
+         LEFT JOIN reportes r ON r.tipo_contaminacion = cr.codigo 
+           AND r.deleted_at IS NULL
+         ${whereClause}
+         GROUP BY cr.id_categoria, cr.codigo
+         ORDER BY cr.nombre ASC`,
+        []
+      );
+
+      return rows;
+    } catch (error) {
+      console.error('Error en CategoriaRiesgoModel.findAll:', error);
+      throw error;
+    }
+  },
+
+  /**
+   * Obtiene una categoría por su código
+   * @param {string} codigo - Código de la categoría (ej: 'deforestacion')
+   * @returns {Promise<Object|null>} Objeto categoría o null
+   */
+  findByCodigo: async (codigo) => {
+    try {
+      if (!await hasCategoriasTable()) {
+        const [categoria] = await withReportStats(
+          CATEGORIAS_FALLBACK.filter((item) => item.codigo === codigo && item.activo)
+        );
+
+        return categoria ?? null;
+      }
+
+      const [rows] = await pool.execute(
+        `SELECT 
+          cr.id_categoria,
+          cr.codigo,
+          cr.nombre,
+          cr.descripcion,
+          cr.icono,
+          cr.color_hex,
+          cr.nivel_prioridad_default,
+          cr.activo,
+          COUNT(r.id_reporte) as total_reportes
+         FROM categorias_riesgo cr
+         LEFT JOIN reportes r ON r.tipo_contaminacion = cr.codigo 
+           AND r.deleted_at IS NULL
+         WHERE cr.codigo = ? AND cr.activo = 1
+         GROUP BY cr.id_categoria`,
+        [codigo]
+      );
+
+      return rows.length > 0 ? rows[0] : null;
+    } catch (error) {
+      console.error('Error en CategoriaRiesgoModel.findByCodigo:', error);
+      throw error;
+    }
+  },
+
+  findByCodigoIncludingInactive: async (codigo) => {
+    try {
+      if (!await hasCategoriasTable()) {
+        return CATEGORIAS_FALLBACK.find((item) => item.codigo === codigo) ?? null;
+      }
+
+      const [rows] = await pool.execute(
+        `SELECT 
+          cr.id_categoria,
+          cr.codigo,
+          cr.nombre,
+          cr.descripcion,
+          cr.icono,
+          cr.color_hex,
+          cr.nivel_prioridad_default,
+          cr.activo,
+          cr.created_at,
+          cr.updated_at
+         FROM categorias_riesgo cr
+         WHERE cr.codigo = ? AND cr.deleted_at IS NULL
+         LIMIT 1`,
+        [codigo]
+      );
+
+      return rows[0] ?? null;
+    } catch (error) {
+      console.error('Error en CategoriaRiesgoModel.findByCodigoIncludingInactive:', error);
+      throw error;
+    }
+  },
+
+  create: async ({
+    codigo,
+    nombre,
+    descripcion = null,
+    icono = null,
+    color_hex = null,
+    nivel_prioridad_default = null,
+    activo = true,
+  }) => {
+    try {
+      if (!await hasCategoriasTable()) {
+        const error = new Error('La tabla categorias_riesgo no existe en la base de datos actual.');
+        error.code = 'ER_NO_SUCH_TABLE';
+        throw error;
+      }
+
+      const [result] = await pool.execute(
+        `INSERT INTO categorias_riesgo
+           (codigo, nombre, descripcion, icono, color_hex, nivel_prioridad_default, activo)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        [
+          codigo,
+          nombre,
+          descripcion,
+          icono,
+          color_hex,
+          nivel_prioridad_default,
+          activo ? 1 : 0,
+        ]
+      );
+
+      return result.insertId;
+    } catch (error) {
+      console.error('Error en CategoriaRiesgoModel.create:', error);
+      throw error;
+    }
+  },
+
+  updateByCodigo: async (codigo, fields) => {
+    try {
+      if (!await hasCategoriasTable()) {
+        return false;
+      }
+
+      const allowed = [
+        'nombre',
+        'descripcion',
+        'icono',
+        'color_hex',
+        'nivel_prioridad_default',
+      ];
+      const sets = [];
+      const params = [];
+
+      for (const key of allowed) {
+        if (Object.prototype.hasOwnProperty.call(fields, key)) {
+          sets.push(`${key} = ?`);
+          params.push(fields[key]);
+        }
+      }
+
+      if (sets.length === 0) {
+        return false;
+      }
+
+      params.push(codigo);
+
+      const [result] = await pool.execute(
+        `UPDATE categorias_riesgo
+         SET ${sets.join(', ')}, updated_at = NOW()
+         WHERE codigo = ? AND deleted_at IS NULL`,
+        params
+      );
+
+      return result.affectedRows > 0;
+    } catch (error) {
+      console.error('Error en CategoriaRiesgoModel.updateByCodigo:', error);
+      throw error;
+    }
+  },
+
+  updateActivoByCodigo: async (codigo, activo) => {
+    try {
+      if (!await hasCategoriasTable()) {
+        return false;
+      }
+
+      const [result] = await pool.execute(
+        `UPDATE categorias_riesgo
+         SET activo = ?, updated_at = NOW()
+         WHERE codigo = ? AND deleted_at IS NULL`,
+        [activo ? 1 : 0, codigo]
+      );
+
+      return result.affectedRows > 0;
+    } catch (error) {
+      console.error('Error en CategoriaRiesgoModel.updateActivoByCodigo:', error);
+      throw error;
+    }
+  },
+
+  /**
+   * Obtiene estadísticas de reportes por categoría
+   * @returns {Promise<Array>} Array con estadísticas por categoría
+   */
+  getEstadisticasPorCategoria: async () => {
+    try {
+      if (!await hasCategoriasTable()) {
+        return withReportStats(CATEGORIAS_FALLBACK.filter((categoria) => categoria.activo));
+      }
+
+      const [rows] = await pool.execute(
+        `SELECT 
+          cr.codigo,
+          cr.nombre,
+          cr.icono,
+          cr.color_hex,
+          COUNT(r.id_reporte) as total_reportes,
+          SUM(CASE WHEN r.estado = 'pendiente' THEN 1 ELSE 0 END) as pendientes,
+          SUM(CASE WHEN r.estado = 'en_revision' THEN 1 ELSE 0 END) as en_revision,
+          SUM(CASE WHEN r.estado = 'verificado' THEN 1 ELSE 0 END) as verificados,
+          SUM(CASE WHEN r.estado = 'resuelto' THEN 1 ELSE 0 END) as resueltos,
+          SUM(CASE WHEN r.nivel_severidad = 'critico' THEN 1 ELSE 0 END) as criticos
+         FROM categorias_riesgo cr
+         LEFT JOIN reportes r ON r.tipo_contaminacion = cr.codigo 
+           AND r.deleted_at IS NULL
+         WHERE cr.activo = 1
+         GROUP BY cr.id_categoria, cr.codigo
+         ORDER BY total_reportes DESC, cr.nombre ASC`,
+        []
+      );
+
+      return rows;
+    } catch (error) {
+      console.error('Error en CategoriaRiesgoModel.getEstadisticasPorCategoria:', error);
+      throw error;
+    }
+  },
+
+  getEstadisticasPorSeveridad: async () => {
+    try {
+      if (!await hasCategoriasTable()) {
+        return withReportStats(CATEGORIAS_FALLBACK.filter((categoria) => categoria.activo));
+      }
+
+      const [rows] = await pool.execute(
+        `SELECT
+          cr.codigo,
+          cr.nombre,
+          cr.icono,
+          cr.color_hex,
+          SUM(CASE WHEN r.nivel_severidad = 'bajo' THEN 1 ELSE 0 END) AS bajo,
+          SUM(CASE WHEN r.nivel_severidad = 'medio' THEN 1 ELSE 0 END) AS medio,
+          SUM(CASE WHEN r.nivel_severidad = 'alto' THEN 1 ELSE 0 END) AS alto,
+          SUM(CASE WHEN r.nivel_severidad = 'critico' THEN 1 ELSE 0 END) AS critico
+         FROM categorias_riesgo cr
+         LEFT JOIN reportes r ON r.tipo_contaminacion = cr.codigo
+           AND r.deleted_at IS NULL
+         WHERE cr.activo = 1
+         GROUP BY cr.id_categoria, cr.codigo, cr.nombre, cr.icono, cr.color_hex
+         ORDER BY cr.nombre ASC`,
+        []
+      );
+
+      return rows;
+    } catch (error) {
+      console.error('Error en CategoriaRiesgoModel.getEstadisticasPorSeveridad:', error);
+      throw error;
+    }
+  },
+
+  /**
+   * Valida si un código de categoría existe y está activo
+   * @param {string} codigo - Código de categoría
+   * @returns {Promise<boolean>} true si existe y está activo
+   */
+  esValido: async function (codigo) {
+    try {
+      const categoria = await this.findByCodigo(codigo);
+      return Boolean(categoria?.activo);
+    } catch (error) {
+      console.error('Error en CategoriaRiesgoModel.esValido:', error);
+      throw error;
+    }
+  },
+
+  /**
+   * Obtiene todos los códigos válidos de categorías para validación
+   * @returns {Promise<Array>} Array de códigos de categorías
+   */
+  obtenerCodigosValidos: async () => {
+    try {
+      if (!await hasCategoriasTable()) {
+        return CATEGORIAS_FALLBACK
+          .filter((categoria) => categoria.activo)
+          .map((categoria) => categoria.codigo);
+      }
+
+      const [rows] = await pool.execute(
+        `SELECT codigo FROM categorias_riesgo WHERE activo = 1 ORDER BY nombre ASC`,
+        []
+      );
+
+      return rows.map(row => row.codigo);
+    } catch (error) {
+      console.error('Error en CategoriaRiesgoModel.obtenerCodigosValidos:', error);
+      throw error;
+    }
+  }
+};
+</file>
+
+<file path="src/models/usuario.model.js">
+import pool from '../config/database.js';
+import { columnExists } from '../config/schema-compat.js';
+import { randomUUID } from 'crypto';
+
+export const DEFAULT_NOTIFICATION_PREFERENCES = {
+  email_alerts: true,
+  push_notifications: false,
+  report_updates: true,
+  weekly_summary: false,
+};
+
+export const parseNotificationPreferences = (preferences) => {
+  if (!preferences) {
+    return { ...DEFAULT_NOTIFICATION_PREFERENCES };
+  }
+
+  const parsed = typeof preferences === 'string'
+    ? JSON.parse(preferences)
+    : preferences;
+
+  return {
+    ...DEFAULT_NOTIFICATION_PREFERENCES,
+    ...parsed,
+  };
+};
+
+export const UsuarioModel = {
+
+  // Columnas públicas del usuario (sin password_hash)
+  _publicUserFields: `id_usuario, uuid, nombre, apellido, email,
+              rol, activo, email_verificado, avatar_url, telefono,
+              created_at, updated_at`,
+
+  _optionalColumnSelect: async (column, fallback = 'NULL') => (
+    await columnExists('usuarios', column)
+      ? column
+      : `${fallback} AS ${column}`
+  ),
+
+  _publicUserSelect: async () => {
+    const notificationPreferences = await UsuarioModel._optionalColumnSelect(
+      'notification_preferences'
+    );
+    const googleId = await UsuarioModel._optionalColumnSelect('google_id');
+    const facebookId = await UsuarioModel._optionalColumnSelect('facebook_id');
+
+    return `${UsuarioModel._publicUserFields}, ${notificationPreferences}, ${googleId}, ${facebookId}`;
+  },
+  
+    // Busca un usuario por su email 
+  findByEmail: async (email) => {
+    const publicFields = await UsuarioModel._publicUserSelect();
+
+    const [rows] = await pool.execute(
+      `SELECT ${publicFields}, password_hash, ultimo_acceso
+       FROM usuarios
+       WHERE email = ? AND deleted_at IS NULL
+       LIMIT 1`,
+      [email]
+    );
+    return rows[0] ?? null;
+  },
+
+  
+    // Busca un usuario por su id_usuario 
+   
+  findById: async (id_usuario) => {
+    const publicFields = await UsuarioModel._publicUserSelect();
+
+    const [rows] = await pool.execute(
+      `SELECT ${publicFields}, ultimo_acceso
+       FROM usuarios
+       WHERE id_usuario = ? AND deleted_at IS NULL
+       LIMIT 1`,
+      [id_usuario]
+    );
+    return rows[0] ?? null;
+  },
+
+  // Busca usuario por id con los campos públicos para perfil
+  findByIdWithDetails: async (id_usuario) => {
+    const publicFields = await UsuarioModel._publicUserSelect();
+
+    const [rows] = await pool.execute(
+      `SELECT ${publicFields}
+       FROM usuarios
+       WHERE id_usuario = ? AND deleted_at IS NULL
+       LIMIT 1`,
+      [id_usuario]
+    );
+
+    const user = rows[0] ?? null;
+    if (!user) {
+      return null;
+    }
+
+    return {
+      ...user,
+      notification_preferences: parseNotificationPreferences(user.notification_preferences),
+    };
+  },
+
+  // Lista usuarios con filtros opcionales
+  findAll: async ({ rol, activo, search, limit, offset } = {}) => {
+    const conditions = ['deleted_at IS NULL'];
+    const params = [];
+
+    if (rol) {
+      conditions.push('rol = ?');
+      params.push(rol);
+    }
+
+    if (activo !== undefined && activo !== null) {
+      conditions.push('activo = ?');
+      params.push(activo);
+    }
+
+    if (search) {
+      const like = `%${search}%`;
+      conditions.push('(nombre LIKE ? OR apellido LIKE ? OR email LIKE ?)');
+      params.push(like, like, like);
+    }
+
+    const publicFields = await UsuarioModel._publicUserSelect();
+
+    let query = `SELECT ${publicFields}
+       FROM usuarios
+       WHERE ${conditions.join(' AND ')}
+       ORDER BY created_at DESC`;
+
+    if (limit !== undefined && limit !== null) {
+      const validLimit = parseInt(limit, 10);
+      if (!Number.isInteger(validLimit) || validLimit < 0) {
+        throw new Error('limit must be a non-negative integer');
+      }
+      query += ` LIMIT ${validLimit}`;
+
+      if (offset !== undefined && offset !== null) {
+        const validOffset = parseInt(offset, 10);
+        if (!Number.isInteger(validOffset) || validOffset < 0) {
+          throw new Error('offset must be a non-negative integer');
+        }
+        query += ` OFFSET ${validOffset}`;
+      }
+    }
+
+    const [rows] = await pool.execute(query, params);
+    return rows;
+  },
+
+  // Cuenta usuarios con filtros opcionales
+  countAll: async ({ rol, activo, search } = {}) => {
+    const conditions = ['deleted_at IS NULL'];
+    const params = [];
+
+    if (rol) {
+      conditions.push('rol = ?');
+      params.push(rol);
+    }
+
+    if (activo !== undefined && activo !== null) {
+      conditions.push('activo = ?');
+      params.push(activo);
+    }
+
+    if (search) {
+      const like = `%${search}%`;
+      conditions.push('(nombre LIKE ? OR apellido LIKE ? OR email LIKE ?)');
+      params.push(like, like, like);
+    }
+
+    const [rows] = await pool.execute(
+      `SELECT COUNT(*) AS total
+       FROM usuarios
+       WHERE ${conditions.join(' AND ')}`,
+      params
+    );
+
+    return rows[0]?.total ?? 0;
+  },
+
+  
+   //Crea un nuevo usuario.
+   
+  create: async ({ nombre, apellido, email, password_hash, rol = 'ciudadano', telefono = null }) => {
+    const uuid = randomUUID();
+    const [result] = await pool.execute(
+      `INSERT INTO usuarios (uuid, nombre, apellido, email, password_hash, rol, telefono)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [uuid, nombre, apellido, email, password_hash, rol, telefono]
+    );
+    return result.insertId;
+  },
+
+    //actualizar ultimo acceso del usuario
+
+  updateUltimoAcceso: async (id_usuario) => {
+    await pool.execute(
+      `UPDATE usuarios SET ultimo_acceso = NOW() WHERE id_usuario = ?`,
+      [id_usuario]
+    );
+  },
+
+  // Actualiza solo campos permitidos del perfil y retorna usuario actualizado
+  updatePerfil: async (id_usuario, { nombre, apellido, telefono, avatar_url }) => {
+    const [result] = await pool.execute(
+      `UPDATE usuarios
+       SET nombre = ?, apellido = ?, telefono = ?, avatar_url = ?, updated_at = NOW()
+       WHERE id_usuario = ? AND deleted_at IS NULL`,
+      [nombre, apellido, telefono, avatar_url, id_usuario]
+    );
+
+    if (result.affectedRows === 0) {
+      return null;
+    }
+
+    return UsuarioModel.findByIdWithDetails(id_usuario);
+  },
+
+  updateAvatar: async (id_usuario, avatar_url) => {
+    const [result] = await pool.execute(
+      `UPDATE usuarios
+       SET avatar_url = ?, updated_at = NOW()
+       WHERE id_usuario = ? AND deleted_at IS NULL`,
+      [avatar_url, id_usuario]
+    );
+
+    if (result.affectedRows === 0) {
+      return null;
+    }
+
+    return UsuarioModel.findByIdWithDetails(id_usuario);
+  },
+
+  // Actualiza password_hash y updated_at
+  updatePassword: async (id_usuario, newPasswordHash) => {
+    const [result] = await pool.execute(
+      `UPDATE usuarios
+       SET password_hash = ?, updated_at = NOW()
+       WHERE id_usuario = ? AND deleted_at IS NULL`,
+      [newPasswordHash, id_usuario]
+    );
+
+    if (result.affectedRows === 0) {
+      return null;
+    }
+
+    return UsuarioModel.findByIdWithDetails(id_usuario);
+  },
+
+  updateNotificationPreferences: async (id_usuario, preferences) => {
+    if (!await columnExists('usuarios', 'notification_preferences')) {
+      return UsuarioModel.findByIdWithDetails(id_usuario);
+    }
+
+    const [result] = await pool.execute(
+      `UPDATE usuarios
+       SET notification_preferences = ?, updated_at = NOW()
+       WHERE id_usuario = ? AND deleted_at IS NULL`,
+      [JSON.stringify(preferences), id_usuario]
+    );
+
+    if (result.affectedRows === 0) {
+      return null;
+    }
+
+    return UsuarioModel.findByIdWithDetails(id_usuario);
+  },
+
+  // Guarda token de recuperacion y expiracion
+  setResetToken: async (id_usuario, tokenReset, tokenResetExp) => {
+    const [result] = await pool.execute(
+      `UPDATE usuarios
+       SET token_reset = ?, token_reset_exp = ?, updated_at = NOW()
+       WHERE id_usuario = ? AND deleted_at IS NULL`,
+      [tokenReset, tokenResetExp, id_usuario]
+    );
+
+    return result.affectedRows > 0;
+  },
+
+  // Busca usuario por token de recuperacion
+  findByResetToken: async (tokenReset) => {
+    const [rows] = await pool.execute(
+      `SELECT id_usuario, email, token_reset_exp
+       FROM usuarios
+       WHERE token_reset = ? AND deleted_at IS NULL
+       LIMIT 1`,
+      [tokenReset]
+    );
+
+    return rows[0] ?? null;
+  },
+
+  // Limpia token de recuperacion
+  clearResetToken: async (id_usuario) => {
+    const [result] = await pool.execute(
+      `UPDATE usuarios
+       SET token_reset = NULL, token_reset_exp = NULL, updated_at = NOW()
+       WHERE id_usuario = ? AND deleted_at IS NULL`,
+      [id_usuario]
+    );
+
+    return result.affectedRows > 0;
+  },
+
+  // Guarda token de verificacion de correo y expiracion
+  setEmailVerificationToken: async (id_usuario, tokenHash, tokenExp) => {
+    const hasEmailToken = await columnExists('usuarios', 'email_verification_token');
+    const hasEmailExp = await columnExists('usuarios', 'email_verification_exp');
+
+    if (!hasEmailToken || !hasEmailExp) {
+      return UsuarioModel.setOtp(id_usuario, tokenHash, tokenExp);
+    }
+
+    const [result] = await pool.execute(
+      `UPDATE usuarios
+       SET email_verification_token = ?, email_verification_exp = ?, updated_at = NOW()
+       WHERE id_usuario = ? AND deleted_at IS NULL`,
+      [tokenHash, tokenExp, id_usuario]
+    );
+
+    return result.affectedRows > 0;
+  },
+
+  // Busca usuario por token de verificacion de correo
+  findByEmailVerificationToken: async (tokenHash) => {
+    const hasEmailToken = await columnExists('usuarios', 'email_verification_token');
+    const hasEmailExp = await columnExists('usuarios', 'email_verification_exp');
+
+    if (!hasEmailToken || !hasEmailExp) {
+      const [rows] = await pool.execute(
+        `SELECT id_usuario, email, email_verificado, otp_exp AS email_verification_exp
+         FROM usuarios
+         WHERE otp_code_hash = ? AND deleted_at IS NULL
+         LIMIT 1`,
+        [tokenHash]
+      );
+
+      return rows[0] ?? null;
+    }
+
+    const [rows] = await pool.execute(
+      `SELECT id_usuario, email, email_verificado, email_verification_exp
+       FROM usuarios
+       WHERE email_verification_token = ? AND deleted_at IS NULL
+       LIMIT 1`,
+      [tokenHash]
+    );
+
+    return rows[0] ?? null;
+  },
+
+  // Limpia token de verificacion de correo
+  clearEmailVerificationToken: async (id_usuario) => {
+    const hasEmailToken = await columnExists('usuarios', 'email_verification_token');
+    const hasEmailExp = await columnExists('usuarios', 'email_verification_exp');
+
+    if (!hasEmailToken || !hasEmailExp) {
+      return UsuarioModel.clearOtp(id_usuario);
+    }
+
+    const [result] = await pool.execute(
+      `UPDATE usuarios
+       SET email_verification_token = NULL, email_verification_exp = NULL, updated_at = NOW()
+       WHERE id_usuario = ? AND deleted_at IS NULL`,
+      [id_usuario]
+    );
+
+    return result.affectedRows > 0;
+  },
+
+  // Actualiza rol del usuario
+  updateRol: async (id_usuario, rol) => {
+    const [result] = await pool.execute(
+      `UPDATE usuarios
+       SET rol = ?, updated_at = NOW()
+       WHERE id_usuario = ? AND deleted_at IS NULL`,
+      [rol, id_usuario]
+    );
+
+    if (result.affectedRows === 0) {
+      return null;
+    }
+
+    return UsuarioModel.findByIdWithDetails(id_usuario);
+  },
+
+  // Activa o desactiva usuario
+  updateActivo: async (id_usuario, activo) => {
+    const [result] = await pool.execute(
+      `UPDATE usuarios
+       SET activo = ?, updated_at = NOW()
+       WHERE id_usuario = ? AND deleted_at IS NULL`,
+      [activo, id_usuario]
+    );
+
+    if (result.affectedRows === 0) {
+      return null;
+    }
+
+    return UsuarioModel.findByIdWithDetails(id_usuario);
+  },
+
+  // Estadisticas generales de usuarios
+  getStats: async () => {
+    const [rows] = await pool.execute(
+      `SELECT
+         COUNT(*) AS total,
+         SUM(CASE WHEN rol = 'ciudadano' THEN 1 ELSE 0 END) AS ciudadanos,
+         SUM(CASE WHEN rol = 'moderador' THEN 1 ELSE 0 END) AS moderadores,
+         SUM(CASE WHEN rol = 'admin' THEN 1 ELSE 0 END) AS admins,
+         SUM(CASE WHEN activo = 1 THEN 1 ELSE 0 END) AS activos,
+         SUM(CASE WHEN activo = 0 THEN 1 ELSE 0 END) AS inactivos,
+         SUM(CASE WHEN created_at >= DATE_FORMAT(CURRENT_DATE, '%Y-%m-01') THEN 1 ELSE 0 END) AS nuevos_este_mes
+       FROM usuarios
+       WHERE deleted_at IS NULL`
+    );
+
+    return rows[0] ?? {
+      total: 0,
+      ciudadanos: 0,
+      moderadores: 0,
+      admins: 0,
+      activos: 0,
+      inactivos: 0,
+      nuevos_este_mes: 0,
+    };
+  },
+
+    // Elimina un usuario con (Soft Delete)
+  remove: async (id_usuario) => {
+    const [result] = await pool.execute(
+      `UPDATE usuarios SET deleted_at = NOW() WHERE id_usuario = ? AND deleted_at IS NULL`,
+      [id_usuario]
+    );
+    return result.affectedRows > 0;
+  },
+
+  // ============ MÉTODOS PARA OTP DE VERIFICACIÓN DE EMAIL ============
+
+  // Guarda código OTP hasheado y fecha de expiración
+  setOtp: async (id_usuario, otpCodeHash, otpExp) => {
+    const hasAttempts = await columnExists('usuarios', 'otp_attempts');
+    const attemptsSet = hasAttempts ? ', otp_attempts = 0' : '';
+
+    const [result] = await pool.execute(
+      `UPDATE usuarios
+       SET otp_code_hash = ?, otp_exp = ?${attemptsSet}, updated_at = NOW()
+       WHERE id_usuario = ? AND deleted_at IS NULL`,
+      [otpCodeHash, otpExp, id_usuario]
+    );
+    return result.affectedRows > 0;
+  },
+
+  // Limpia OTP del usuario
+  clearOtp: async (id_usuario) => {
+    const hasAttempts = await columnExists('usuarios', 'otp_attempts');
+    const attemptsSet = hasAttempts ? ', otp_attempts = 0' : '';
+
+    const [result] = await pool.execute(
+      `UPDATE usuarios
+       SET otp_code_hash = NULL, otp_exp = NULL${attemptsSet}, updated_at = NOW()
+       WHERE id_usuario = ? AND deleted_at IS NULL`,
+      [id_usuario]
+    );
+    return result.affectedRows > 0;
+  },
+
+  // Busca usuario por OTP hasheado
+  findByOtpHash: async (otpCodeHash) => {
+    const otpAttempts = await UsuarioModel._optionalColumnSelect('otp_attempts', '0');
+
+    const [rows] = await pool.execute(
+      `SELECT id_usuario, email, otp_exp, ${otpAttempts}, email_verificado
+       FROM usuarios
+       WHERE otp_code_hash = ? AND deleted_at IS NULL
+       LIMIT 1`,
+      [otpCodeHash]
+    );
+    return rows[0] ?? null;
+  },
+
+  // Incrementa contador de intentos fallidos de OTP
+  incrementOtpAttempts: async (id_usuario) => {
+    if (!await columnExists('usuarios', 'otp_attempts')) {
+      return true;
+    }
+
+    const [result] = await pool.execute(
+      `UPDATE usuarios
+       SET otp_attempts = otp_attempts + 1
+       WHERE id_usuario = ? AND deleted_at IS NULL`,
+      [id_usuario]
+    );
+    return result.affectedRows > 0;
+  },
+
+  // Marca email como verificado
+  verifyEmail: async (id_usuario) => {
+    const hasEmailToken = await columnExists('usuarios', 'email_verification_token');
+    const hasEmailExp = await columnExists('usuarios', 'email_verification_exp');
+    const clearEmailTokenSet = hasEmailToken && hasEmailExp
+      ? `email_verification_token = NULL,
+           email_verification_exp = NULL,`
+      : '';
+
+    const [result] = await pool.execute(
+      `UPDATE usuarios
+       SET email_verificado = 1,
+           ${clearEmailTokenSet}
+           updated_at = NOW()
+       WHERE id_usuario = ? AND deleted_at IS NULL`,
+      [id_usuario]
+    );
+    return result.affectedRows > 0;
+  },
+
+  // Obtiene timestamp del último reenvío de OTP
+  getOtpLastRequest: async (id_usuario) => {
+    if (!await columnExists('usuarios', 'otp_last_request')) {
+      return null;
+    }
+
+    const [rows] = await pool.execute(
+      `SELECT otp_last_request
+       FROM usuarios
+       WHERE id_usuario = ? AND deleted_at IS NULL
+       LIMIT 1`,
+      [id_usuario]
+    );
+    return rows[0]?.otp_last_request ?? null;
+  },
+
+  // Actualiza timestamp del último reenvío de OTP
+  updateOtpLastRequest: async (id_usuario) => {
+    if (!await columnExists('usuarios', 'otp_last_request')) {
+      return true;
+    }
+
+    const [result] = await pool.execute(
+      `UPDATE usuarios
+       SET otp_last_request = NOW()
+       WHERE id_usuario = ? AND deleted_at IS NULL`,
+      [id_usuario]
+    );
+    return result.affectedRows > 0;
+  },
+
+  // ============ MÉTODOS PARA GOOGLE OAUTH ============
+
+  // Busca usuario por google_id
+  findByGoogleId: async (google_id) => {
+    if (!await columnExists('usuarios', 'google_id')) {
+      return null;
+    }
+
+    const publicFields = await UsuarioModel._publicUserSelect();
+
+    const [rows] = await pool.execute(
+      `SELECT ${publicFields}, google_id
+       FROM usuarios
+       WHERE google_id = ? AND deleted_at IS NULL
+       LIMIT 1`,
+      [google_id]
+    );
+    return rows[0] ?? null;
+  },
+
+  // Crea usuario desde Google OAuth
+  createFromGoogle: async ({ google_id, email, nombre, apellido, avatar_url }) => {
+    const uuid = randomUUID();
+    const hasGoogleId = await columnExists('usuarios', 'google_id');
+    
+    try {
+      if (!hasGoogleId) {
+        const [result] = await pool.execute(
+          `INSERT INTO usuarios (uuid, email, nombre, apellido, password_hash, avatar_url, rol, email_verificado)
+           VALUES (?, ?, ?, ?, ?, ?, 'ciudadano', 1)`,
+          [uuid, email, nombre, apellido, `oauth:${randomUUID()}`, avatar_url]
+        );
+        return result.insertId;
+      }
+
+      const [result] = await pool.execute(
+        `INSERT INTO usuarios (uuid, google_id, email, nombre, apellido, password_hash, avatar_url, rol, email_verificado)
+         VALUES (?, ?, ?, ?, ?, ?, ?, 'ciudadano', 1)`,
+        [uuid, google_id, email, nombre, apellido, `oauth:${randomUUID()}`, avatar_url]
+      );
+      return result.insertId;
+    } catch (error) {
+      if (error.code === 'ER_DUP_ENTRY') {
+        // Email ya existe, retornar null
+        return null;
+      }
+      throw error;
+    }
+  },
+
+  // Actualiza google_id de usuario existente
+  updateGoogleId: async (id_usuario, google_id) => {
+    if (!await columnExists('usuarios', 'google_id')) {
+      return true;
+    }
+
+    const [result] = await pool.execute(
+      `UPDATE usuarios
+       SET google_id = ?, updated_at = NOW()
+       WHERE id_usuario = ? AND deleted_at IS NULL`,
+      [google_id, id_usuario]
+    );
+    return result.affectedRows > 0;
+  },
+
+  // Crea usuario desde Facebook OAuth usando email verificado por Facebook
+  findByFacebookId: async (facebook_id) => {
+    if (!await columnExists('usuarios', 'facebook_id')) {
+      return null;
+    }
+
+    const publicFields = await UsuarioModel._publicUserSelect();
+
+    const [rows] = await pool.execute(
+      `SELECT ${publicFields}, facebook_id
+       FROM usuarios
+       WHERE facebook_id = ? AND deleted_at IS NULL
+       LIMIT 1`,
+      [facebook_id]
+    );
+    return rows[0] ?? null;
+  },
+
+  updateFacebookId: async (id_usuario, facebook_id) => {
+    if (!await columnExists('usuarios', 'facebook_id')) {
+      return true;
+    }
+
+    const [result] = await pool.execute(
+      `UPDATE usuarios
+       SET facebook_id = ?, updated_at = NOW()
+       WHERE id_usuario = ? AND deleted_at IS NULL`,
+      [facebook_id, id_usuario]
+    );
+    return result.affectedRows > 0;
+  },
+
+  createFromFacebook: async ({ facebook_id, email, nombre, apellido, avatar_url }) => {
+    const uuid = randomUUID();
+    const hasFacebookId = await columnExists('usuarios', 'facebook_id');
+
+    try {
+      if (!hasFacebookId) {
+        const [result] = await pool.execute(
+          `INSERT INTO usuarios (uuid, email, nombre, apellido, password_hash, avatar_url, rol, email_verificado)
+           VALUES (?, ?, ?, ?, ?, ?, 'ciudadano', 1)`,
+          [uuid, email, nombre, apellido, `oauth:${randomUUID()}`, avatar_url]
+        );
+        return result.insertId;
+      }
+
+      const [result] = await pool.execute(
+        `INSERT INTO usuarios (uuid, facebook_id, email, nombre, apellido, password_hash, avatar_url, rol, email_verificado)
+         VALUES (?, ?, ?, ?, ?, ?, ?, 'ciudadano', 1)`,
+        [uuid, facebook_id, email, nombre, apellido, `oauth:${randomUUID()}`, avatar_url]
+      );
+      return result.insertId;
+    } catch (error) {
+      if (error.code === 'ER_DUP_ENTRY') {
+        return null;
+      }
+      throw error;
+    }
+  },
+};
+</file>
+
+<file path=".env.example">
+# Server Configuration
+PORT=3000
+NODE_ENV=development
+
+# Database Configuration
+DB_HOST=localhost
+DB_PORT=3306
+DB_USER=root
+DB_PASSWORD= 
+DB_NAME=green-alert
+
+# JWT Configuration
+JWT_SECRET=cambia_esto_por_un_secreto_seguro
+JWT_EXPIRES_IN=1h
+REFRESH_TOKEN_EXPIRES_DAYS=7
+OAUTH_CALLBACK_CODE_TTL_SECONDS=120
+RATE_LIMIT_LOGIN_MAX=5
+RATE_LIMIT_AUTH_MAX=20
+RATE_LIMIT_PASSWORD_RESET_MAX=5
+
+# File Upload Configuration
+UPLOAD_DIR=./uploads
+MAX_FILE_SIZE=10485760
+
+# Email Configuration
+APP_NAME=GreenAlert
+EMAIL_HOST=smtp.gmail.com
+EMAIL_PORT=587
+EMAIL_USER=tu_correo@gmail.com
+EMAIL_PASS=xxxx xxxx xxxx xxxx
+EMAIL_FROM=GreenAlert <tu_correo@gmail.com>
+EMAIL_TEST_TO=tu_correo@gmail.com
+
+# SMTP aliases
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USER=tu_correo@gmail.com
+SMTP_PASS=xxxx xxxx xxxx xxxx
+SMTP_FROM=GreenAlert <tu_correo@gmail.com>
+
+# Logging
+LOG_LEVEL=info
+
+# CORS Configuration
+CORS_ORIGIN=http://localhost:5173
+
+# Frontend URL
+FRONTEND_URL=http://localhost:5173
+
+# Google OAuth Configuration
+# Ver: GOOGLE_OAUTH_SETUP.md para obtener estas credenciales
+GOOGLE_CLIENT_ID=your_client_id_here.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=your_client_secret_here
+GOOGLE_CALLBACK_URL=http://localhost:3000/auth/google/callback
+
+# Facebook OAuth Configuration
+# Ver README.md para obtener estas credenciales
+FACEBOOK_APP_ID=your_facebook_app_id
+FACEBOOK_APP_SECRET=your_facebook_app_secret
+FACEBOOK_CALLBACK_URL=http://localhost:3000/auth/facebook/callback
+FACEBOOK_GRAPH_API_VERSION=v20.0
+FACEBOOK_CALLBACK_RESPONSE=json
+
+# API Configuration
+API_PREFIX=
+API_PUBLIC_URL=http://localhost:3000
+
+# Hugging Face API
+# Token con scope "Inference Providers" en https://huggingface.co/settings/tokens
+HF_API_KEY=hf_xxxxxxxxxxxxxxxxxxxxxxxx
+# Modelo VLM usado via HF Router. Default: zai-org/GLM-4.5V
+HF_IMAGE_MODEL=zai-org/GLM-4.5V
+
+# Chatbot NLP - Groq
+GROQ_API_KEY=gsk_xxxxxxxxxxxxxxxxxxxxxxxx
+# Opciones: llama-3.1-8b-instant, llama-3.3-70b-versatile
+GROQ_MODEL=llama-3.1-8b-instant
+
+# Chatbot NLP - Gemini fallback
+GEMINI_API_KEY=AIzaxxxxxxxxxxxxxxxxxxxxxxxx
+# Opciones: gemini-2.0-flash-exp, gemini-1.5-flash
+GEMINI_MODEL=gemini-2.0-flash-exp
+
+# Firebase Admin SDK
+# Obtener de Firebase Console > Project Settings > Service Accounts > Generate new private key
+FIREBASE_PROJECT_ID=green-alert-1
+FIREBASE_CLIENT_EMAIL=firebase-adminsdk-fbsvc@green-alert-1.iam.gserviceaccount.com
+FIREBASE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
+</file>
+
+<file path="package.json">
+{
+  "name": "green-alert-backend",
+  "version": "1.0.0",
+  "description": "api backend de greenalertr",
+  "type": "module",
+  "main": "src/server.js",
+  "scripts": {
+    "dev": "nodemon src/server.js",
+    "start": "node src/server.js",
+    "test": "npm run test:unit",
+    "test:unit": "node --test tests/unit/*.test.js",
+    "test:legacy": "node tests/run-all.js",
+    "test:email": "node tests/email/smtp-send.test.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.6",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "express-rate-limit": "^8.4.1",
+    "google-auth-library": "^10.6.2",
+    "helmet": "^8.1.0",
+    "jsonwebtoken": "^9.0.2",
+    "multer": "^2.1.1",
+    "mysql2": "^3.9.8",
+    "node-fetch": "^3.3.2",
+    "nodemailer": "^8.0.5"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.3"
+  }
+}
+</file>
+
+<file path="README.md">
+# Green Alert Backend
+
+API REST para autenticacion, reportes ambientales, categorias de riesgo, administracion de usuarios, evidencias y salud del servicio.
+
+## Requisitos
+
+- Node.js 18 o superior
+- MySQL 8 o compatible
+- npm
+
+## Instalacion
+
+```bash
+npm install
+```
+
+Copia `.env.example` a `.env` y ajusta las variables de entorno segun tu entorno local.
+
+```bash
+copy .env.example .env
+```
+
+## Comandos
+
+```bash
+npm run dev          # Inicia el servidor con nodemon
+npm start            # Inicia el servidor con node
+npm test             # Ejecuta la suite unitaria estable
+npm run test:unit    # Ejecuta pruebas unitarias con node:test
+npm run test:legacy  # Ejecuta el runner historico tests/run-all.js
+npm run test:email   # Ejecuta prueba SMTP, requiere configuracion de email
+```
+
+## Variables de entorno
+
+| Variable | Uso |
+| --- | --- |
+| `PORT` | Puerto del servidor. |
+| `NODE_ENV` | Entorno de ejecucion. |
+| `DB_HOST` | Host de MySQL. |
+| `DB_PORT` | Puerto de MySQL. |
+| `DB_USER` | Usuario de MySQL. |
+| `DB_PASSWORD` | Contrasena de MySQL. |
+| `DB_NAME` | Nombre de la base de datos. |
+| `JWT_SECRET` | Secreto para firmar JWT. |
+| `JWT_EXPIRES_IN` | Duracion del access token. |
+| `REFRESH_TOKEN_EXPIRES_DAYS` | Dias de vida del refresh token. |
+| `OAUTH_CALLBACK_CODE_TTL_SECONDS` | Vida del codigo temporal usado por callbacks OAuth. |
+| `RATE_LIMIT_LOGIN_MAX` | Maximo de intentos para login. |
+| `RATE_LIMIT_AUTH_MAX` | Maximo de peticiones para endpoints de auth generales. |
+| `RATE_LIMIT_PASSWORD_RESET_MAX` | Maximo de peticiones para recuperacion de contrasena. |
+| `UPLOAD_DIR` | Carpeta donde se guardan archivos subidos. |
+| `MAX_FILE_SIZE` | Tamano maximo de archivo en bytes. |
+| `EMAIL_HOST` | Host SMTP. |
+| `EMAIL_PORT` | Puerto SMTP. |
+| `EMAIL_USER` | Usuario SMTP. |
+| `EMAIL_PASS` | Contrasena SMTP. |
+| `EMAIL_FROM` | Remitente de correos. |
+| `EMAIL_TEST_TO` | Destinatario para prueba SMTP. |
+| `LOG_LEVEL` | Nivel de logs. |
+| `CORS_ORIGIN` | Origen permitido por CORS. |
+| `FRONTEND_URL` | URL del frontend para enlaces y callbacks. |
+| `GOOGLE_CLIENT_ID` | Client ID de Google OAuth. |
+| `GOOGLE_CLIENT_SECRET` | Client secret de Google OAuth. |
+| `GOOGLE_CALLBACK_URL` | Callback backend de Google OAuth. |
+| `FACEBOOK_APP_ID` | App ID de Facebook OAuth. |
+| `FACEBOOK_APP_SECRET` | App secret de Facebook OAuth. |
+| `FACEBOOK_CALLBACK_URL` | Callback backend de Facebook OAuth. |
+| `FACEBOOK_GRAPH_API_VERSION` | Version de Facebook Graph API. |
+| `FACEBOOK_CALLBACK_RESPONSE` | Modo de respuesta del callback de Facebook. |
+| `API_PREFIX` | Prefijo base opcional de la API. Por defecto vacio para desarrollo con Vite. |
+| `API_PUBLIC_URL` | URL publica del backend para enlaces enviados por email. |
+
+## Estructura real
+
+```text
+Backend/
+  .env.example
+  DATABASE_SCHEMA_COMPLETE.sql
+  package.json
+  validate-facebook-credentials.js
+  validate-google-credentials.js
+  docs/
+    README.md
+  middlewares/
+    auth.middleware.js
+    errorHandler.js
+    rateLimit.middleware.js
+    upload.middleware.js
+    validate-id.middleware.js
+  migrations/
+    001_add_otp_columns_usuarios.sql
+    002_add_comentario_moderacion_reportes.sql
+    003_add_google_oauth_support.sql
+    004_add_facebook_oauth_support.sql
+    005_add_email_verification_token.sql
+    006_create_refresh_tokens.sql
+    007_set_reportes_estado_default_pendiente.sql
+    008_add_notification_preferences_to_usuarios.sql
+  routes/
+    admin.routes.js
+    auth.routes.js
+    categoria-riesgo.routes.js
+    health.routes.js
+    reporte.routes.js
+  src/
+    app.js
+    server.js
+    config/
+      database.js
+      email.config.js
+      facebook.config.js
+      google.config.js
+      security.config.js
+      upload.config.js
+    controllers/
+      admin.controller.js
+      auth.controller.js
+      categoria-riesgo.controller.js
+      health.controller.js
+      reporte.controller.js
+    models/
+      categoria-riesgo.model.js
+      evidencia.model.js
+      refresh-token.model.js
+      reporte.model.js
+      usuario.model.js
+    services/
+      email.service.js
+      facebook-oauth.service.js
+      google-oauth.service.js
+      oauth-callback-code.service.js
+    utils/
+      constantes-validacion.js
+      response.js
+  tests/
+    run-all.js
+    unit/
+    auth/
+    config/
+    email/
+    models/
+```
+
+## Base de datos
+
+El archivo `DATABASE_SCHEMA_COMPLETE.sql` contiene el esquema consolidado. Las migraciones incrementales estan en `migrations/`.
+
+Tablas principales:
+
+- `usuarios`
+- `reportes`
+- `categorias_riesgo`
+- `evidencias`
+- `refresh_tokens`
+
+Para aplicar cambios en una base existente, ejecuta las migraciones pendientes en orden.
+
+## Seguridad
+
+El backend incluye:
+
+- JWT para rutas privadas.
+- Refresh tokens opacos almacenados con hash.
+- Rotacion de refresh token en `/auth/refresh`.
+- Revocacion de refresh tokens en logout global, cambio de contrasena y reset de contrasena.
+- Helmet para cabeceras HTTP de seguridad.
+- CORS configurado con `CORS_ORIGIN`.
+- Rate limiting para autenticacion y recuperacion de contrasena.
+- Validacion de IDs numericos positivos en rutas con `:id`.
+- Validacion de coordenadas geograficas en reportes.
+- Validacion de enums de estado y severidad.
+- OTP generado con `crypto.randomInt`.
+
+## Prefijo de API
+
+Por defecto `API_PREFIX` es vacio y las rutas se montan sin prefijo:
+
+Ejemplo:
+
+```text
+http://localhost:3000/auth/login
+```
+
+En desarrollo, el frontend puede seguir llamando `/api/*` porque Vite reescribe ese prefijo antes de enviar la peticion al backend. Por ejemplo, `/api/reportes` en el navegador llega al backend como `/reportes`.
+
+Si necesitas publicar el backend directamente bajo `/api`, define `API_PREFIX=/api`. No se montan ambos prefijos al mismo tiempo.
+
+## Rutas
+
+### Salud
+
+| Metodo | Ruta | Descripcion |
+| --- | --- | --- |
+| `GET` | `/health` | Verifica servidor y conexion a base de datos. |
+
+### Autenticacion
+
+| Metodo | Ruta | Protegida | Descripcion |
+| --- | --- | --- | --- |
+| `POST` | `/auth/register` | No | Registro de usuario. |
+| `POST` | `/auth/login` | No | Inicio de sesion con email y contrasena. |
+| `POST` | `/auth/refresh` | No | Renueva access token y rota refresh token. |
+| `POST` | `/auth/oauth/exchange` | No | Canjea codigo temporal OAuth por tokens backend. |
+| `POST` | `/auth/logout` | Parcial | Logout individual con refresh token; logout global requiere JWT. |
+| `GET` | `/auth/verify-email` | No | Verifica email por token de enlace. |
+| `POST` | `/auth/forgot-password` | No | Solicita recuperacion de contrasena. |
+| `POST` | `/auth/reset-password` | No | Restablece contrasena con token. |
+| `GET` | `/auth/perfil` | Si | Obtiene perfil del usuario autenticado. |
+| `PATCH` | `/auth/perfil` | Si | Actualiza perfil. |
+| `PATCH` | `/auth/cambiar-contrasena` | Si | Cambia contrasena y revoca refresh tokens. |
+| `PATCH` | `/auth/notificaciones` | Si | Actualiza preferencias de notificaciones. |
+| `POST` | `/auth/enviar-verificacion` | Si | Envia OTP de verificacion de email. |
+| `POST` | `/auth/verificar-email` | Si | Verifica OTP de email. |
+| `GET` | `/auth/google/url` | No | Genera URL de login con Google. |
+| `POST` | `/auth/google/login` | No | Login con `id_token` de Google. |
+| `GET` | `/auth/google/callback` | No | Callback OAuth de Google. |
+| `GET` | `/auth/facebook/url` | No | Genera URL de login con Facebook. |
+| `GET` | `/auth/facebook/callback` | No | Callback OAuth de Facebook. |
+
+### Reportes
+
+| Metodo | Ruta | Protegida | Descripcion |
+| --- | --- | --- | --- |
+| `GET` | `/reportes/stats` | No | Estadisticas generales de reportes. |
+| `GET` | `/reportes/stats/categoria` | No | Estadisticas por categoria. |
+| `GET` | `/reportes/stats/timeline` | No | Serie temporal de reportes. |
+| `GET` | `/reportes/stats/heatmap` | No | Puntos para heatmap. |
+| `GET` | `/reportes/export` | Si, admin o moderador | Exporta reportes. |
+| `GET` | `/reportes/mis-reportes` | Si | Lista reportes del usuario autenticado. |
+| `GET` | `/reportes` | No | Lista reportes con filtros. |
+| `GET` | `/reportes/:id` | No | Obtiene un reporte por ID. |
+| `POST` | `/reportes` | Si | Crea reporte, con archivo opcional en campo `file`. |
+| `PATCH` | `/reportes/:id` | Si | Actualiza reporte. |
+| `DELETE` | `/reportes/:id` | Si | Elimina reporte logicamente. |
+
+### Categorias de riesgo
+
+| Metodo | Ruta | Descripcion |
+| --- | --- | --- |
+| `GET` | `/categorias/estadisticas/resumen` | Resumen por categorias. |
+| `GET` | `/categorias/estadisticas/por-severidad` | Estadisticas por severidad. |
+| `GET` | `/categorias` | Lista categorias activas. |
+| `GET` | `/categorias/:codigo/reportes` | Reportes de una categoria. |
+| `GET` | `/categorias/:codigo` | Detalle de categoria. |
+
+### Administracion
+
+Todas las rutas de administracion requieren JWT con rol `admin`.
+
+| Metodo | Ruta | Descripcion |
+| --- | --- | --- |
+| `GET` | `/admin/usuarios/stats` | Estadisticas de usuarios y reportes. |
+| `GET` | `/admin/usuarios` | Lista usuarios. |
+| `GET` | `/admin/usuarios/:id` | Obtiene usuario por ID. |
+| `PATCH` | `/admin/usuarios/:id/rol` | Cambia rol de usuario. |
+| `PATCH` | `/admin/usuarios/:id/estado` | Activa o desactiva usuario. |
+| `DELETE` | `/admin/usuarios/:id` | Elimina usuario logicamente. |
+
+## OAuth
+
+El backend soporta Google y Facebook.
+
+Flujo recomendado con callbacks:
+
+1. El frontend solicita `/api/auth/google/url` o `/api/auth/facebook/url` en desarrollo con Vite, que reescribe a `/auth/google/url` o `/auth/facebook/url` en el backend.
+2. El usuario autentica con el proveedor.
+3. El proveedor redirige al callback backend.
+4. El backend crea o vincula el usuario.
+5. El backend redirige al frontend con un codigo temporal en el fragmento `#oauth_code=...`.
+6. El frontend canjea ese codigo en `/api/auth/oauth/exchange`; Vite lo reescribe a `/auth/oauth/exchange`.
+
+Los access tokens y refresh tokens del backend no se envian por query string.
+
+## Uploads
+
+Los archivos se configuran con:
+
+- `UPLOAD_DIR`: carpeta de almacenamiento.
+- `MAX_FILE_SIZE`: tamano maximo en bytes.
+
+Tipos permitidos:
+
+- `image/jpeg`
+- `image/jpg`
+- `image/png`
+- `image/webp`
+- `image/gif`
+- `video/mp4`
+- `video/quicktime`
+
+Los archivos se sirven desde `/uploads`.
+
+## Preferencias de notificaciones
+
+El endpoint `PATCH /auth/notificaciones` persiste las preferencias en `usuarios.notification_preferences`.
+
+Estructura soportada:
+
+```json
+{
+  "email_alerts": true,
+  "push_notifications": false,
+  "report_updates": true,
+  "weekly_summary": false
+}
+```
+
+## Testing
+
+Suite unitaria estable:
+
+```bash
+npm test
+```
+
+Runner legacy:
+
+```bash
+npm run test:legacy
+```
+
+Prueba SMTP:
+
+```bash
+npm run test:email
+```
+
+Las pruebas de integracion y algunos scripts legacy pueden requerir servidor, base de datos o servicios externos configurados.
+
+## Scripts de validacion OAuth
+
+```bash
+node validate-google-credentials.js
+node validate-facebook-credentials.js
+```
+
+Estos scripts revisan que las variables de entorno OAuth esten configuradas y no tengan valores de ejemplo.
+</file>
+
+<file path="routes/reporte.routes.js">
+import { Router } from 'express';
+import { optionalAuth, verifyToken, requireRoles } from '../middlewares/auth.middleware.js';
+import { upload, uploadMultiple } from '../middlewares/upload.middleware.js';
+import { validatePositiveIdParam } from '../middlewares/validate-id.middleware.js';
+import {
+  createReporte,
+  getReportes,
+  getReporteById,
+  getStats,
+  getStatsByCategoria,
+  getStatsTimeline,
+  getHeatmapPoints,
+  getStatsIA,
+  getTrendingReportes,
+  toggleLikeReporte,
+  analizarImagen,
+  getMisReportes,
+  updateReporte,
+  deleteReporte,
+  exportReportes,
+  listEvidenciasReporte,
+  addEvidenciaReporte,
+  deleteEvidenciaReporte,
+} from '../src/controllers/reporte.controller.js';
+import {
+  getAlertasPredictivas,
+  getZonasRiesgo,
+} from '../src/controllers/prediccion.controller.js';
+ 
+
+const reporteRouter = Router();
+
+reporteRouter.get('/stats', getStats);
+reporteRouter.get('/stats/categoria', getStatsByCategoria);
+reporteRouter.get('/stats/timeline', getStatsTimeline);
+reporteRouter.get('/stats/heatmap', getHeatmapPoints);
+reporteRouter.get('/stats/ia', verifyToken, requireRoles('admin', 'moderador'), getStatsIA);
+reporteRouter.get('/zonas-riesgo', verifyToken, requireRoles('admin', 'moderador'), getZonasRiesgo);
+reporteRouter.get('/alertas-predictivas', optionalAuth, getAlertasPredictivas);
+reporteRouter.get('/trending', optionalAuth, getTrendingReportes);
+reporteRouter.get('/export', verifyToken, requireRoles('admin', 'moderador'), exportReportes);
+reporteRouter.get('/mis-reportes', verifyToken, getMisReportes);
+reporteRouter.post('/analizar-imagen', verifyToken, upload.single('imagen'), analizarImagen);
+reporteRouter.get('/', optionalAuth, getReportes);
+reporteRouter.post('/:id/like', validatePositiveIdParam('id'), verifyToken, toggleLikeReporte);
+reporteRouter.get('/:id/evidencias', validatePositiveIdParam('id'), verifyToken, listEvidenciasReporte);
+reporteRouter.post('/:id/evidencias', validatePositiveIdParam('id'), verifyToken, upload.single('file'), addEvidenciaReporte);
+reporteRouter.delete(
+  '/:id/evidencias/:evidenciaId',
+  validatePositiveIdParam('id'),
+  validatePositiveIdParam('evidenciaId'),
+  verifyToken,
+  deleteEvidenciaReporte
+);
+reporteRouter.get('/:id', validatePositiveIdParam('id'), optionalAuth, getReporteById);
+reporteRouter.post(
+  '/',
+  verifyToken,
+  uploadMultiple,
+  createReporte
+);
+reporteRouter.patch('/:id', validatePositiveIdParam('id'), verifyToken, updateReporte);
+reporteRouter.delete('/:id', validatePositiveIdParam('id'), verifyToken, deleteReporte);
+
+export default reporteRouter;
+</file>
+
+<file path=".github/workflows/Maven.yml">
+name: Backend CI
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  backend-validation:
+    name: Validate backend
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+ 
+
+      - name: Cache npm
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json', 'package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+ 
+          cache: npm
+ 
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Validate JavaScript syntax
+        run: |
+          find . \
+            -path ./node_modules -prune -o \
+            -path ./.git -prune -o \
+            -name "*.js" -print0 | xargs -0 -n1 node --check
+
+      - name: Run unit tests
+        run: npm run test:unit
+</file>
+
+<file path="src/controllers/auth.controller.js">
+import crypto from 'crypto';
+import jwt from 'jsonwebtoken';
+import {
+  DEFAULT_NOTIFICATION_PREFERENCES,
+  parseNotificationPreferences,
+  UsuarioModel,
+} from '../models/usuario.model.js';
+import { RefreshTokenModel } from '../models/refresh-token.model.js';
+import { errorResponse, successResponse } from '../utils/response.js';
+import {
+  enviarCorreo,
+  enviarCorreoBienvenida,
+  generarTemplateBaseCorreo,
+} from '../services/email.service.js';
+import { verifyGoogleToken, exchangeCodeForTokens, getGoogleUserInfo, generateAuthUrl } from '../services/google-oauth.service.js';
+import {
+  exchangeFacebookCodeForToken,
+  generateFacebookAuthUrl,
+  getFacebookUserInfo,
+} from '../services/facebook-oauth.service.js';
+import {
+  consumeOAuthCallbackCode,
+  createOAuthCallbackCode,
+} from '../services/oauth-callback-code.service.js';
+import { getApiPrefix } from '../config/api-prefix.config.js';
+
+/**
+ * ESTRATEGIA DE AUTENTICACIÓN CON FACEBOOK
+ * ==========================================
+ * Flujo único: Authorization Code Flow (lado del servidor)
+ * 
+ * 1. Frontend obtiene URL de autenticación en /facebook/url
+ * 2. Usuario se autentica en Facebook
+ * 3. Facebook redirige a /facebook/callback con código
+ * 4. Backend intercambia código por token (seguro, lado servidor)
+ * 5. Backend retorna JWT al cliente
+ * 
+ * Ventajas:
+ * - Secret de Facebook nunca se expone al cliente
+ * - Un único flujo consistente
+ * - Cumple estándares OAuth 2.0
+ * - Mejor seguridad
+ */
+import {
+  validarNombreUsuario,
+  validarTelefono,
+  validarPassword,
+} from '../utils/constantes-validacion.js';
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const DEFAULT_ACCESS_EXPIRES_IN = '15m';
+const DEFAULT_REFRESH_EXPIRES_DAYS = 7;
+
+const hashPassword = (password) => {
+  const salt = crypto.randomBytes(16).toString('hex');
+  const derivedKey = crypto.scryptSync(password, salt, 64).toString('hex');
+  return `${salt}:${derivedKey}`;
+};
+
+const getJwtSecret = () => {
+  if (!process.env.JWT_SECRET) {
+    const error = new Error('JWT_SECRET no configurado');
+    error.statusCode = 500;
+    throw error;
+  }
+
+  return process.env.JWT_SECRET;
+};
+
+const validateGeneratedToken = (token, secret, user) => {
+  const decoded = jwt.verify(token, secret);
+
+  if (
+    Number(decoded.sub) !== Number(user.id_usuario) ||
+    decoded.email !== user.email ||
+    decoded.rol !== user.rol ||
+    (user.uuid && decoded.uuid !== user.uuid)
+  ) {
+    const error = new Error('JWT generado no coincide con el usuario autenticado');
+    error.statusCode = 500;
+    throw error;
+  }
+
+  return decoded;
+};
+
+const buildToken = (user) => {
+  const secret = getJwtSecret();
+  const expiresIn = process.env.JWT_EXPIRES_IN || DEFAULT_ACCESS_EXPIRES_IN;
+
+  const token = jwt.sign(
+    {
+      sub: user.id_usuario,
+      uuid: user.uuid,
+      rol: user.rol,
+      email: user.email,
+    },
+    secret,
+    { expiresIn }
+  );
+
+  validateGeneratedToken(token, secret, user);
+
+  return token;
+};
+
+const getRefreshExpiresDays = () => {
+  const value = Number(process.env.REFRESH_TOKEN_EXPIRES_DAYS);
+  return Number.isFinite(value) && value > 0 ? value : DEFAULT_REFRESH_EXPIRES_DAYS;
+};
+
+const getRefreshTokenExpiration = () => {
+  const exp = new Date();
+  exp.setDate(exp.getDate() + getRefreshExpiresDays());
+  return exp;
+};
+
+const buildRefreshToken = () => {
+  const rawToken = crypto.randomBytes(64).toString('hex');
+  return {
+    rawToken,
+    tokenHash: hashToken(rawToken),
+    expiresAt: getRefreshTokenExpiration(),
+  };
+};
+
+const createRefreshTokenForUser = async (user, req) => {
+  const { rawToken, tokenHash, expiresAt } = buildRefreshToken();
+
+  await RefreshTokenModel.create({
+    id_usuario: user.id_usuario,
+    token_hash: tokenHash,
+    expires_at: expiresAt,
+    user_agent: req.get('user-agent')?.slice(0, 255) || null,
+    ip_address: req.ip || null,
+  });
+
+  return {
+    refreshToken: rawToken,
+    refreshTokenExpiresAt: expiresAt,
+  };
+};
+
+const buildAuthPayload = async (user, req) => {
+  const accessToken = buildToken(user);
+  const refresh = await createRefreshTokenForUser(user, req);
+
+  return {
+    token: accessToken,
+    accessToken,
+    refreshToken: refresh.refreshToken,
+    refreshTokenExpiresAt: refresh.refreshTokenExpiresAt,
+    user: toPublicUser(user),
+  };
+};
+
+const toPublicUser = (user) => ({
+  id_usuario: user.id_usuario,
+  uuid: user.uuid,
+  nombre: user.nombre,
+  apellido: user.apellido,
+  email: user.email,
+  rol: user.rol,
+  activo: user.activo,
+  email_verificado: user.email_verificado,
+  avatar_url: user.avatar_url,
+  telefono: user.telefono,
+  es_oauth: Boolean(user.google_id || user.facebook_id || (
+    typeof user.password_hash === 'string' && user.password_hash.startsWith('oauth:')
+  )),
+  notification_preferences: parseNotificationPreferences(user.notification_preferences),
+  created_at: user.created_at,
+});
+
+const isDevelopment = () => process.env.NODE_ENV === 'development';
+
+const buildFrontendAuthCallbackUrl = (authPayload) => {
+  const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:5173';
+  const callbackCode = createOAuthCallbackCode(authPayload);
+  const url = new URL('/auth/callback', frontendUrl);
+
+  url.hash = `oauth_code=${encodeURIComponent(callbackCode)}`;
+
+  return url.toString();
+};
+
+const redirectToFrontendAuthCallback = (res, authPayload) => {
+  res.set({
+    'Cache-Control': 'no-store',
+    Pragma: 'no-cache',
+    'Referrer-Policy': 'no-referrer',
+  });
+
+  return res.redirect(303, buildFrontendAuthCallbackUrl(authPayload));
+};
+
+const errorResponseWithDevelopmentDetails = (
+  res,
+  message,
+  statusCode = 400,
+  details = undefined
+) => {
+  if (!isDevelopment() || !details) {
+    return errorResponse(res, message, statusCode);
+  }
+
+  return res.status(statusCode).json({
+    status: 'error',
+    message,
+    details,
+  });
+};
+
+const verifyPassword = (password, storedHash) => {
+  if (typeof storedHash !== 'string' || !storedHash.includes(':')) {
+    return false;
+  }
+
+  const [salt, key] = storedHash.split(':');
+  if (!salt || !key) {
+    return false;
+  }
+
+  const derivedKey = crypto.scryptSync(password, salt, 64).toString('hex');
+  return key === derivedKey;
+};
+
+const RESET_TOKEN_MINUTES = 30;
+
+const buildResetToken = () => {
+  const rawToken = crypto.randomBytes(32).toString('hex');
+  const tokenHash = crypto.createHash('sha256').update(rawToken).digest('hex');
+  return { rawToken, tokenHash };
+};
+
+const buildResetLink = (token) => {
+  const baseUrl = process.env.FRONTEND_URL || 'http://localhost:5173';
+  return `${baseUrl}/reset-password?token=${token}`;
+};
+
+const VERIFICATION_TOKEN_HOURS = 24;
+
+const buildVerificationToken = () => {
+  const rawToken = crypto.randomBytes(32).toString('hex');
+  const tokenHash = crypto.createHash('sha256').update(rawToken).digest('hex');
+  return { rawToken, tokenHash };
+};
+
+const getVerificationTokenExpiration = () => {
+  const exp = new Date();
+  exp.setHours(exp.getHours() + VERIFICATION_TOKEN_HOURS);
+  return exp;
+};
+
+const buildEmailVerificationLink = (token) => {
+  const apiBaseUrl = process.env.API_PUBLIC_URL || `http://localhost:${process.env.PORT || 3000}`;
+  const apiPrefix = getApiPrefix();
+  return `${apiBaseUrl}${apiPrefix}/auth/verify-email?token=${token}`;
+};
+
+const hashToken = (token) => crypto.createHash('sha256').update(token).digest('hex');
+
+const buildPublicUploadUrl = (filename) => {
+  const apiBaseUrl = process.env.API_PUBLIC_URL || `http://localhost:${process.env.PORT || 3000}`;
+  return `${apiBaseUrl.replace(/\/+$/, '')}/uploads/${filename}`;
+};
+
+const buildOtpEmailHtml = ({ user, otpCode }) => generarTemplateBaseCorreo({
+  title: 'Verifica tu correo',
+  subtitle: 'Codigo de seguridad de GreenAlert',
+  previewText: 'Usa este codigo de 6 digitos para activar tu cuenta.',
+  content: `
+    <div class="message">
+      Hola ${user.nombre}, usa este codigo para verificar tu correo electronico en GreenAlert.
+    </div>
+    <div style="text-align:center;margin:28px 0;">
+      <div style="display:inline-block;background:#ecfdf5;border:1px solid #10b981;border-radius:12px;padding:18px 24px;">
+        <p style="margin:0 0 8px;color:#047857;font-size:13px;font-weight:600;">Codigo de verificacion</p>
+        <p style="margin:0;color:#064e3b;font-size:36px;letter-spacing:8px;font-weight:800;">${otpCode}</p>
+      </div>
+    </div>
+    <div class="panel">
+      <h3>Seguridad</h3>
+      <p>Este codigo expira en ${OTP_MINUTES} minutos. Si no creaste esta cuenta, ignora este correo.</p>
+    </div>
+  `,
+});
+
+const sendVerificationOtpEmail = async (user) => {
+  const otpCode = generateOtpCode();
+  const otpCodeHash = hashOtpCode(otpCode);
+  const otpExp = new Date(Date.now() + OTP_MINUTES * 60 * 1000);
+
+  await UsuarioModel.setOtp(user.id_usuario, otpCodeHash, otpExp);
+  await UsuarioModel.updateOtpLastRequest(user.id_usuario);
+  await enviarCorreo(
+    user.email,
+    'Codigo de verificacion - GreenAlert',
+    buildOtpEmailHtml({ user, otpCode })
+  );
+
+  return {
+    expiresIn: OTP_MINUTES * 60,
+  };
+};
+
+export const register = async (req, res, next) => {
+  try {
+    const { nombre, apellido, email, password, telefono } = req.body ?? {};
+
+    const normalizedNombre  = typeof nombre   === 'string' ? nombre.trim()   : '';
+    const normalizedApellido = typeof apellido === 'string' ? apellido.trim() : '';
+    const normalizedEmail   = typeof email    === 'string' ? email.trim().toLowerCase() : '';
+    const normalizedTelefono = typeof telefono === 'string' ? telefono.trim() : null;
+
+    if (!normalizedNombre || normalizedNombre.length < 2) {
+      return errorResponse(res, 'El nombre debe tener al menos 2 caracteres.', 400);
+    }
+
+    if (!normalizedApellido || normalizedApellido.length < 2) {
+      return errorResponse(res, 'El apellido debe tener al menos 2 caracteres.', 400);
+    }
+
+    if (!normalizedEmail || !EMAIL_REGEX.test(normalizedEmail)) {
+      return errorResponse(res, 'Correo electronico invalido.', 400);
+    }
+
+    if (typeof password !== 'string' || password.length < 8) {
+      return errorResponse(res, 'La contrasena debe tener al menos 8 caracteres.', 400);
+    }
+
+    const existingUser = await UsuarioModel.findByEmail(normalizedEmail);
+    if (existingUser) {
+      return errorResponse(res, 'Ya existe una cuenta registrada con ese correo.', 409);
+    }
+
+    const password_hash = hashPassword(password);
+
+    const idUsuario = await UsuarioModel.create({
+      nombre: normalizedNombre,
+      apellido: normalizedApellido,
+      email: normalizedEmail,
+      password_hash,
+      rol: 'ciudadano',
+      telefono: normalizedTelefono || null,
+    });
+
+    const createdUser = await UsuarioModel.findById(idUsuario);
+    if (!createdUser) {
+      return errorResponse(res, 'No fue posible recuperar el usuario recien creado.', 500);
+    }
+
+    // Generar y enviar OTP automáticamente después del registro
+    try {
+      await sendVerificationOtpEmail(createdUser);
+    } catch (emailError) {
+      console.error('Error enviando verificacion en registro:', emailError);
+      // No fallar el registro si falla el email, pero loguear el error
+    }
+
+    const authPayload = await buildAuthPayload(createdUser, req);
+
+    // Enviar correo de bienvenida de forma no-bloqueante (fire-and-forget)
+    enviarCorreoBienvenida(
+      createdUser.email,
+      createdUser.nombre,
+      createdUser.apellido
+    ).catch((error) => {
+      console.error('Error al enviar correo de bienvenida:', error);
+    });
+
+    return successResponse(
+      res,
+      {
+        ...authPayload,
+        pendingEmailVerification: true,
+      },
+      'Cuenta creada correctamente. Verifica tu email con el codigo enviado.',
+      201
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const login = async (req, res, next) => {
+  try {
+    const { email, password } = req.body ?? {};
+
+    const normalizedEmail = typeof email === 'string' ? email.trim().toLowerCase() : '';
+
+    if (!normalizedEmail || !EMAIL_REGEX.test(normalizedEmail)) {
+      return errorResponse(res, 'Correo electronico invalido.', 400);
+    }
+
+    if (typeof password !== 'string' || password.length < 1) {
+      return errorResponse(res, 'Contrasena requerida.', 400);
+    }
+
+    const user = await UsuarioModel.findByEmail(normalizedEmail);
+    if (!user) {
+      return errorResponse(res, 'Credenciales incorrectas.', 401);
+    }
+
+    if (!user.activo) {
+      return errorResponse(res, 'Cuenta desactivada. Contacta al administrador.', 403);
+    }
+
+    if (!user.password_hash) {
+      if (user.google_id || user.facebook_id) {
+        return errorResponse(
+          res,
+          'Cuenta registrada con Google o Facebook. Inicia sesion con ese proveedor o crea una contrasena.',
+          400
+        );
+      }
+
+      return errorResponse(res, 'No se puede iniciar sesion con contrasena en este momento.', 400);
+    }
+
+    if (!verifyPassword(password, user.password_hash)) {
+      return errorResponse(res, 'Credenciales incorrectas.', 401);
+    }
+
+    await UsuarioModel.updateUltimoAcceso(user.id_usuario);
+
+    const authPayload = await buildAuthPayload(user, req);
+
+    return successResponse(res, authPayload, 'Inicio de sesion exitoso.');
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const refreshAccessToken = async (req, res, next) => {
+  try {
+    const { refreshToken } = req.body ?? {};
+
+    if (typeof refreshToken !== 'string' || refreshToken.length < 32) {
+      return errorResponse(res, 'Refresh token requerido.', 400);
+    }
+
+    const currentHash = hashToken(refreshToken);
+    const current = await RefreshTokenModel.findActiveByHash(currentHash);
+
+    if (!current) {
+      return errorResponse(res, 'Refresh token invalido o expirado.', 401);
+    }
+
+    if (!current.activo) {
+      await RefreshTokenModel.revokeByHash(currentHash);
+      return errorResponse(res, 'Cuenta desactivada. Contacta al administrador.', 403);
+    }
+
+    const next = buildRefreshToken();
+    const rotated = await RefreshTokenModel.rotate({
+      current_hash: currentHash,
+      next_hash: next.tokenHash,
+      expires_at: next.expiresAt,
+      user_agent: req.get('user-agent')?.slice(0, 255) || null,
+      ip_address: req.ip || null,
+    });
+
+    if (!rotated) {
+      return errorResponse(res, 'Refresh token invalido o expirado.', 401);
+    }
+
+    const accessToken = buildToken(current);
+
+    return successResponse(
+      res,
+      {
+        token: accessToken,
+        accessToken,
+        refreshToken: next.rawToken,
+        refreshTokenExpiresAt: next.expiresAt,
+        user: toPublicUser(current),
+      },
+      'Token renovado correctamente.'
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const exchangeOAuthCallbackCode = async (req, res, next) => {
+  try {
+    const { code } = req.body ?? {};
+    const authPayload = consumeOAuthCallbackCode(code);
+
+    if (!authPayload) {
+      return errorResponse(res, 'Codigo OAuth invalido o expirado.', 400);
+    }
+
+    return successResponse(
+      res,
+      authPayload,
+      'Autenticacion OAuth completada.',
+      200
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const logout = async (req, res, next) => {
+  try {
+    const { refreshToken, allDevices = false } = req.body ?? {};
+
+    if (allDevices && !req.user?.sub) {
+      return errorResponse(res, 'JWT requerido para cerrar sesion en todos los dispositivos.', 401);
+    }
+
+    if (allDevices) {
+      await RefreshTokenModel.revokeAllForUser(req.user.sub);
+      return successResponse(res, null, 'Sesion cerrada en todos los dispositivos.');
+    }
+
+    if (typeof refreshToken !== 'string' || refreshToken.length < 32) {
+      return errorResponse(res, 'Refresh token requerido.', 400);
+    }
+
+    await RefreshTokenModel.revokeByHash(hashToken(refreshToken));
+    return successResponse(res, null, 'Sesion cerrada correctamente.');
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const getPerfil = async (req, res, next) => {
+  try {
+    const id_usuario = req.user?.sub;
+
+    if (!id_usuario) {
+      return errorResponse(res, 'No autorizado.', 401);
+    }
+
+    const user = await UsuarioModel.findByIdWithDetails(id_usuario);
+    if (!user) {
+      return errorResponse(res, 'Usuario no encontrado.', 404);
+    }
+
+    return successResponse(res, { user }, 'Perfil obtenido correctamente.', 200);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const updatePerfil = async (req, res, next) => {
+  try {
+    const id_usuario = req.user?.sub;
+
+    if (!id_usuario) {
+      return errorResponse(res, 'No autorizado.', 401);
+    }
+
+    const {
+      nombre,
+      apellido,
+      telefono,
+      avatar_url,
+    } = req.body ?? {};
+
+    if (!validarNombreUsuario(nombre)) {
+      return errorResponse(res, 'El nombre no es valido.', 400);
+    }
+
+    if (!validarNombreUsuario(apellido)) {
+      return errorResponse(res, 'El apellido no es valido.', 400);
+    }
+
+    if (!validarTelefono(telefono)) {
+      return errorResponse(res, 'El telefono no tiene un formato valido.', 400);
+    }
+
+    const payload = {
+      nombre: nombre.trim(),
+      apellido: apellido.trim(),
+      telefono: typeof telefono === 'string' ? (telefono.trim() || null) : null,
+      avatar_url: typeof avatar_url === 'string' ? (avatar_url.trim() || null) : null,
+    };
+
+    const updatedUser = await UsuarioModel.updatePerfil(id_usuario, payload);
+    if (!updatedUser) {
+      return errorResponse(res, 'Usuario no encontrado.', 404);
+    }
+
+    return successResponse(res, { user: updatedUser }, 'Perfil actualizado', 200);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const updateAvatar = async (req, res, next) => {
+  try {
+    const id_usuario = req.user?.sub;
+
+    if (!id_usuario) {
+      return errorResponse(res, 'No autorizado.', 401);
+    }
+
+    if (!req.file) {
+      return errorResponse(res, 'Imagen de avatar requerida.', 400);
+    }
+
+    const avatarUrl = buildPublicUploadUrl(req.file.filename);
+    const updatedUser = await UsuarioModel.updateAvatar(id_usuario, avatarUrl);
+
+    if (!updatedUser) {
+      return errorResponse(res, 'Usuario no encontrado.', 404);
+    }
+
+    return successResponse(res, { user: updatedUser }, 'Avatar actualizado correctamente.', 200);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const changePassword = async (req, res, next) => {
+  try {
+    const id_usuario = req.user?.sub;
+    const tokenEmail = req.user?.email;
+
+    if (!id_usuario) {
+      return errorResponse(res, 'No autorizado.', 401);
+    }
+
+    const {
+      currentPassword,
+      newPassword,
+      confirmPassword,
+    } = req.body ?? {};
+
+    if (
+      typeof currentPassword !== 'string' ||
+      typeof newPassword !== 'string' ||
+      typeof confirmPassword !== 'string'
+    ) {
+      return errorResponse(
+        res,
+        'currentPassword, newPassword y confirmPassword son obligatorios.',
+        400
+      );
+    }
+
+    if (newPassword !== confirmPassword) {
+      return errorResponse(res, 'La nueva contrasena y la confirmacion no coinciden.', 400);
+    }
+
+    if (!validarPassword(newPassword)) {
+      return errorResponse(res, 'La nueva contrasena no cumple con los requisitos de seguridad.', 400);
+    }
+
+    if (!tokenEmail) {
+      return errorResponse(res, 'No autorizado.', 401);
+    }
+
+    const user = await UsuarioModel.findByEmail(tokenEmail);
+    if (!user || Number(user.id_usuario) !== Number(id_usuario)) {
+      return errorResponse(res, 'Usuario no encontrado.', 404);
+    }
+
+    if (!verifyPassword(currentPassword, user.password_hash)) {
+      return errorResponse(res, 'La contrasena actual es incorrecta.', 401);
+    }
+
+    const newPasswordHash = hashPassword(newPassword);
+    const updatedUser = await UsuarioModel.updatePassword(id_usuario, newPasswordHash);
+
+    if (!updatedUser) {
+      return errorResponse(res, 'Usuario no encontrado.', 404);
+    }
+
+    await RefreshTokenModel.revokeAllForUser(id_usuario);
+
+    return successResponse(res, null, 'Contrasena actualizada. Se cerraron las sesiones activas.', 200);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const forgotPassword = async (req, res, next) => {
+  try {
+    const { email } = req.body ?? {};
+    const normalizedEmail = typeof email === 'string' ? email.trim().toLowerCase() : '';
+
+    if (!normalizedEmail || !EMAIL_REGEX.test(normalizedEmail)) {
+      return errorResponse(res, 'Correo electronico invalido.', 400);
+    }
+
+    const user = await UsuarioModel.findByEmail(normalizedEmail);
+
+    if (user && user.activo) {
+      const { rawToken, tokenHash } = buildResetToken();
+      const tokenExp = new Date(Date.now() + RESET_TOKEN_MINUTES * 60 * 1000);
+
+      await UsuarioModel.setResetToken(user.id_usuario, tokenHash, tokenExp);
+
+      const resetLink = buildResetLink(rawToken);
+      const html = generarTemplateBaseCorreo({
+        title: 'Recupera tu contrasena',
+        subtitle: 'Solicitud de restablecimiento',
+        previewText: 'Usa este enlace para crear una nueva contrasena.',
+        actionUrl: resetLink,
+        actionText: 'Restablecer contrasena',
+        content: `
+          <div class="message">
+            Se recibio una solicitud para recuperar tu contrasena.
+            Haz clic en el boton para crear una nueva contrasena.
+          </div>
+          <div class="panel">
+            <h3>Seguridad</h3>
+            <p>Este enlace expira en ${RESET_TOKEN_MINUTES} minutos. Si no solicitaste este cambio, ignora este correo.</p>
+          </div>
+        `,
+      });
+
+      await enviarCorreo(user.email, 'Recuperacion de contrasena', html);
+    }
+
+    return successResponse(
+      res,
+      null,
+      'Si el correo existe, recibiras un enlace de recuperacion.'
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const resetPassword = async (req, res, next) => {
+  try {
+    const { token, newPassword, confirmPassword } = req.body ?? {};
+
+    if (typeof token !== 'string' || token.length < 10) {
+      return errorResponse(res, 'Token invalido.', 400);
+    }
+
+    if (
+      typeof newPassword !== 'string' ||
+      typeof confirmPassword !== 'string'
+    ) {
+      return errorResponse(
+        res,
+        'newPassword y confirmPassword son obligatorios.',
+        400
+      );
+    }
+
+    if (newPassword !== confirmPassword) {
+      return errorResponse(res, 'La nueva contrasena y la confirmacion no coinciden.', 400);
+    }
+
+    if (!validarPassword(newPassword)) {
+      return errorResponse(res, 'La nueva contrasena no cumple con los requisitos de seguridad.', 400);
+    }
+
+    const tokenHash = hashToken(token);
+    const user = await UsuarioModel.findByResetToken(tokenHash);
+
+    if (!user || !user.token_reset_exp) {
+      return errorResponse(res, 'Token invalido o expirado.', 400);
+    }
+
+    const expiresAt = new Date(user.token_reset_exp);
+    if (Number.isNaN(expiresAt.getTime()) || expiresAt.getTime() < Date.now()) {
+      await UsuarioModel.clearResetToken(user.id_usuario);
+      return errorResponse(res, 'Token invalido o expirado.', 400);
+    }
+
+    const newPasswordHash = hashPassword(newPassword);
+    const updatedUser = await UsuarioModel.updatePassword(user.id_usuario, newPasswordHash);
+
+    if (!updatedUser) {
+      return errorResponse(res, 'Usuario no encontrado.', 404);
+    }
+
+    await UsuarioModel.clearResetToken(user.id_usuario);
+    await RefreshTokenModel.revokeAllForUser(user.id_usuario);
+
+    return successResponse(res, null, 'Contrasena actualizada correctamente. Se cerraron las sesiones activas.', 200);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const verifyEmail = async (req, res, next) => {
+  try {
+    const { token } = req.query ?? {};
+
+    if (typeof token !== 'string' || token.length < 10) {
+      return errorResponse(res, 'Token de verificacion invalido.', 400);
+    }
+
+    const tokenHash = hashToken(token);
+    const user = await UsuarioModel.findByEmailVerificationToken(tokenHash);
+
+    if (!user || !user.email_verification_exp) {
+      return errorResponse(res, 'Token de verificacion invalido o expirado.', 400);
+    }
+
+    if (user.email_verificado) {
+      await UsuarioModel.clearEmailVerificationToken(user.id_usuario);
+      return successResponse(res, null, 'El correo ya estaba verificado.', 200);
+    }
+
+    const expiresAt = new Date(user.email_verification_exp);
+    if (Number.isNaN(expiresAt.getTime()) || expiresAt.getTime() < Date.now()) {
+      await UsuarioModel.clearEmailVerificationToken(user.id_usuario);
+      return errorResponse(res, 'Token de verificacion invalido o expirado.', 400);
+    }
+
+    await UsuarioModel.verifyEmail(user.id_usuario);
+
+    return successResponse(res, null, 'Correo verificado correctamente.', 200);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+// ============ HANDLERS PARA VERIFICACIÓN DE EMAIL CON OTP ============
+
+const OTP_MINUTES = 10;
+const OTP_RESEND_COOLDOWN_SECONDS = 60;
+const MAX_OTP_ATTEMPTS = 5;
+
+// Genera un codigo OTP de 6 digitos con aleatoriedad criptografica.
+export const generateOtpCode = () => {
+  return crypto.randomInt(100000, 1000000).toString();
+};
+
+// Hashea el código OTP con SHA-256
+const hashOtpCode = (otpCode) => {
+  return crypto.createHash('sha256').update(otpCode).digest('hex');
+};
+
+// Envía OTP por correo electrónico
+export const sendVerificationOtp = async (req, res, next) => {
+  try {
+    const id_usuario = req.user?.sub;
+
+    if (!id_usuario) {
+      return errorResponse(res, 'No autorizado.', 401);
+    }
+
+    const user = await UsuarioModel.findById(id_usuario);
+    if (!user) {
+      return errorResponse(res, 'Usuario no encontrado.', 404);
+    }
+
+    // Si email ya está verificado, retorna 409
+    if (user.email_verificado) {
+      return errorResponse(res, 'El email ya está verificado.', 409);
+    }
+
+    // Verificar cooldown de 1 minuto entre reenvíos
+    const lastRequest = await UsuarioModel.getOtpLastRequest(id_usuario);
+    if (lastRequest) {
+      const lastRequestTime = new Date(lastRequest).getTime();
+      const timeDiffSeconds = (Date.now() - lastRequestTime) / 1000;
+      if (timeDiffSeconds < OTP_RESEND_COOLDOWN_SECONDS) {
+        const remainingSeconds = Math.ceil(OTP_RESEND_COOLDOWN_SECONDS - timeDiffSeconds);
+        return errorResponse(
+          res,
+          `Por favor espera ${remainingSeconds} segundos antes de solicitar otro código.`,
+          429
+        );
+      }
+    }
+
+    const otp = await sendVerificationOtpEmail(user);
+
+    return successResponse(
+      res,
+      {
+        message: `Codigo de verificacion enviado a ${user.email}`,
+        expiresIn: otp.expiresIn,
+      },
+      'Codigo OTP enviado correctamente.',
+      200
+    );
+
+    // Generar OTP
+    const otpCode = generateOtpCode();
+    const otpCodeHash = hashOtpCode(otpCode);
+    const otpExp = new Date(Date.now() + OTP_MINUTES * 60 * 1000);
+
+    // Guardar OTP hasheado en BD
+    await UsuarioModel.setOtp(id_usuario, otpCodeHash, otpExp);
+    await UsuarioModel.updateOtpLastRequest(id_usuario);
+
+    // Generar plantilla HTML del email
+    const html = `
+      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
+        <h2 style="color: #333; text-align: center;">Verifica tu Correo Electrónico</h2>
+        <p style="color: #666; font-size: 16px;">Hola ${user.nombre},</p>
+        <p style="color: #666; font-size: 16px;">Se ha solicitado la verificación de tu correo electrónico en <strong>Green Alert</strong>.</p>
+        
+        <div style="background-color: #f5f5f5; border: 2px solid #007bff; border-radius: 8px; padding: 30px; margin: 30px 0; text-align: center;">
+          <p style="color: #999; font-size: 14px; margin: 0 0 15px 0;">Tu código de verificación:</p>
+          <h1 style="color: #007bff; font-size: 48px; letter-spacing: 10px; margin: 0;">${otpCode}</h1>
+          <p style="color: #999; font-size: 14px; margin: 15px 0 0 0;">Este código expira en ${OTP_MINUTES} minutos</p>
+        </div>
+        
+        <div style="background-color: #fff3cd; border-left: 4px solid #ffc107; padding: 15px; margin: 20px 0; border-radius: 4px;">
+          <p style="color: #856404; margin: 0; font-size: 14px;">
+            <strong>[SECURITY]</strong> Nunca compartas este código con nadie. El equipo de Green Alert nunca te pedirá este código.
+          </p>
+        </div>
+        
+        <p style="color: #999; font-size: 12px; margin-top: 30px; border-top: 1px solid #eee; padding-top: 20px;">
+          Si no solicitaste este código, por favor ignora este correo.
+        </p>
+      </div>
+    `;
+
+    await enviarCorreo(user.email, 'Código de Verificación de Correo - Green Alert', html);
+
+    return successResponse(
+      res,
+      {
+        message: `Código de verificación enviado a ${user.email}`,
+        expiresIn: OTP_MINUTES * 60,
+      },
+      'Código OTP enviado correctamente.',
+      200
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+// Verifica el OTP y marca el email como verificado
+export const verifyEmailOtp = async (req, res, next) => {
+  try {
+    const id_usuario = req.user?.sub;
+
+    if (!id_usuario) {
+      return errorResponse(res, 'No autorizado.', 401);
+    }
+
+    const otp_code = req.body?.otp_code ?? req.body?.codigo;
+
+    if (typeof otp_code !== 'string' || otp_code.length !== 6 || !/^\d{6}$/.test(otp_code)) {
+      return errorResponse(res, 'El código OTP debe ser un número de 6 dígitos.', 400);
+    }
+
+    const user = await UsuarioModel.findById(id_usuario);
+    if (!user) {
+      return errorResponse(res, 'Usuario no encontrado.', 404);
+    }
+
+    // Si email ya está verificado, retorna 409
+    if (user.email_verificado) {
+      return errorResponse(res, 'El email ya está verificado.', 409);
+    }
+
+    // Verificar si hay un OTP pendiente
+    const otpCodeHash = hashOtpCode(otp_code);
+    const userWithOtp = await UsuarioModel.findByOtpHash(otpCodeHash);
+
+    if (!userWithOtp || Number(userWithOtp.id_usuario) !== Number(id_usuario)) {
+      await UsuarioModel.incrementOtpAttempts(id_usuario);
+      return errorResponse(res, 'Código OTP incorrecto.', 400);
+    }
+
+    // Verificar expiración
+    const expiresAt = new Date(userWithOtp.otp_exp).getTime();
+    if (Number.isNaN(expiresAt) || expiresAt < Date.now()) {
+      await UsuarioModel.clearOtp(id_usuario);
+      return errorResponse(res, 'El código OTP ha expirado. Solicita uno nuevo.', 400);
+    }
+
+    // Verificar intentos fallidos
+    if (userWithOtp.otp_attempts >= MAX_OTP_ATTEMPTS) {
+      await UsuarioModel.clearOtp(id_usuario);
+      return errorResponse(
+        res,
+        'Demasiados intentos fallidos. Se ha generado un nuevo código. Solicítalo nuevamente.',
+        429
+      );
+    }
+
+    // Marcar email como verificado
+    await UsuarioModel.verifyEmail(id_usuario);
+    
+    // Limpiar OTP
+    await UsuarioModel.clearOtp(id_usuario);
+
+    const verifiedUser = await UsuarioModel.findByIdWithDetails(id_usuario);
+
+    return successResponse(
+      res,
+      { user: toPublicUser(verifiedUser) },
+      'Email verificado correctamente.',
+      200
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+// ============ HANDLER PARA ACTUALIZAR PREFERENCIAS DE NOTIFICACIONES ============
+
+export const updateNotifications = async (req, res, next) => {
+  try {
+    const id_usuario = req.user?.sub;
+    if (!id_usuario) return errorResponse(res, 'No autorizado.', 401);
+
+    const preferences = req.body?.preferences ?? req.body;
+    if (!preferences || typeof preferences !== 'object' || Array.isArray(preferences)) {
+      return errorResponse(res, 'Las preferencias deben ser un objeto.', 400);
+    }
+
+    const validKeys = ['email_alerts', 'push_notifications', 'report_updates', 'weekly_summary'];
+    const validatedPreferences = {};
+    const invalidKeys = Object.keys(preferences).filter((key) => !validKeys.includes(key));
+
+    if (invalidKeys.length > 0) {
+      return errorResponse(
+        res,
+        `Preferencias no permitidas: ${invalidKeys.join(', ')}.`,
+        400
+      );
+    }
+
+    for (const key of validKeys) {
+      if (key in preferences) validatedPreferences[key] = Boolean(preferences[key]);
+    }
+
+    if (Object.keys(validatedPreferences).length === 0) {
+      return errorResponse(res, 'Debe enviar al menos una preferencia valida.', 400);
+    }
+
+    const user = await UsuarioModel.findByIdWithDetails(id_usuario);
+    if (!user) {
+      return errorResponse(res, 'Usuario no encontrado.', 404);
+    }
+
+    const notificationPreferences = {
+      ...DEFAULT_NOTIFICATION_PREFERENCES,
+      ...(user.notification_preferences || {}),
+      ...validatedPreferences,
+    };
+
+    const updatedUser = await UsuarioModel.updateNotificationPreferences(
+      id_usuario,
+      notificationPreferences
+    );
+
+    if (!updatedUser) {
+      return errorResponse(res, 'Usuario no encontrado.', 404);
+    }
+
+    return successResponse(
+      res,
+      {
+        preferences: updatedUser.notification_preferences,
+        user: toPublicUser(updatedUser),
+      },
+      'Preferencias de notificaciones actualizadas.',
+      200
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+// ============ MÉTODOS PARA AUTENTICACIÓN CON GOOGLE OAUTH ============
+
+const findOrCreateGoogleUser = async ({ googleId, email, nombre, apellido, avatar_url }) => {
+  if (!googleId || !email) {
+    const error = new Error('No se recibio identificacion completa de Google.');
+    error.statusCode = 400;
+    throw error;
+  }
+
+  let user = googleId ? await UsuarioModel.findByGoogleId(googleId) : null;
+
+  if (!user) {
+    user = await UsuarioModel.findByEmail(email);
+
+    if (user?.google_id && user.google_id !== googleId) {
+      const error = new Error('El correo ya esta vinculado a otra cuenta de Google.');
+      error.statusCode = 409;
+      throw error;
+    }
+
+    if (user && !user.google_id && googleId) {
+      await UsuarioModel.updateGoogleId(user.id_usuario, googleId);
+      user.google_id = googleId;
+    }
+  }
+
+  if (user) {
+    if (!user.activo) {
+      const error = new Error('Cuenta desactivada. Contacta al administrador.');
+      error.statusCode = 403;
+      throw error;
+    }
+
+    await UsuarioModel.updateUltimoAcceso(user.id_usuario);
+    return user;
+  }
+
+  const idUsuario = await UsuarioModel.createFromGoogle({
+    google_id: googleId,
+    email,
+    nombre: nombre || '',
+    apellido: apellido || '',
+    avatar_url,
+  });
+
+  if (!idUsuario) {
+    return null;
+  }
+
+  return UsuarioModel.findById(idUsuario);
+};
+
+export const googleLogin = async (req, res, next) => {
+  try {
+    const { id_token } = req.body ?? {};
+
+    if (!id_token || typeof id_token !== 'string') {
+      return errorResponse(res, 'El id_token de Google es requerido.', 400);
+    }
+
+    // Verificar token de Google
+    const googleVerification = await verifyGoogleToken(id_token);
+    if (!googleVerification.success) {
+      return errorResponse(res, 'Token de Google inválido.', 401);
+    }
+
+    const {
+      googleId,
+      email,
+      nombre,
+      apellido,
+      avatar_url,
+      email_verified,
+    } = googleVerification;
+
+    let user;
+    try {
+      user = await findOrCreateGoogleUser({
+        googleId,
+        email,
+        nombre,
+        apellido,
+        avatar_url,
+      });
+    } catch (error) {
+      if (error.statusCode) {
+        return errorResponse(res, error.message, error.statusCode);
+      }
+      throw error;
+    }
+
+    if (!user) {
+      return errorResponse(res, 'No fue posible crear la cuenta con este correo.', 400);
+    }
+
+    // Generar JWT
+    const authPayload = await buildAuthPayload(user, req);
+
+    return successResponse(
+      res,
+      authPayload,
+      'Autenticación con Google exitosa.',
+      200
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const googleAccessTokenLogin = async (req, res, next) => {
+  try {
+    const { access_token, id_token } = req.body ?? {};
+
+    if (id_token) {
+      req.body.id_token = id_token;
+      return googleLogin(req, res, next);
+    }
+
+    if (!access_token || typeof access_token !== 'string') {
+      return errorResponse(res, 'El access_token de Google es requerido.', 400);
+    }
+
+    const googleUser = await getGoogleUserInfo(access_token);
+    if (!googleUser.success) {
+      return errorResponse(res, 'No fue posible obtener informacion de Google.', 401);
+    }
+
+    let user;
+    try {
+      user = await findOrCreateGoogleUser(googleUser);
+    } catch (error) {
+      if (error.statusCode) {
+        return errorResponse(res, error.message, error.statusCode);
+      }
+      throw error;
+    }
+
+    if (!user) {
+      return errorResponse(res, 'No fue posible crear la cuenta con este correo.', 400);
+    }
+
+    const authPayload = await buildAuthPayload(user, req);
+
+    return successResponse(
+      res,
+      authPayload,
+      'Autenticacion con Google exitosa.',
+      200
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const googleCallback = async (req, res, next) => {
+  try {
+    const { code } = req.query ?? {};
+
+    if (!code || typeof code !== 'string') {
+      return errorResponse(res, 'Código de autorización de Google requerido.', 400);
+    }
+
+    // Intercambiar código por tokens
+    const tokenExchange = await exchangeCodeForTokens(code);
+    if (!tokenExchange.success) {
+      return errorResponse(res, 'No fue posible intercambiar el código de Google.', 400);
+    }
+
+    const { tokens } = tokenExchange;
+    const { id_token, access_token } = tokens;
+
+    if (!id_token && !access_token) {
+      return errorResponse(res, 'No se recibieron tokens de Google.', 400);
+    }
+
+    // Obtener información del usuario
+    let googleUser;
+    
+    if (id_token) {
+      const verification = await verifyGoogleToken(id_token);
+      if (!verification.success) {
+        return errorResponse(res, 'Token de Google inválido.', 401);
+      }
+      googleUser = verification;
+    } else {
+      const userInfo = await getGoogleUserInfo(access_token);
+      if (!userInfo.success) {
+        return errorResponse(res, 'No fue posible obtener información de Google.', 400);
+      }
+      googleUser = userInfo;
+    }
+
+    const {
+      googleId,
+      email,
+      nombre,
+      apellido,
+      avatar_url,
+    } = googleUser;
+
+    let user;
+    try {
+      user = await findOrCreateGoogleUser({
+        googleId,
+        email,
+        nombre,
+        apellido,
+        avatar_url,
+      });
+    } catch (error) {
+      if (error.statusCode) {
+        return errorResponse(res, error.message, error.statusCode);
+      }
+      throw error;
+    }
+
+    if (!user) {
+      return errorResponse(res, 'No fue posible crear la cuenta con este correo.', 400);
+    }
+
+    // Generar JWT
+    const authPayload = await buildAuthPayload(user, req);
+
+    return redirectToFrontendAuthCallback(res, authPayload);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const getGoogleAuthUrl = async (req, res, next) => {
+  try {
+    const result = generateAuthUrl();
+
+    if (!result.success) {
+      return errorResponse(res, 'No fue posible generar la URL de autenticación de Google.', 500);
+    }
+
+    return successResponse(
+      res,
+      {
+        authUrl: result.authUrl,
+        configured: result.isConfigured,
+      },
+      'URL de autenticación generada exitosamente.',
+      200
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+// ============ METODOS PARA AUTENTICACION CON FACEBOOK OAUTH ============
+
+const findOrCreateFacebookUser = async ({ facebookId, email, nombre, apellido, avatar_url }) => {
+  if (!facebookId || !email) {
+    const error = new Error('No se recibio identificacion completa de Facebook.');
+    error.statusCode = 400;
+    throw error;
+  }
+
+  let user = await UsuarioModel.findByFacebookId(facebookId);
+
+  if (!user) {
+    user = await UsuarioModel.findByEmail(email);
+
+    if (user?.facebook_id && user.facebook_id !== facebookId) {
+      const error = new Error('El correo ya esta vinculado a otra cuenta de Facebook.');
+      error.statusCode = 409;
+      throw error;
+    }
+
+    if (user && !user.facebook_id) {
+      await UsuarioModel.updateFacebookId(user.id_usuario, facebookId);
+      user.facebook_id = facebookId;
+    }
+  }
+
+  if (user) {
+    if (!user.activo) {
+      const error = new Error('Cuenta desactivada. Contacta al administrador.');
+      error.statusCode = 403;
+      throw error;
+    }
+
+    await UsuarioModel.updateUltimoAcceso(user.id_usuario);
+    return user;
+  }
+
+  const idUsuario = await UsuarioModel.createFromFacebook({
+    facebook_id: facebookId,
+    email,
+    nombre: nombre || '',
+    apellido: apellido || '',
+    avatar_url,
+  });
+
+  if (!idUsuario) {
+    return null;
+  }
+
+  return UsuarioModel.findById(idUsuario);
+};
+
+export const getFacebookAuthUrl = async (req, res, next) => {
+  try {
+    const result = generateFacebookAuthUrl();
+
+    if (!result.success) {
+      return errorResponse(res, 'No fue posible generar la URL de autenticacion con Facebook.', 500);
+    }
+
+    return successResponse(
+      res,
+      { authUrl: result.authUrl },
+      'URL de autenticacion con Facebook generada correctamente.',
+      200
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const facebookLogin = async (req, res, next) => {
+  try {
+    const { code, access_token } = req.body ?? {};
+
+    let accessToken = access_token;
+    if (!accessToken) {
+      if (!code || typeof code !== 'string') {
+        return errorResponse(res, 'Codigo de autorizacion de Facebook requerido.', 400);
+      }
+
+      const tokenExchange = await exchangeFacebookCodeForToken(code);
+      if (!tokenExchange.success) {
+        return errorResponseWithDevelopmentDetails(
+          res,
+          'No fue posible intercambiar el codigo de Facebook.',
+          400,
+          tokenExchange.facebookError || tokenExchange.error
+        );
+      }
+      accessToken = tokenExchange.accessToken;
+    }
+
+    const facebookUser = await getFacebookUserInfo(accessToken);
+    if (!facebookUser.success) {
+      return errorResponseWithDevelopmentDetails(
+        res,
+        'No fue posible obtener informacion de Facebook.',
+        400,
+        facebookUser.facebookError || facebookUser.error
+      );
+    }
+
+    let user;
+    try {
+      user = await findOrCreateFacebookUser(facebookUser);
+    } catch (error) {
+      if (error.statusCode) {
+        return errorResponse(res, error.message, error.statusCode);
+      }
+      throw error;
+    }
+
+    if (!user) {
+      return errorResponse(res, 'No fue posible autenticar con Facebook.', 400);
+    }
+
+    const authPayload = await buildAuthPayload(user, req);
+    return successResponse(res, authPayload, 'Inicio de sesion con Facebook exitoso.', 200);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const facebookCallback = async (req, res, next) => {
+  try {
+    const { code } = req.query ?? {};
+
+    if (!code || typeof code !== 'string') {
+      return errorResponse(res, 'Codigo de autorizacion de Facebook requerido.', 400);
+    }
+
+    const tokenExchange = await exchangeFacebookCodeForToken(code);
+    if (!tokenExchange.success) {
+      return errorResponseWithDevelopmentDetails(
+        res,
+        'No fue posible intercambiar el codigo de Facebook.',
+        400,
+        tokenExchange.facebookError || tokenExchange.error
+      );
+    }
+
+    const facebookUser = await getFacebookUserInfo(tokenExchange.accessToken);
+    if (!facebookUser.success) {
+      return errorResponseWithDevelopmentDetails(
+        res,
+        'No fue posible obtener informacion de Facebook.',
+        400,
+        facebookUser.facebookError || facebookUser.error
+      );
+    }
+
+    let user;
+    try {
+      user = await findOrCreateFacebookUser(facebookUser);
+    } catch (error) {
+      if (error.statusCode) {
+        return errorResponse(res, error.message, error.statusCode);
+      }
+      throw error;
+    }
+
+    if (!user) {
+      return errorResponse(res, 'No fue posible autenticar con Facebook.', 400);
+    }
+
+    const authPayload = await buildAuthPayload(user, req);
+    const publicUser = authPayload.user;
+    const callbackResponseMode = (process.env.FACEBOOK_CALLBACK_RESPONSE || '').toLowerCase();
+    const shouldRedirect = callbackResponseMode === 'redirect' || (
+      callbackResponseMode !== 'json' && !isDevelopment()
+    );
+
+    if (!shouldRedirect) {
+      return successResponse(
+        res,
+        {
+          token: authPayload.accessToken,
+          accessToken: authPayload.accessToken,
+          refreshToken: authPayload.refreshToken,
+          refreshTokenExpiresAt: authPayload.refreshTokenExpiresAt,
+          user: publicUser,
+        },
+        'Inicio de sesion con Facebook exitoso.',
+        200
+      );
+    }
+
+    return redirectToFrontendAuthCallback(res, {
+      ...authPayload,
+      user: publicUser,
+    });
+  } catch (error) {
+    return next(error);
+  }
+};
+</file>
+
+<file path="src/models/reporte.model.js">
+import pool from '../config/database.js';
+import { tableExists } from '../config/schema-compat.js';
+import { CATEGORIAS_FALLBACK } from './categoria-riesgo.model.js';
+import { randomUUID } from 'crypto';
+
+export const ESTADO_INICIAL_REPORTE = 'pendiente';
+export const ESTADOS_REPORTE_PERMITIDOS = [
+  'pendiente',
+  'en_revision',
+  'verificado',
+  'en_proceso',
+  'rechazado',
+  'resuelto',
+];
+export const NIVELES_SEVERIDAD_PERMITIDOS = [
+  'bajo',
+  'medio',
+  'alto',
+  'critico',
+];
+
+const buildReportesFilter = ({
+  estado,
+  tipo_contaminacion,
+  nivel_severidad,
+  municipio,
+} = {}) => {
+  const conditions = ['r.deleted_at IS NULL'];
+  const params = [];
+
+  if (estado) {
+    conditions.push('r.estado = ?');
+    params.push(estado);
+  }
+  if (tipo_contaminacion) {
+    conditions.push('r.tipo_contaminacion = ?');
+    params.push(tipo_contaminacion);
+  }
+  if (nivel_severidad) {
+    conditions.push('r.nivel_severidad = ?');
+    params.push(nivel_severidad);
+  }
+  if (municipio) {
+    conditions.push('r.municipio = ?');
+    params.push(municipio);
+  }
+
+  return {
+    where: conditions.join(' AND '),
+    params,
+  };
+};
+
+export const normalizeReporteIA = (reporte) => {
+  if (!reporte) return reporte;
+
+  let etiquetas = [];
+  if (Array.isArray(reporte.ia_etiquetas)) {
+    etiquetas = reporte.ia_etiquetas;
+  } else if (typeof reporte.ia_etiquetas === 'string' && reporte.ia_etiquetas.trim()) {
+    try {
+      const parsed = JSON.parse(reporte.ia_etiquetas);
+      etiquetas = Array.isArray(parsed) ? parsed : [];
+    } catch {
+      etiquetas = [];
+    }
+  }
+  const confianza = Number(reporte.ia_confianza);
+
+  return {
+    ...reporte,
+    ia_etiquetas: etiquetas,
+    ia_confianza: reporte.ia_confianza === null || reporte.ia_confianza === undefined
+      ? null
+      : (Number.isFinite(confianza) ? confianza : null),
+    ia_procesado: reporte.ia_procesado === true ||
+      reporte.ia_procesado === 'true' ||
+      Boolean(Number(reporte.ia_procesado)),
+  };
+};
+
+export const ReporteModel = {
+  
+    // Lista reportes con filtros opcionales y paginación
+   
+  findAll: async ({
+    estado,
+    tipo_contaminacion,
+    nivel_severidad,
+    municipio,
+    limit = 20,
+    offset = 0,
+  } = {}) => {
+    const { where, params } = buildReportesFilter({
+      estado,
+      tipo_contaminacion,
+      nivel_severidad,
+      municipio,
+    });
+    const safeLimit  = Math.max(1, Math.min(100, parseInt(limit,  10) || 20));
+    const safeOffset = Math.max(0,               parseInt(offset, 10) || 0);
+
+    const [rows] = await pool.execute(
+      `SELECT r.id_reporte, r.uuid, r.id_usuario,
+              r.tipo_contaminacion, r.subcategoria, r.estado, r.nivel_severidad,
+              r.titulo, r.descripcion,
+              r.latitud, r.longitud, r.direccion, r.municipio, r.departamento,
+              r.ia_etiquetas, r.ia_confianza, r.ia_procesado,
+              r.votos_relevancia, r.vistas,
+              r.created_at, r.updated_at,
+              u.nombre AS autor_nombre, u.apellido AS autor_apellido, u.rol AS autor_rol
+       FROM reportes r
+       LEFT JOIN usuarios u ON u.id_usuario = r.id_usuario
+       WHERE ${where}
+       ORDER BY r.created_at DESC
+       LIMIT ${safeLimit} OFFSET ${safeOffset}`,
+      params
+    );
+    return rows.map(normalizeReporteIA);
+  },
+
+  countAll: async ({
+    estado,
+    tipo_contaminacion,
+    nivel_severidad,
+    municipio,
+  } = {}) => {
+    const { where, params } = buildReportesFilter({
+      estado,
+      tipo_contaminacion,
+      nivel_severidad,
+      municipio,
+    });
+
+    const [[row]] = await pool.execute(
+      `SELECT COUNT(*) AS total
+       FROM reportes r
+       WHERE ${where}`,
+      params
+    );
+
+    return Number(row?.total) || 0;
+  },
+
+  // Exporta reportes con filtros opcionales (para CSV/JSON)
+  findForExport: async ({
+    estado,
+    tipo_contaminacion,
+    nivel_severidad,
+    municipio,
+    desde,
+    hasta,
+  } = {}) => {
+    const conditions = ['r.deleted_at IS NULL'];
+    const params = [];
+
+    if (estado) {
+      conditions.push('r.estado = ?');
+      params.push(estado);
+    }
+    if (tipo_contaminacion) {
+      conditions.push('r.tipo_contaminacion = ?');
+      params.push(tipo_contaminacion);
+    }
+    if (nivel_severidad) {
+      conditions.push('r.nivel_severidad = ?');
+      params.push(nivel_severidad);
+    }
+    if (municipio) {
+      conditions.push('r.municipio = ?');
+      params.push(municipio);
+    }
+    if (desde) {
+      conditions.push('r.created_at >= ?');
+      params.push(desde);
+    }
+    if (hasta) {
+      conditions.push('r.created_at <= ?');
+      params.push(hasta);
+    }
+
+    const where = conditions.join(' AND ');
+
+    const [rows] = await pool.execute(
+      `SELECT r.titulo,
+              r.tipo_contaminacion,
+              r.subcategoria,
+              r.nivel_severidad,
+              r.estado,
+              r.municipio,
+              r.created_at,
+              u.nombre AS autor_nombre,
+              u.apellido AS autor_apellido
+       FROM reportes r
+       LEFT JOIN usuarios u ON u.id_usuario = r.id_usuario
+       WHERE ${where}
+       ORDER BY r.created_at DESC`,
+      params
+    );
+
+    return rows.map(normalizeReporteIA);
+  },
+
+  
+    // Busca un reporte por id_reporte 
+   
+  findById: async (id_reporte) => {
+    const [rows] = await pool.execute(
+      `SELECT r.id_reporte, r.uuid, r.id_usuario,
+              r.tipo_contaminacion, r.subcategoria, r.estado, r.nivel_severidad,
+              r.titulo, r.descripcion,
+              r.latitud, r.longitud, r.direccion, r.municipio, r.departamento,
+              r.ia_etiquetas, r.ia_confianza, r.ia_procesado,
+              r.votos_relevancia, r.vistas,
+              r.comentario_moderacion,
+              r.created_at, r.updated_at
+       FROM reportes r
+       WHERE r.id_reporte = ? AND r.deleted_at IS NULL
+       LIMIT 1`,
+      [id_reporte]
+    );
+    return normalizeReporteIA(rows[0] ?? null);
+  },
+
+  
+    //Busca los reportes creados por un usuario específico
+   
+  findByUsuario: async (id_usuario, { limit = 20, offset = 0 } = {}) => {
+    const safeLimit  = Math.max(1, Math.min(100, parseInt(limit,  10) || 20));
+    const safeOffset = Math.max(0,               parseInt(offset, 10) || 0);
+    const [rows] = await pool.execute(
+      `SELECT id_reporte, uuid, tipo_contaminacion, subcategoria, estado, nivel_severidad,
+              titulo, municipio, departamento, ia_etiquetas, ia_confianza, ia_procesado,
+              votos_relevancia, vistas,
+              created_at, updated_at
+       FROM reportes
+       WHERE id_usuario = ? AND deleted_at IS NULL
+       ORDER BY created_at DESC
+       LIMIT ${safeLimit} OFFSET ${safeOffset}`,
+      [id_usuario]
+    );
+    return rows.map(normalizeReporteIA);
+  },
+
+  
+    // Crea un nuevo reporte, genera punto_geo automáticamente a partir de lat/lon
+    
+  create: async ({
+    id_usuario,
+    tipo_contaminacion,
+    subcategoria = null,
+    nivel_severidad = 'medio',
+    titulo,
+    descripcion = null,
+    latitud,
+    longitud,
+    direccion = null,
+    municipio = null,
+    departamento = null,
+  }) => {
+    const uuid = randomUUID();
+    // Orden base esperado: tipo_contaminacion, estado, nivel_severidad.
+    const hasCoords = latitud !== null && latitud !== undefined &&
+                      longitud !== null && longitud !== undefined;
+
+    if (hasCoords) {
+      const [result] = await pool.execute(
+        `INSERT INTO reportes
+           (uuid, id_usuario, tipo_contaminacion, subcategoria, estado, nivel_severidad, titulo, descripcion,
+            latitud, longitud, direccion, municipio, departamento, punto_geo)
+         VALUES
+           (?, ?, ?, ?, ?, ?, ?, ?,
+            ?, ?, ?, ?, ?,
+            ST_GeomFromText(CONCAT('POINT(', ?, ' ', ?, ')'), 4326))`,
+        [
+          uuid,
+          id_usuario, tipo_contaminacion, subcategoria, ESTADO_INICIAL_REPORTE, nivel_severidad, titulo, descripcion,
+          latitud, longitud, direccion, municipio, departamento,
+          longitud, latitud,
+        ]
+      );
+      return result.insertId;
+    } else {
+      const [result] = await pool.execute(
+        `INSERT INTO reportes
+           (uuid, id_usuario, tipo_contaminacion, subcategoria, estado, nivel_severidad, titulo, descripcion,
+            latitud, longitud, direccion, municipio, departamento)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [uuid,
+         id_usuario, tipo_contaminacion, subcategoria, ESTADO_INICIAL_REPORTE, nivel_severidad, titulo, descripcion,
+         null, null, direccion, municipio, departamento]
+      );
+      return result.insertId;
+    }
+  },
+
+  
+    //Actualiza campos permitidos de un reporte
+  
+  update: async (id_reporte, campos) => {
+    const permitidos = [
+      'estado', 'nivel_severidad', 'titulo', 'descripcion', 'subcategoria',
+      'direccion', 'municipio', 'departamento', 'comentario_moderacion',
+    ];
+
+    const sets = [];
+    const params = [];
+
+    for (const key of permitidos) {
+      if (Object.prototype.hasOwnProperty.call(campos, key)) {
+        sets.push(`${key} = ?`);
+        params.push(campos[key]);
+      }
+    }
+
+    if (sets.length === 0) return false;
+
+    params.push(id_reporte);
+
+    const [result] = await pool.execute(
+      `UPDATE reportes SET ${sets.join(', ')} WHERE id_reporte = ? AND deleted_at IS NULL`,
+      params
+    );
+    return result.affectedRows > 0;
+  },
+
+  updateIaAnalysis: async (id_reporte, { etiquetas, confianza, procesado = true }) => {
+    const [result] = await pool.execute(
+      `UPDATE reportes
+       SET ia_etiquetas = ?, ia_confianza = ?, ia_procesado = ?, updated_at = NOW()
+       WHERE id_reporte = ? AND deleted_at IS NULL`,
+      [
+        JSON.stringify(etiquetas ?? []),
+        confianza,
+        procesado ? 1 : 0,
+        id_reporte,
+      ]
+    );
+
+    return result.affectedRows > 0;
+  },
+
+  
+    // Incrementa el contador de vistas en 1
+   
+  incrementarVistas: async (id_reporte) => {
+    await pool.execute(
+      `UPDATE reportes SET vistas = vistas + 1 WHERE id_reporte = ? AND deleted_at IS NULL`,
+      [id_reporte]
+    );
+  },
+
+  registrarVistaUsuario: async (id_reporte, id_usuario) => {
+    if (!id_usuario || !await tableExists('reporte_vistas')) {
+      await ReporteModel.incrementarVistas(id_reporte);
+      return true;
+    }
+
+    const [result] = await pool.execute(
+      `INSERT IGNORE INTO reporte_vistas (id_reporte, id_usuario)
+       VALUES (?, ?)`,
+      [id_reporte, id_usuario]
+    );
+
+    if (result.affectedRows === 0) {
+      return false;
+    }
+
+    await ReporteModel.incrementarVistas(id_reporte);
+    return true;
+  },
+
+  
+    // Soft-delete de un reporte
+  
+  remove: async (id_reporte) => {
+    const [result] = await pool.execute(
+      `UPDATE reportes SET deleted_at = NOW() WHERE id_reporte = ? AND deleted_at IS NULL`,
+      [id_reporte]
+    );
+    return result.affectedRows > 0;
+  },
+
+  // Cuenta total de reportes de un usuario específico
+  countByUsuario: async (id_usuario) => {
+    const [[row]] = await pool.execute(
+      `SELECT COUNT(*) AS total
+       FROM reportes
+       WHERE id_usuario = ? AND deleted_at IS NULL`,
+      [id_usuario]
+    );
+    return row?.total ?? 0;
+  },
+
+  // Estadísticas globales para Dashboard y Home
+  getStats: async () => {
+    const [[r]] = await pool.execute(
+      `SELECT
+         COUNT(*)                                                                          AS total_reportes,
+         SUM(CASE WHEN MONTH(created_at)=MONTH(NOW()) AND YEAR(created_at)=YEAR(NOW()) THEN 1 ELSE 0 END) AS reportes_este_mes,
+         SUM(CASE WHEN estado='en_revision'  THEN 1 ELSE 0 END)                          AS en_revision,
+         SUM(CASE WHEN estado='resuelto'     THEN 1 ELSE 0 END)                          AS resueltos,
+         COUNT(DISTINCT CASE WHEN municipio IS NOT NULL AND municipio!='' THEN municipio END) AS municipios_activos,
+         SUM(CASE WHEN estado IN ('en_revision','verificado','en_proceso') THEN 1 ELSE 0 END) AS con_seguimiento
+       FROM reportes WHERE deleted_at IS NULL`
+    );
+    const [[u]] = await pool.execute(
+      `SELECT COUNT(*) AS total_usuarios FROM usuarios WHERE activo=1 AND deleted_at IS NULL`
+    );
+    return { ...r, ...u };
+  },
+
+  // Conteos de reportes agrupados por categoria para analitica publica
+  getStatsByCategoria: async () => {
+    if (!await tableExists('categorias_riesgo')) {
+      const [rows] = await pool.execute(
+        `SELECT
+           tipo_contaminacion AS codigo,
+           COUNT(*) AS total_reportes,
+           SUM(CASE WHEN estado = 'pendiente' THEN 1 ELSE 0 END) AS pendientes,
+           SUM(CASE WHEN estado = 'en_revision' THEN 1 ELSE 0 END) AS en_revision,
+           SUM(CASE WHEN estado = 'verificado' THEN 1 ELSE 0 END) AS verificados,
+           SUM(CASE WHEN estado = 'en_proceso' THEN 1 ELSE 0 END) AS en_proceso,
+           SUM(CASE WHEN estado = 'resuelto' THEN 1 ELSE 0 END) AS resueltos,
+           SUM(CASE WHEN estado = 'rechazado' THEN 1 ELSE 0 END) AS rechazados,
+           SUM(CASE WHEN nivel_severidad = 'bajo' THEN 1 ELSE 0 END) AS bajo,
+           SUM(CASE WHEN nivel_severidad = 'medio' THEN 1 ELSE 0 END) AS medio,
+           SUM(CASE WHEN nivel_severidad = 'alto' THEN 1 ELSE 0 END) AS alto,
+           SUM(CASE WHEN nivel_severidad = 'critico' THEN 1 ELSE 0 END) AS critico
+         FROM reportes
+         WHERE deleted_at IS NULL
+         GROUP BY tipo_contaminacion`
+      );
+      const statsByCodigo = new Map(rows.map((row) => [row.codigo, row]));
+
+      return CATEGORIAS_FALLBACK
+        .filter((categoria) => categoria.activo)
+        .map((categoria) => ({
+          ...categoria,
+          total_reportes: 0,
+          pendientes: 0,
+          en_revision: 0,
+          verificados: 0,
+          en_proceso: 0,
+          resueltos: 0,
+          rechazados: 0,
+          bajo: 0,
+          medio: 0,
+          alto: 0,
+          critico: 0,
+          ...(statsByCodigo.get(categoria.codigo) ?? {}),
+        }))
+        .sort((a, b) => Number(b.total_reportes) - Number(a.total_reportes) || a.nombre.localeCompare(b.nombre));
+    }
+
+    const [rows] = await pool.execute(
+      `SELECT
+         cr.codigo,
+         cr.nombre,
+         cr.icono,
+         cr.color_hex,
+         COUNT(r.id_reporte) AS total_reportes,
+         SUM(CASE WHEN r.estado = 'pendiente' THEN 1 ELSE 0 END) AS pendientes,
+         SUM(CASE WHEN r.estado = 'en_revision' THEN 1 ELSE 0 END) AS en_revision,
+         SUM(CASE WHEN r.estado = 'verificado' THEN 1 ELSE 0 END) AS verificados,
+         SUM(CASE WHEN r.estado = 'en_proceso' THEN 1 ELSE 0 END) AS en_proceso,
+         SUM(CASE WHEN r.estado = 'resuelto' THEN 1 ELSE 0 END) AS resueltos,
+         SUM(CASE WHEN r.estado = 'rechazado' THEN 1 ELSE 0 END) AS rechazados,
+         SUM(CASE WHEN r.nivel_severidad = 'bajo' THEN 1 ELSE 0 END) AS bajo,
+         SUM(CASE WHEN r.nivel_severidad = 'medio' THEN 1 ELSE 0 END) AS medio,
+         SUM(CASE WHEN r.nivel_severidad = 'alto' THEN 1 ELSE 0 END) AS alto,
+         SUM(CASE WHEN r.nivel_severidad = 'critico' THEN 1 ELSE 0 END) AS critico
+       FROM categorias_riesgo cr
+       LEFT JOIN reportes r ON r.tipo_contaminacion = cr.codigo
+        AND r.deleted_at IS NULL
+       WHERE cr.activo = 1
+       GROUP BY cr.id_categoria, cr.codigo, cr.nombre, cr.icono, cr.color_hex
+       ORDER BY total_reportes DESC, cr.nombre ASC`
+    );
+
+    return rows;
+  },
+
+  // Timeline de reportes agrupado por semana o mes
+  getStatsTimeline: async ({ bucket = 'week', limit = 12 } = {}) => {
+    const safeLimit = Math.max(1, Math.min(60, parseInt(limit, 10) || 12));
+    const isMonth = bucket === 'month';
+
+    const periodKey = isMonth
+      ? "DATE_FORMAT(r.created_at, '%Y-%m')"
+      : "CONCAT(YEARWEEK(r.created_at, 3), '')";
+    const periodLabel = isMonth
+      ? "DATE_FORMAT(r.created_at, '%Y-%m')"
+      : "CONCAT(YEAR(DATE_SUB(DATE(r.created_at), INTERVAL WEEKDAY(r.created_at) DAY)), '-W', LPAD(WEEK(r.created_at, 3), 2, '0'))";
+    const periodStart = isMonth
+      ? "DATE_FORMAT(r.created_at, '%Y-%m-01')"
+      : "DATE_FORMAT(DATE_SUB(DATE(r.created_at), INTERVAL WEEKDAY(r.created_at) DAY), '%Y-%m-%d')";
+
+    const [rows] = await pool.execute(
+      `SELECT *
+       FROM (
+         SELECT
+           ${periodKey} AS periodo_key,
+           ${periodLabel} AS periodo,
+           ${periodStart} AS periodo_inicio,
+           COUNT(*) AS total_reportes,
+           SUM(CASE WHEN r.nivel_severidad = 'bajo' THEN 1 ELSE 0 END) AS bajo,
+           SUM(CASE WHEN r.nivel_severidad = 'medio' THEN 1 ELSE 0 END) AS medio,
+           SUM(CASE WHEN r.nivel_severidad = 'alto' THEN 1 ELSE 0 END) AS alto,
+           SUM(CASE WHEN r.nivel_severidad = 'critico' THEN 1 ELSE 0 END) AS critico,
+           SUM(CASE WHEN r.estado = 'resuelto' THEN 1 ELSE 0 END) AS resueltos
+         FROM reportes r
+         WHERE r.deleted_at IS NULL
+         GROUP BY periodo_key, periodo, periodo_inicio
+         ORDER BY periodo_key DESC
+         LIMIT ${safeLimit}
+       ) timeline
+       ORDER BY periodo_key ASC`
+    );
+
+    return rows;
+  },
+
+  // Puntos georreferenciados para heatmap con intensidad derivada de severidad
+  getHeatmapPoints: async () => {
+    const [rows] = await pool.execute(
+      `SELECT
+         r.id_reporte,
+         r.tipo_contaminacion,
+         r.nivel_severidad,
+         r.estado,
+         r.municipio,
+         r.latitud,
+         r.longitud,
+         CASE r.nivel_severidad
+           WHEN 'critico' THEN 1.0
+           WHEN 'alto' THEN 0.75
+           WHEN 'medio' THEN 0.5
+           WHEN 'bajo' THEN 0.25
+           ELSE 0.25
+         END AS intensidad,
+         r.created_at
+       FROM reportes r
+       WHERE r.deleted_at IS NULL
+        AND r.latitud IS NOT NULL
+        AND r.longitud IS NOT NULL
+       ORDER BY r.created_at DESC`
+    );
+
+    return rows;
+  },
+
+  findParaPrediccion: async ({ desde, tipo } = {}) => {
+    const conditions = [
+      'r.deleted_at IS NULL',
+      'r.latitud IS NOT NULL',
+      'r.longitud IS NOT NULL',
+      "r.estado IN ('verificado', 'en_proceso', 'resuelto')",
+    ];
+    const params = [];
+
+    if (desde) {
+      conditions.push('r.created_at >= ?');
+      params.push(desde);
+    }
+
+    if (tipo) {
+      conditions.push('r.tipo_contaminacion = ?');
+      params.push(tipo);
+    }
+
+    const [rows] = await pool.execute(
+      `SELECT
+         r.id_reporte,
+         r.tipo_contaminacion,
+         r.subcategoria,
+         r.estado,
+         r.nivel_severidad,
+         r.latitud,
+         r.longitud,
+         r.municipio,
+         r.departamento,
+         r.created_at
+       FROM reportes r
+       WHERE ${conditions.join(' AND ')}
+       ORDER BY r.created_at DESC`,
+      params
+    );
+
+    return rows;
+  },
+
+  findTrending: async ({ limit = 12 } = {}) => {
+    const safeLimit = Math.max(1, Math.min(50, parseInt(limit, 10) || 12));
+    const [rows] = await pool.execute(
+      `SELECT r.id_reporte, r.uuid, r.id_usuario,
+              r.tipo_contaminacion, r.subcategoria, r.estado, r.nivel_severidad,
+              r.titulo, r.descripcion,
+              r.latitud, r.longitud, r.direccion, r.municipio, r.departamento,
+              r.ia_etiquetas, r.ia_confianza, r.ia_procesado,
+              r.votos_relevancia, r.vistas,
+              r.created_at, r.updated_at,
+              (r.votos_relevancia * 3 + r.vistas + GREATEST(0, 30 - TIMESTAMPDIFF(DAY, r.created_at, NOW()))) AS trending_score
+       FROM reportes r
+       WHERE r.deleted_at IS NULL
+       ORDER BY trending_score DESC, r.created_at DESC
+       LIMIT ${safeLimit}`
+    );
+
+    return rows.map((row) => ({
+      ...row,
+      trending_score: Number(row.trending_score) || 0,
+    }));
+  },
+
+  getStatsIA: async ({ dias = 30 } = {}) => {
+    const safeDias = Math.max(1, Math.min(365, parseInt(dias, 10) || 30));
+
+    const [[summary]] = await pool.execute(
+      `SELECT
+         COUNT(*) AS total_procesados,
+         ROUND(AVG(COALESCE(ia_confianza, 0)), 0) AS confianza_promedio,
+         SUM(CASE WHEN ia_confianza >= 75 THEN 1 ELSE 0 END) AS confianza_alta,
+         SUM(CASE WHEN ia_confianza >= 50 AND ia_confianza < 75 THEN 1 ELSE 0 END) AS confianza_media,
+         SUM(CASE WHEN ia_confianza < 50 THEN 1 ELSE 0 END) AS confianza_baja
+       FROM reportes
+       WHERE deleted_at IS NULL
+         AND ia_procesado = 1
+         AND created_at >= DATE_SUB(NOW(), INTERVAL ${safeDias} DAY)`
+    );
+
+    const [topEtiquetas] = await pool.execute(
+      `SELECT tipo_contaminacion AS label,
+              tipo_contaminacion AS nombre,
+              COUNT(*) AS count
+       FROM reportes
+       WHERE deleted_at IS NULL
+         AND ia_procesado = 1
+         AND created_at >= DATE_SUB(NOW(), INTERVAL ${safeDias} DAY)
+       GROUP BY tipo_contaminacion
+       ORDER BY count DESC
+       LIMIT 8`
+    );
+
+    const [timeline] = await pool.execute(
+      `SELECT DATE(created_at) AS fecha,
+              COUNT(*) AS procesados
+       FROM reportes
+       WHERE deleted_at IS NULL
+         AND ia_procesado = 1
+         AND created_at >= DATE_SUB(NOW(), INTERVAL ${safeDias} DAY)
+       GROUP BY DATE(created_at)
+       ORDER BY fecha ASC`
+    );
+
+    const totalProcesados = Number(summary?.total_procesados) || 0;
+    return {
+      total_procesados: totalProcesados,
+      accuracy: {
+        aceptadas: totalProcesados,
+        modificadas: 0,
+        porcentaje: totalProcesados > 0 ? 100 : 0,
+      },
+      confianza: {
+        promedio: Number(summary?.confianza_promedio) || 0,
+        distribucion: {
+          baja: Number(summary?.confianza_baja) || 0,
+          media: Number(summary?.confianza_media) || 0,
+          alta: Number(summary?.confianza_alta) || 0,
+        },
+      },
+      top_etiquetas: topEtiquetas,
+      timeline: timeline.map((row) => ({
+        ...row,
+        fecha: row.fecha instanceof Date ? row.fecha.toISOString().slice(0, 10) : row.fecha,
+      })),
+    };
+  },
+
+  getZonasRiesgo: async ({ dias = 30, min_score = 30 } = {}) => {
+    const safeDias = Math.max(1, Math.min(365, parseInt(dias, 10) || 30));
+    const safeMinScore = Math.max(0, Math.min(100, Number(min_score) || 0));
+
+    const [rows] = await pool.execute(
+      `SELECT
+         MIN(id_reporte) AS id,
+         municipio,
+         departamento,
+         tipo_contaminacion AS tipo_dominante,
+         subcategoria AS subcategoria_dominante,
+         AVG(latitud) AS lat,
+         AVG(longitud) AS lng,
+         COUNT(*) AS n_reportes,
+         AVG(CASE nivel_severidad
+           WHEN 'critico' THEN 4
+           WHEN 'alto' THEN 3
+           WHEN 'medio' THEN 2
+           WHEN 'bajo' THEN 1
+           ELSE 1
+         END) AS severidad_promedio,
+         MAX(created_at) AS ultimo_reporte
+       FROM reportes
+       WHERE deleted_at IS NULL
+         AND latitud IS NOT NULL
+         AND longitud IS NOT NULL
+         AND created_at >= DATE_SUB(NOW(), INTERVAL ${safeDias} DAY)
+       GROUP BY municipio, departamento, tipo_contaminacion, subcategoria
+       HAVING n_reportes > 0
+       ORDER BY n_reportes DESC, severidad_promedio DESC
+       LIMIT 30`
+    );
+
+    return rows
+      .map((row) => {
+        const score = Math.min(100, Math.round((Number(row.n_reportes) * 18) + (Number(row.severidad_promedio) * 14)));
+        const nivel = score >= 80 ? 'critico' : score >= 60 ? 'alto' : score >= 35 ? 'medio' : 'bajo';
+        return {
+          id: `${row.id}-${row.tipo_dominante}`,
+          zona_id: `${row.id}-${row.tipo_dominante}`,
+          municipio: row.municipio,
+          departamento: row.departamento,
+          tipo_dominante: row.tipo_dominante,
+          subcategoria_dominante: row.subcategoria_dominante,
+          centro: {
+            lat: Number(row.lat),
+            lng: Number(row.lng),
+          },
+          n_reportes: Number(row.n_reportes),
+          severidad_promedio: Number(row.severidad_promedio),
+          ultimo_reporte: row.ultimo_reporte,
+          score,
+          nivel,
+        };
+      })
+      .filter((zona) => zona.score >= safeMinScore);
+  },
+
+  getAlertasPredictivas: async ({ nivel_min = 'medio', tipo, limite = 10, ...params } = {}) => {
+    const nivelRank = { bajo: 1, medio: 2, alto: 3, critico: 4 };
+    const minRank = nivelRank[nivel_min] || 2;
+    const zonas = await ReporteModel.getZonasRiesgo({
+      dias: params.dias || 30,
+      min_score: 0,
+    });
+    const safeLimit = Math.max(1, Math.min(50, parseInt(limite, 10) || 10));
+
+    return zonas
+      .filter((zona) => (nivelRank[zona.nivel] || 1) >= minRank)
+      .filter((zona) => !tipo || zona.tipo_dominante === tipo)
+      .slice(0, safeLimit);
+  },
+
+};
+</file>
+
+<file path="src/controllers/reporte.controller.js">
+import {
+  ESTADO_INICIAL_REPORTE,
+  ESTADOS_REPORTE_PERMITIDOS,
+  NIVELES_SEVERIDAD_PERMITIDOS,
+  ReporteModel,
+} from '../models/reporte.model.js';
+import fs from 'node:fs/promises';
+import { CategoriaRiesgoModel } from '../models/categoria-riesgo.model.js';
+import { UsuarioModel }   from '../models/usuario.model.js';
+import { EvidenciaModel } from '../models/evidencia.model.js';
+import { LikeModel } from '../models/like.model.js';
+import { analyzeReporte } from '../services/ia.service.js';
+import { clasificarImagen } from '../services/clasificacion.service.js';
+import { invalidatePrediccionCache } from '../services/prediccion.service.js';
+import { errorResponse, successResponse } from '../utils/response.js';
+import { crearNotificacion } from './notificacion.controller.js';
+
+const ANONYMOUS_VIEW_THROTTLE_MS = 5 * 60 * 1000;
+const anonymousViewThrottle = new Map();
+
+const parseCoordinate = (value, { field, min, max }) => {
+  if (value === undefined || value === null || value === '') {
+    return { value: null };
+  }
+
+  const parsed = Number(value);
+
+  if (!Number.isFinite(parsed)) {
+    return {
+      error: `${field} debe ser un numero valido.`,
+    };
+  }
+
+  if (parsed < min || parsed > max) {
+    return {
+      error: `${field} debe estar entre ${min} y ${max}.`,
+    };
+  }
+
+  return { value: parsed };
+};
+
+const normalizeEnumValue = (value) => (
+  typeof value === 'string' ? value.trim().toLowerCase() : ''
+);
+
+const buildAllowedValuesMessage = (field, allowedValues) => (
+  `${field} debe ser uno de: ${allowedValues.join(', ')}.`
+);
+
+const buildReporteLink = (reporte) => `/reports/${reporte.uuid ?? reporte.id_reporte}`;
+
+const canManageReporteEvidence = (reporte, user) => {
+  if (!reporte || !user) {
+    return false;
+  }
+
+  return (
+    Number(reporte.id_usuario) === Number(user.sub) ||
+    user.rol === 'moderador' ||
+    user.rol === 'admin'
+  );
+};
+
+const getReporteForEvidenceManagement = async (req, res) => {
+  const id = Number(req.params.id);
+  const reporte = await ReporteModel.findById(id);
+
+  if (!reporte) {
+    errorResponse(res, 'Reporte no encontrado.', 404);
+    return null;
+  }
+
+  if (!canManageReporteEvidence(reporte, req.user)) {
+    errorResponse(res, 'No tienes permiso para gestionar evidencias de este reporte.', 403);
+    return null;
+  }
+
+  return reporte;
+};
+
+const toCsvValue = (value) => {
+  if (value === null || value === undefined) return '';
+  const raw = String(value);
+  const escaped = raw.replace(/"/g, '""');
+  return /[",\n\r]/.test(raw) ? `"${escaped}"` : escaped;
+};
+
+const normalizeHasta = (value) => {
+  if (!value) return value;
+  return /^\d{4}-\d{2}-\d{2}$/.test(value) ? `${value} 23:59:59` : value;
+};
+
+const parseAnalyticsLimit = (value, defaultValue = 12, maxValue = 60) => {
+  const parsed = parseInt(value, 10);
+  if (Number.isNaN(parsed)) return defaultValue;
+  return Math.max(1, Math.min(maxValue, parsed));
+};
+
+const getUploadedFiles = (req) => ([
+  ...(req.file ? [req.file] : []),
+  ...(Array.isArray(req.files) ? req.files : []),
+  ...(Array.isArray(req.files?.file) ? req.files.file : []),
+  ...(Array.isArray(req.files?.files) ? req.files.files : []),
+]);
+
+const validateReporteEvidenceFiles = (files) => {
+  if (files.length > 10) {
+    return 'Solo puedes adjuntar hasta 10 evidencias por reporte.';
+  }
+
+  const videoCount = files.filter((file) => file.mimetype?.startsWith('video/')).length;
+  if (videoCount > 1) {
+    return 'Solo puedes adjuntar un video por reporte.';
+  }
+
+  return null;
+};
+
+const parseBooleanLike = (value) => (
+  value === true || value === 1 || value === '1' || String(value).toLowerCase() === 'true'
+);
+
+const parseAcceptedIaPayload = ({ ia_etiquetas, ia_confianza, ia_procesado }) => {
+  if (!parseBooleanLike(ia_procesado)) {
+    return { procesado: false };
+  }
+
+  let etiquetas = [];
+  if (typeof ia_etiquetas === 'string') {
+    try {
+      etiquetas = JSON.parse(ia_etiquetas);
+    } catch {
+      return { error: 'ia_etiquetas debe ser un arreglo JSON valido.' };
+    }
+  } else {
+    etiquetas = ia_etiquetas ?? [];
+  }
+
+  if (!Array.isArray(etiquetas)) {
+    return { error: 'ia_etiquetas debe ser un arreglo.' };
+  }
+
+  const confianza = Number(ia_confianza);
+  if (!Number.isFinite(confianza) || confianza < 0 || confianza > 100) {
+    return { error: 'ia_confianza debe ser un numero entre 0 y 100.' };
+  }
+
+  return {
+    procesado: true,
+    analysis: {
+      etiquetas,
+      confianza,
+      procesado: true,
+    },
+  };
+};
+
+const getAnonymousViewerKey = (req, idReporte) => {
+  const ip = req.ip || req.socket?.remoteAddress || 'unknown-ip';
+  const userAgent = req.get?.('user-agent') || req.headers?.['user-agent'] || 'unknown-agent';
+  return `${idReporte}:${ip}:${userAgent}`;
+};
+
+const registerReporteView = async (req, idReporte) => {
+  if (req.query?.skip_view === 'true') return false;
+
+  if (req.user?.sub) {
+    return ReporteModel.registrarVistaUsuario(idReporte, req.user.sub);
+  }
+
+  const now = Date.now();
+  const key = getAnonymousViewerKey(req, idReporte);
+  const lastSeenAt = anonymousViewThrottle.get(key) || 0;
+
+  if (now - lastSeenAt < ANONYMOUS_VIEW_THROTTLE_MS) {
+    return false;
+  }
+
+  anonymousViewThrottle.set(key, now);
+  await ReporteModel.incrementarVistas(idReporte);
+  return true;
+};
+
+const enrichLikedByMe = async (reportes, idUsuario) => {
+  const items = Array.isArray(reportes) ? reportes : [reportes].filter(Boolean);
+  if (!idUsuario || items.length === 0) return reportes;
+
+  const likedSet = await LikeModel.likedSet(
+    items.map((reporte) => reporte.id_reporte),
+    idUsuario
+  );
+  const enriched = items.map((reporte) => ({
+    ...reporte,
+    liked_by_me: likedSet.has(Number(reporte.id_reporte)),
+  }));
+
+  return Array.isArray(reportes) ? enriched : enriched[0];
+};
+
+export const createReporte = async (req, res, next) => {
+  try {
+    const {
+      tipo_contaminacion,
+      nivel_severidad,
+      subcategoria,
+      titulo,
+      descripcion,
+      direccion,
+      municipio,
+      departamento,
+      ia_etiquetas,
+      ia_confianza,
+      ia_procesado,
+      latitud,
+      longitud,
+    } = req.body ?? {};
+
+    if (!tipo_contaminacion?.trim()) {
+      return errorResponse(res, 'El tipo de contaminación es requerido.', 400);
+    }
+    if (!nivel_severidad?.trim()) {
+      return errorResponse(res, 'El nivel de severidad es requerido.', 400);
+    }
+    if (!titulo?.trim() || titulo.trim().length < 5) {
+      return errorResponse(res, 'El título debe tener al menos 5 caracteres.', 400);
+    }
+    if (!direccion?.trim() || direccion.trim().length < 3) {
+      return errorResponse(res, 'La dirección es requerida.', 400);
+    }
+
+    const tipoContaminacion = tipo_contaminacion.trim().toLowerCase();
+    const nivelSeveridad = normalizeEnumValue(nivel_severidad);
+    const uploadedFiles = getUploadedFiles(req);
+    const evidenceError = validateReporteEvidenceFiles(uploadedFiles);
+    const iaPayload = parseAcceptedIaPayload({ ia_etiquetas, ia_confianza, ia_procesado });
+
+    if (evidenceError) {
+      return errorResponse(res, evidenceError, 400);
+    }
+
+    if (iaPayload.error) {
+      return errorResponse(res, iaPayload.error, 400);
+    }
+
+    if (!NIVELES_SEVERIDAD_PERMITIDOS.includes(nivelSeveridad)) {
+      return errorResponse(
+        res,
+        buildAllowedValuesMessage('El nivel de severidad', NIVELES_SEVERIDAD_PERMITIDOS),
+        400
+      );
+    }
+
+    const categoriaValida = await CategoriaRiesgoModel.esValido(tipoContaminacion);
+
+    if (!categoriaValida) {
+      return errorResponse(res, 'La categoría de contaminación no existe o está inactiva.', 400);
+    }
+
+    const parsedLatitud = parseCoordinate(latitud, {
+      field: 'La latitud',
+      min: -90,
+      max: 90,
+    });
+
+    if (parsedLatitud.error) {
+      return errorResponse(res, parsedLatitud.error, 400);
+    }
+
+    const parsedLongitud = parseCoordinate(longitud, {
+      field: 'La longitud',
+      min: -180,
+      max: 180,
+    });
+
+    if (parsedLongitud.error) {
+      return errorResponse(res, parsedLongitud.error, 400);
+    }
+
+    const idReporte = await ReporteModel.create({
+      id_usuario:       req.user.sub,
+      tipo_contaminacion: tipoContaminacion,
+      subcategoria:        subcategoria?.trim() || null,
+      nivel_severidad:    nivelSeveridad,
+      titulo:             titulo.trim(),
+      descripcion:        descripcion?.trim() || null,
+      direccion:          direccion.trim(),
+      municipio:          municipio?.trim() || null,
+      departamento:       departamento?.trim() || null,
+      latitud:            parsedLatitud.value,
+      longitud:           parsedLongitud.value,
+    });
+
+    let reporte = await ReporteModel.findById(idReporte);
+
+    let iaAnalysis;
+    if (iaPayload.procesado) {
+      iaAnalysis = iaPayload.analysis;
+    } else {
+      iaAnalysis = analyzeReporte({
+        ...reporte,
+        tipo_contaminacion: tipoContaminacion,
+        nivel_severidad: nivelSeveridad,
+        titulo: titulo.trim(),
+        descripcion: descripcion?.trim() || null,
+        direccion: direccion.trim(),
+        municipio: municipio?.trim() || null,
+        departamento: departamento?.trim() || null,
+        latitud: parsedLatitud.value,
+        longitud: parsedLongitud.value,
+      });
+    }
+
+    await ReporteModel.updateIaAnalysis(idReporte, iaAnalysis);
+    reporte = await ReporteModel.findById(idReporte);
+
+    for (const [index, file] of uploadedFiles.entries()) {
+      const tipo = file.mimetype.startsWith('video/') ? 'video' : 'imagen';
+      await EvidenciaModel.create({
+        id_reporte:      idReporte,
+        id_usuario:      req.user.sub,
+        tipo_archivo:    tipo,
+        url_archivo:     `/uploads/${file.filename}`,
+        nombre_original: file.originalname,
+        mime_type:       file.mimetype,
+        tamano_bytes:    file.size,
+        orden:           index,
+      });
+    }
+
+    invalidatePrediccionCache();
+    return successResponse(res, { reporte }, 'Reporte creado correctamente.', 201);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const getReportes = async (req, res, next) => {
+  try {
+    const { estado, tipo_contaminacion, nivel_severidad, municipio, limit = 20, offset = 0 } = req.query;
+    const filters = {
+      estado, tipo_contaminacion, nivel_severidad, municipio,
+      limit: Number(limit),
+      offset: Number(offset),
+    };
+    const countFilters = {
+      estado,
+      tipo_contaminacion,
+      nivel_severidad,
+      municipio,
+    };
+    const [reportes, total] = await Promise.all([
+      ReporteModel.findAll(filters),
+      ReporteModel.countAll(countFilters),
+    ]);
+    const enrichedReportes = await enrichLikedByMe(reportes, req.user?.sub);
+
+    return successResponse(res, {
+      reportes: enrichedReportes,
+      total,
+      limit: Math.max(1, Math.min(100, parseInt(limit, 10) || 20)),
+      offset: Math.max(0, parseInt(offset, 10) || 0),
+    });
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const exportReportes = async (req, res, next) => {
+  try {
+    const {
+      format,
+      tipo_contaminacion,
+      estado,
+      nivel_severidad,
+      municipio,
+      desde,
+      hasta,
+    } = req.query ?? {};
+
+    const reportes = await ReporteModel.findForExport({
+      tipo_contaminacion,
+      estado,
+      nivel_severidad,
+      municipio,
+      desde,
+      hasta: normalizeHasta(hasta),
+    });
+
+    if (String(format).toLowerCase() === 'json') {
+      return successResponse(
+        res,
+        { reportes },
+        'Exportacion de reportes generada correctamente.'
+      );
+    }
+
+    const headers = [
+      'titulo',
+      'tipo_contaminacion',
+      'nivel_severidad',
+      'estado',
+      'municipio',
+      'autor_nombre',
+      'autor_apellido',
+      'created_at',
+    ];
+
+    const csvRows = [
+      headers.join(','),
+      ...reportes.map((row) => headers.map((key) => toCsvValue(row[key])).join(',')),
+    ];
+
+    const csvContent = `\ufeff${csvRows.join('\n')}`;
+
+    res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+    res.setHeader('Content-Disposition', 'attachment; filename="reportes_export.csv"');
+    return res.status(200).send(csvContent);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const getMisReportes = async (req, res, next) => {
+  try {
+    const id_usuario = req.user?.sub;
+
+    if (!id_usuario) {
+      return errorResponse(res, 'No autorizado.', 401);
+    }
+
+    const { limit = 20, offset = 0 } = req.query;
+
+    const reportes = await ReporteModel.findByUsuario(id_usuario, {
+      limit: Number(limit),
+      offset: Number(offset),
+    });
+
+    const total = await ReporteModel.countByUsuario(id_usuario);
+
+    return successResponse(
+      res,
+      { reportes, total },
+      'Reportes del usuario obtenidos correctamente.',
+      200
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const getStats = async (req, res, next) => {
+  try {
+    const stats = await ReporteModel.getStats();
+    return successResponse(res, { stats });
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const getStatsByCategoria = async (req, res, next) => {
+  try {
+    const data = await ReporteModel.getStatsByCategoria();
+    return successResponse(
+      res,
+      { data, total: data.length },
+      'Estadisticas por categoria obtenidas correctamente.'
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const getStatsTimeline = async (req, res, next) => {
+  try {
+    const bucket = String(req.query.bucket ?? 'week').toLowerCase();
+
+    if (!['week', 'month'].includes(bucket)) {
+      return errorResponse(res, 'El parametro bucket debe ser week o month.', 400);
+    }
+
+    const limit = parseAnalyticsLimit(req.query.limit);
+    const data = await ReporteModel.getStatsTimeline({ bucket, limit });
+
+    return successResponse(
+      res,
+      { data, bucket, limit, total: data.length },
+      'Timeline de reportes obtenido correctamente.'
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const getHeatmapPoints = async (req, res, next) => {
+  try {
+    const data = await ReporteModel.getHeatmapPoints();
+    return successResponse(
+      res,
+      { data, total: data.length },
+      'Puntos de heatmap obtenidos correctamente.'
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const getStatsIA = async (req, res, next) => {
+  try {
+    const data = await ReporteModel.getStatsIA({ dias: req.query?.dias });
+    return successResponse(
+      res,
+      { data },
+      'Estadisticas IA obtenidas correctamente.'
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const getZonasRiesgo = async (req, res, next) => {
+  try {
+    const zonas = await ReporteModel.getZonasRiesgo({
+      dias: req.query?.dias,
+      min_score: req.query?.min_score,
+    });
+
+    return successResponse(
+      res,
+      { zonas, total: zonas.length },
+      'Zonas de riesgo obtenidas correctamente.'
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const getAlertasPredictivas = async (req, res, next) => {
+  try {
+    const alertas = await ReporteModel.getAlertasPredictivas({
+      nivel_min: req.query?.nivel_min,
+      tipo: req.query?.tipo,
+      limite: req.query?.limite,
+      dias: req.query?.dias,
+      lat: req.query?.lat,
+      lng: req.query?.lng,
+      radio_km: req.query?.radio_km,
+    });
+
+    return successResponse(
+      res,
+      { alertas, total: alertas.length },
+      'Alertas predictivas obtenidas correctamente.'
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const getTrendingReportes = async (req, res, next) => {
+  try {
+    const reportes = await ReporteModel.findTrending({ limit: req.query?.limit });
+    const enrichedReportes = await enrichLikedByMe(reportes, req.user?.sub);
+    return successResponse(
+      res,
+      { reportes: enrichedReportes, total: reportes.length },
+      'Reportes en tendencia obtenidos correctamente.'
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const toggleLikeReporte = async (req, res, next) => {
+  try {
+    const id = Number(req.params.id);
+    const idUsuario = req.user?.sub;
+
+    const reporte = await ReporteModel.findById(id);
+    if (!reporte) return errorResponse(res, 'Reporte no encontrado.', 404);
+
+    if (Number(reporte.id_usuario) === Number(idUsuario)) {
+      return errorResponse(res, 'No puedes reaccionar a tu propio reporte.', 400);
+    }
+
+    const result = await LikeModel.toggle(id, idUsuario);
+
+    return successResponse(
+      res,
+      result,
+      result.liked ? 'Like registrado.' : 'Like retirado.'
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const analizarImagen = async (req, res, next) => {
+  try {
+    if (!req.file) {
+      return errorResponse(res, 'Imagen requerida.', 400);
+    }
+
+    const analysis = await clasificarImagen(req.file);
+    return successResponse(
+      res,
+      analysis,
+      'Imagen analizada correctamente.'
+    );
+  } catch (error) {
+    return next(error);
+  } finally {
+    if (req.file?.path) {
+      await fs.unlink(req.file.path).catch(() => {});
+    }
+  }
+};
+
+export const updateReporte = async (req, res, next) => {
+  try {
+    const id = Number(req.params.id);
+    const reporte = await ReporteModel.findById(id);
+    if (!reporte) return errorResponse(res, 'Reporte no encontrado.', 404);
+
+    const { rol, sub } = req.user;
+    const isOwner = reporte.id_usuario === sub;
+    const isMod   = rol === 'moderador' || rol === 'admin';
+
+    if (!isOwner && !isMod) {
+      return errorResponse(res, 'No tienes permiso para editar este reporte.', 403);
+    }
+
+    // Owners solo pueden editar reportes en estado inicial.
+    if (isOwner && !isMod && reporte.estado !== ESTADO_INICIAL_REPORTE) {
+      return errorResponse(
+        res,
+        'No puedes editar un reporte que ya está en revisión o procesado.',
+        403
+      );
+    }
+
+    // Owners can edit content fields; mods/admins can also change estado y comentario_moderacion
+    const allowed = isOwner
+      ? ['titulo', 'descripcion', 'direccion', 'municipio', 'departamento']
+      : ['estado', 'nivel_severidad', 'titulo', 'descripcion', 'direccion', 'municipio', 'departamento', 'comentario_moderacion'];
+
+    const campos = {};
+    for (const key of allowed) {
+      if (Object.prototype.hasOwnProperty.call(req.body ?? {}, key)) {
+        campos[key] = req.body[key];
+      }
+    }
+
+    if (Object.keys(campos).length === 0) {
+      return errorResponse(res, 'No se enviaron campos válidos para actualizar.', 400);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(campos, 'estado')) {
+      const estado = normalizeEnumValue(campos.estado);
+
+      if (!ESTADOS_REPORTE_PERMITIDOS.includes(estado)) {
+        return errorResponse(
+          res,
+          buildAllowedValuesMessage('El estado', ESTADOS_REPORTE_PERMITIDOS),
+          400
+        );
+      }
+
+      campos.estado = estado;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(campos, 'nivel_severidad')) {
+      const nivelSeveridad = normalizeEnumValue(campos.nivel_severidad);
+
+      if (!NIVELES_SEVERIDAD_PERMITIDOS.includes(nivelSeveridad)) {
+        return errorResponse(
+          res,
+          buildAllowedValuesMessage('El nivel de severidad', NIVELES_SEVERIDAD_PERMITIDOS),
+          400
+        );
+      }
+
+      campos.nivel_severidad = nivelSeveridad;
+    }
+
+    // Validar que comentario_moderacion es obligatorio si se rechaza
+    if (isMod && campos.estado === 'rechazado') {
+      const comentario = campos.comentario_moderacion?.trim();
+      if (!comentario) {
+        return errorResponse(res, 'El comentario es obligatorio al rechazar un reporte.', 400);
+      }
+    }
+
+    await ReporteModel.update(id, campos);
+    if (
+      Object.prototype.hasOwnProperty.call(campos, 'estado') ||
+      Object.prototype.hasOwnProperty.call(campos, 'nivel_severidad')
+    ) {
+      invalidatePrediccionCache();
+    }
+    const updated = await ReporteModel.findById(id);
+
+    if (isMod && reporte.id_usuario && Number(reporte.id_usuario) !== Number(sub)) {
+      const cambioEstado = (
+        Object.prototype.hasOwnProperty.call(campos, 'estado') &&
+        campos.estado !== reporte.estado
+      );
+      const nuevoComentario = (
+        Object.prototype.hasOwnProperty.call(campos, 'comentario_moderacion') &&
+        String(campos.comentario_moderacion ?? '').trim().length > 0 &&
+        campos.comentario_moderacion !== reporte.comentario_moderacion
+      );
+
+      if (cambioEstado) {
+        crearNotificacion({
+          id_usuario: reporte.id_usuario,
+          tipo: 'reporte_estado',
+          titulo: `Tu reporte cambio a "${campos.estado}"`,
+          mensaje: `El reporte "${reporte.titulo}" ahora esta en estado: ${campos.estado}.`,
+          referencia_tipo: 'reporte',
+          referencia_uuid: reporte.uuid,
+          link: buildReporteLink(reporte),
+        });
+      }
+
+      if (nuevoComentario) {
+        crearNotificacion({
+          id_usuario: reporte.id_usuario,
+          tipo: 'reporte_comentario',
+          titulo: 'Comentario de moderacion en tu reporte',
+          mensaje: String(campos.comentario_moderacion).slice(0, 240),
+          referencia_tipo: 'reporte',
+          referencia_uuid: reporte.uuid,
+          link: buildReporteLink(reporte),
+        });
+      }
+    }
+
+    return successResponse(res, { reporte: updated }, 'Reporte actualizado.');
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const deleteReporte = async (req, res, next) => {
+  try {
+    const id = Number(req.params.id);
+    const reporte = await ReporteModel.findById(id);
+    if (!reporte) return errorResponse(res, 'Reporte no encontrado.', 404);
+
+    const { rol, sub } = req.user;
+    const isOwner = reporte.id_usuario === sub;
+    const isMod   = rol === 'moderador' || rol === 'admin';
+
+    if (!isOwner && !isMod) {
+      return errorResponse(res, 'No tienes permiso para eliminar este reporte.', 403);
+    }
+
+    // Owners solo pueden eliminar reportes en estado inicial.
+    if (isOwner && !isMod && reporte.estado !== ESTADO_INICIAL_REPORTE) {
+      return errorResponse(
+        res,
+        'No puedes eliminar un reporte que ya está en revisión o procesado.',
+        403
+      );
+    }
+
+    await ReporteModel.remove(id);
+    invalidatePrediccionCache();
+    return successResponse(res, null, 'Reporte eliminado.');
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const getReporteById = async (req, res, next) => {
+  try {
+    const id = Number(req.params.id);
+    const reporte = await ReporteModel.findById(id);
+    if (!reporte) return errorResponse(res, 'Reporte no encontrado.', 404);
+    await registerReporteView(req, id);
+    const enrichedReporte = await enrichLikedByMe(reporte, req.user?.sub);
+
+    // Fetch related data in parallel
+    const [evidencias, usuario] = await Promise.all([
+      EvidenciaModel.findByReporte(id),
+      UsuarioModel.findById(reporte.id_usuario),
+    ]);
+
+    // Strip sensitive user fields
+    const autor = usuario
+      ? { nombre: usuario.nombre, apellido: usuario.apellido, rol: usuario.rol, avatar_url: usuario.avatar_url ?? null }
+      : null;
+
+    return successResponse(res, { reporte: enrichedReporte, evidencias, autor });
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const listEvidenciasReporte = async (req, res, next) => {
+  try {
+    const reporte = await getReporteForEvidenceManagement(req, res);
+    if (!reporte) return null;
+
+    const evidencias = await EvidenciaModel.findByReporte(reporte.id_reporte);
+
+    return successResponse(
+      res,
+      { evidencias, total: evidencias.length },
+      'Evidencias obtenidas correctamente.'
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const addEvidenciaReporte = async (req, res, next) => {
+  try {
+    const reporte = await getReporteForEvidenceManagement(req, res);
+    if (!reporte) return null;
+
+    if (!req.file) {
+      return errorResponse(res, 'Archivo de evidencia requerido.', 400);
+    }
+
+    const tipo = req.file.mimetype.startsWith('video/') ? 'video' : 'imagen';
+    const idEvidencia = await EvidenciaModel.create({
+      id_reporte: reporte.id_reporte,
+      id_usuario: req.user.sub,
+      tipo_archivo: tipo,
+      url_archivo: `/uploads/${req.file.filename}`,
+      nombre_original: req.file.originalname,
+      mime_type: req.file.mimetype,
+      tamano_bytes: req.file.size,
+      orden: 0,
+    });
+
+    const evidencia = await EvidenciaModel.findById(idEvidencia);
+
+    return successResponse(
+      res,
+      { evidencia },
+      'Evidencia agregada correctamente.',
+      201
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const deleteEvidenciaReporte = async (req, res, next) => {
+  try {
+    const reporte = await getReporteForEvidenceManagement(req, res);
+    if (!reporte) return null;
+
+    const evidenciaId = Number(req.params.evidenciaId);
+    const evidencia = await EvidenciaModel.findById(evidenciaId);
+
+    if (!evidencia || Number(evidencia.id_reporte) !== Number(reporte.id_reporte)) {
+      return errorResponse(res, 'Evidencia no encontrada.', 404);
+    }
+
+    await EvidenciaModel.remove(evidenciaId);
+
+    return successResponse(res, null, 'Evidencia eliminada correctamente.');
+  } catch (error) {
+    return next(error);
+  }
+};
+</file>
+
+</files>

--- a/routes/notificacion.routes.js
+++ b/routes/notificacion.routes.js
@@ -6,6 +6,7 @@ import {
   listarNotificaciones,
   marcarLeida,
   marcarTodasLeidas,
+  registrarFcmToken,
 } from '../src/controllers/notificacion.controller.js';
 
 const notificacionRouter = Router();
@@ -13,6 +14,7 @@ const notificacionRouter = Router();
 notificacionRouter.use(verifyToken);
 
 notificacionRouter.get('/contador', contadorNotificaciones);
+notificacionRouter.post('/fcm-token', registrarFcmToken);
 notificacionRouter.patch('/marcar-todas', marcarTodasLeidas);
 notificacionRouter.get('/', listarNotificaciones);
 notificacionRouter.patch('/:uuid/leida', marcarLeida);

--- a/src/controllers/notificacion.controller.js
+++ b/src/controllers/notificacion.controller.js
@@ -1,8 +1,48 @@
 import { NotificacionModel } from '../models/notificacion.model.js';
+import { FcmTokenModel } from '../models/fcm-token.model.js';
+import { UsuarioModel } from '../models/usuario.model.js';
 import { errorResponse, successResponse } from '../utils/response.js';
+
+const FCM_TOKEN_MIN_LENGTH = 20;
+const FCM_TOKEN_MAX_LENGTH = 4096;
+
+const validarFcmToken = (token) => {
+  if (typeof token !== 'string' || !token.trim()) {
+    return 'Token FCM requerido.';
+  }
+
+  const normalized = token.trim();
+  if (
+    normalized.length < FCM_TOKEN_MIN_LENGTH ||
+    normalized.length > FCM_TOKEN_MAX_LENGTH ||
+    /\s/.test(normalized)
+  ) {
+    return 'Token FCM invalido.';
+  }
+
+  return null;
+};
+
+const TIPOS_ACTUALIZACION_REPORTE = new Set([
+  'reporte_estado',
+  'reporte_comentario',
+  'reporte_creado',
+]);
+
+const puedeCrearNotificacion = async ({ id_usuario, tipo }) => {
+  if (!TIPOS_ACTUALIZACION_REPORTE.has(tipo)) return true;
+
+  const usuario = await UsuarioModel.findByIdWithDetails(id_usuario);
+  if (!usuario) return false;
+
+  return usuario.notification_preferences?.report_updates !== false;
+};
 
 export const crearNotificacion = async (payload) => {
   try {
+    const allowed = await puedeCrearNotificacion(payload);
+    if (!allowed) return null;
+
     return await NotificacionModel.create(payload);
   } catch (error) {
     console.error('[notificaciones] error al crear:', error.message);
@@ -94,6 +134,27 @@ export const eliminarNotificacion = async (req, res, next) => {
     if (!ok) return errorResponse(res, 'Notificacion no encontrada.', 404);
 
     return successResponse(res, { uuid }, 'Notificacion eliminada.');
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const registrarFcmToken = async (req, res, next) => {
+  try {
+    const idUsuario = req.user?.sub;
+    if (!idUsuario) return errorResponse(res, 'No autorizado.', 401);
+
+    const token = typeof req.body?.token === 'string' ? req.body.token.trim() : req.body?.token;
+    const validationError = validarFcmToken(token);
+    if (validationError) return errorResponse(res, validationError, 400);
+
+    const data = await FcmTokenModel.registrar({
+      id_usuario: idUsuario,
+      token,
+      user_agent: req.get?.('user-agent') ?? req.headers?.['user-agent'] ?? null,
+    });
+
+    return successResponse(res, data, 'Token FCM registrado.');
   } catch (error) {
     return next(error);
   }

--- a/src/controllers/reporte.controller.js
+++ b/src/controllers/reporte.controller.js
@@ -48,6 +48,20 @@ const buildAllowedValuesMessage = (field, allowedValues) => (
   `${field} debe ser uno de: ${allowedValues.join(', ')}.`
 );
 
+const TRANSICIONES_ESTADO_REPORTE = {
+  pendiente: ['en_revision', 'rechazado'],
+  en_revision: ['verificado', 'en_proceso', 'rechazado'],
+  verificado: ['en_proceso', 'resuelto', 'rechazado'],
+  en_proceso: ['resuelto', 'rechazado'],
+  resuelto: [],
+  rechazado: ['pendiente'],
+};
+
+const canTransitionReporteEstado = (estadoActual, estadoNuevo) => {
+  if (estadoActual === estadoNuevo) return true;
+  return (TRANSICIONES_ESTADO_REPORTE[estadoActual] ?? []).includes(estadoNuevo);
+};
+
 const buildReporteLink = (reporte) => `/reports/${reporte.uuid ?? reporte.id_reporte}`;
 
 const canManageReporteEvidence = (reporte, user) => {
@@ -667,6 +681,14 @@ export const updateReporte = async (req, res, next) => {
       }
 
       campos.estado = estado;
+
+      if (!canTransitionReporteEstado(reporte.estado, campos.estado)) {
+        return errorResponse(
+          res,
+          `Transicion de estado no permitida: ${reporte.estado} -> ${campos.estado}.`,
+          400
+        );
+      }
     }
 
     if (Object.prototype.hasOwnProperty.call(campos, 'nivel_severidad')) {
@@ -712,7 +734,7 @@ export const updateReporte = async (req, res, next) => {
       );
 
       if (cambioEstado) {
-        crearNotificacion({
+        await crearNotificacion({
           id_usuario: reporte.id_usuario,
           tipo: 'reporte_estado',
           titulo: `Tu reporte cambio a "${campos.estado}"`,
@@ -724,7 +746,7 @@ export const updateReporte = async (req, res, next) => {
       }
 
       if (nuevoComentario) {
-        crearNotificacion({
+        await crearNotificacion({
           id_usuario: reporte.id_usuario,
           tipo: 'reporte_comentario',
           titulo: 'Comentario de moderacion en tu reporte',

--- a/src/models/fcm-token.model.js
+++ b/src/models/fcm-token.model.js
@@ -1,0 +1,48 @@
+import crypto from 'crypto';
+import pool from '../config/database.js';
+
+const hashToken = (token) => crypto
+  .createHash('sha256')
+  .update(token)
+  .digest('hex');
+
+export const FcmTokenModel = {
+  registrar: async ({ id_usuario, token, user_agent = null }) => {
+    const tokenHash = hashToken(token);
+    const safeUserAgent = user_agent ? String(user_agent).slice(0, 255) : null;
+
+    const [result] = await pool.execute(
+      `INSERT INTO fcm_tokens
+         (id_usuario, token, token_hash, activo, user_agent, last_seen_at)
+       VALUES (?, ?, ?, TRUE, ?, NOW())
+       ON DUPLICATE KEY UPDATE
+         id_usuario = VALUES(id_usuario),
+         token = VALUES(token),
+         activo = TRUE,
+         user_agent = VALUES(user_agent),
+         last_seen_at = NOW(),
+         updated_at = CURRENT_TIMESTAMP`,
+      [id_usuario, token, tokenHash, safeUserAgent]
+    );
+
+    return {
+      id_fcm_token: result.insertId || null,
+      token_hash: tokenHash,
+      registrado: true,
+    };
+  },
+
+  desactivar: async (token) => {
+    const tokenHash = hashToken(token);
+    const [result] = await pool.execute(
+      `UPDATE fcm_tokens
+       SET activo = FALSE, updated_at = CURRENT_TIMESTAMP
+       WHERE token_hash = ?`,
+      [tokenHash]
+    );
+
+    return result.affectedRows > 0;
+  },
+};
+
+export default FcmTokenModel;

--- a/src/services/prediccion.service.js
+++ b/src/services/prediccion.service.js
@@ -109,6 +109,14 @@ export const parseAlertasParams = (query = {}) => {
   if (query.radio_km !== undefined && (radio_km === null || radio_km <= 0 || radio_km > 500)) {
     throw validationError('radio_km debe ser un numero mayor a 0 y menor o igual a 500.');
   }
+  const hasLat = query.lat !== undefined && query.lat !== null && query.lat !== '';
+  const hasLng = query.lng !== undefined && query.lng !== null && query.lng !== '';
+  if (hasLat !== hasLng) {
+    throw validationError('lat y lng deben enviarse juntos.');
+  }
+  if (query.radio_km !== undefined && (!hasLat || !hasLng)) {
+    throw validationError('radio_km requiere lat y lng.');
+  }
 
   return {
     ...zonasParams,

--- a/tests/auth/login.test.js
+++ b/tests/auth/login.test.js
@@ -10,7 +10,7 @@
 import 'dotenv/config';
 import fetch from 'node-fetch';
 
-const API_URL = process.env.API_URL || 'http://localhost:3000/api';
+const API_URL = (process.env.API_URL || 'http://localhost:3000').replace(/\/+$/, '');
 let testsPassed = 0;
 let testsFailed = 0;
 
@@ -40,7 +40,7 @@ const assert = (condition, testName) => {
 async function testConnection() {
   log.info('\n--- TEST 0: Connection ---');
   try {
-    const response = await fetch(`${API_URL}/api/auth/login`, {
+    const response = await fetch(`${API_URL}/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email: 'test@test.com', password: 'test' }),

--- a/tests/auth/password-reset.test.js
+++ b/tests/auth/password-reset.test.js
@@ -10,7 +10,7 @@
 import 'dotenv/config';
 import fetch from 'node-fetch';
 
-const API_URL = process.env.API_URL || 'http://localhost:3000/api';
+const API_URL = (process.env.API_URL || 'http://localhost:3000').replace(/\/+$/, '');
 let testsPassed = 0;
 let testsFailed = 0;
 
@@ -40,7 +40,7 @@ const assert = (condition, testName) => {
 async function testConnection() {
   log.info('\n--- TEST 0: Connection ---');
   try {
-    const response = await fetch(`${API_URL}/api/auth/login`, {
+    const response = await fetch(`${API_URL}/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email: 'test@test.com', password: 'test' }),

--- a/tests/auth/refresh-flow.manual.ps1
+++ b/tests/auth/refresh-flow.manual.ps1
@@ -1,6 +1,6 @@
 $ErrorActionPreference = "Stop"
 
-$baseUrl = "http://localhost:3000/api"
+$baseUrl = "http://localhost:3000"
 $email = "refresh-demo-$([DateTimeOffset]::UtcNow.ToUnixTimeSeconds())@example.com"
 $password = "Password123!"
 

--- a/tests/auth/register.test.js
+++ b/tests/auth/register.test.js
@@ -8,7 +8,7 @@
 import 'dotenv/config';
 import fetch from 'node-fetch';
 
-const API_URL = process.env.API_URL || 'http://localhost:3000/api';
+const API_URL = (process.env.API_URL || 'http://localhost:3000').replace(/\/+$/, '');
 let testsPassed = 0;
 let testsFailed = 0;
 
@@ -38,7 +38,7 @@ const assert = (condition, testName) => {
 async function testConnection() {
   log.info('\n--- TEST 0: Connection ---');
   try {
-    const response = await fetch(`${API_URL}/api/auth/login`, {
+    const response = await fetch(`${API_URL}/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email: 'test@test.com', password: 'test' }),
@@ -56,7 +56,7 @@ async function testValidRegistration() {
   log.info('\n--- TEST 1: Valid Registration ---');
   try {
     const email = `test-${Date.now()}@ejemplo.com`;
-    const response = await fetch(`${API_URL}/api/auth/register`, {
+    const response = await fetch(`${API_URL}/auth/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -84,7 +84,7 @@ async function testValidRegistration() {
 async function testInvalidEmail() {
   log.info('\n--- TEST 2: Invalid Email (Should fail) ---');
   try {
-    const response = await fetch(`${API_URL}/api/auth/register`, {
+    const response = await fetch(`${API_URL}/auth/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -97,7 +97,7 @@ async function testInvalidEmail() {
     
     const data = await response.json();
     assert(response.status === 400, 'Status 400');
-    assert(data.success === false, 'Success false');
+    assert(data.status === 'error', 'Status error');
   } catch (error) {
     log.error(`Error: ${error.message}`);
   }
@@ -106,7 +106,7 @@ async function testInvalidEmail() {
 async function testShortPassword() {
   log.info('\n--- TEST 3: Short Password (Should fail) ---');
   try {
-    const response = await fetch(`${API_URL}/api/auth/register`, {
+    const response = await fetch(`${API_URL}/auth/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -119,7 +119,7 @@ async function testShortPassword() {
     
     const data = await response.json();
     assert(response.status === 400, 'Status 400');
-    assert(data.success === false, 'Success false');
+    assert(data.status === 'error', 'Status error');
   } catch (error) {
     log.error(`Error: ${error.message}`);
   }

--- a/tests/diagnose-routes.js
+++ b/tests/diagnose-routes.js
@@ -21,21 +21,21 @@ async function main() {
 
   // Test rutas básicas
   console.log('Rutas básicas:');
-  await testRoute('GET', '/api/health');
+  await testRoute('GET', '/health');
   await testRoute('GET', '/');
   
   // Test rutas auth
   console.log('\nRutas Auth:');
-  await testRoute('POST', '/api/auth/register');
-  await testRoute('POST', '/api/auth/login');
-  await testRoute('POST', '/api/auth/send-verification-email');
-  await testRoute('GET', '/api/auth/verify-email');
+  await testRoute('POST', '/auth/register');
+  await testRoute('POST', '/auth/login');
+  await testRoute('POST', '/auth/enviar-verificacion');
+  await testRoute('GET', '/auth/verify-email');
   
   // Test rutas reportes
   console.log('\nRutas Reportes:');
-  await testRoute('GET', '/api/reportes/mis-reportes');
-  await testRoute('GET', '/api/reportes');
-  await testRoute('POST', '/api/reportes');
+  await testRoute('GET', '/reportes/mis-reportes');
+  await testRoute('GET', '/reportes');
+  await testRoute('POST', '/reportes');
 
   // Test con headers adicionales
   console.log('\nRutas con Bearer token inválido:');
@@ -44,12 +44,12 @@ async function main() {
   };
   
   try {
-    const response = await fetch(`${BASE_URL}/api/auth/send-verification-email`, {
+    const response = await fetch(`${BASE_URL}/auth/enviar-verificacion`, {
       method: 'POST',
       headers,
       body: JSON.stringify({})
     });
-    console.log(`POST /api/auth/send-verification-email: ${response.status}`);
+    console.log(`POST /auth/enviar-verificacion: ${response.status}`);
     const data = await response.json();
     console.log(`Response:`, data);
   } catch (error) {

--- a/tests/email/verification.test.js
+++ b/tests/email/verification.test.js
@@ -8,7 +8,7 @@
 import 'dotenv/config';
 import fetch from 'node-fetch';
 
-const API_URL = process.env.API_URL || 'http://localhost:3000/api';
+const API_URL = (process.env.API_URL || 'http://localhost:3000').replace(/\/+$/, '');
 const TEST_EMAIL_BASE = `test-${Date.now()}`;
 let testsPassed = 0;
 let testsFailed = 0;
@@ -41,7 +41,7 @@ const assert = (condition, testName) => {
 async function testConnection() {
   log.info('\n--- TEST 0: Connection to Server ---');
   try {
-    const response = await fetch(`${API_URL}/api/auth/login`, {
+    const response = await fetch(`${API_URL}/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email: 'test@test.com', password: 'test' }),
@@ -60,7 +60,7 @@ async function testConnection() {
 async function testRegister() {
   log.info('\n--- TEST 1: Register User ---');
   try {
-    const response = await fetch(`${API_URL}/api/auth/register`, {
+    const response = await fetch(`${API_URL}/auth/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -88,7 +88,7 @@ async function testRegister() {
 async function testSendVerification(jwt) {
   log.info('\n--- TEST 2: Send Verification Email ---');
   try {
-    const response = await fetch(`${API_URL}/api/auth/send-verification-email`, {
+    const response = await fetch(`${API_URL}/auth/enviar-verificacion`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -99,7 +99,7 @@ async function testSendVerification(jwt) {
     const data = await response.json();
     
     assert(response.status === 200, 'Status 200');
-    assert(data.success === true, 'Success true');
+    assert(data.status === 'success', 'Status success');
     
     return true;
   } catch (error) {
@@ -111,7 +111,7 @@ async function testSendVerification(jwt) {
 async function testNoAuth() {
   log.info('\n--- TEST 3: No Authentication (Should fail) ---');
   try {
-    const response = await fetch(`${API_URL}/api/auth/send-verification-email`, {
+    const response = await fetch(`${API_URL}/auth/enviar-verificacion`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
     });
@@ -119,8 +119,8 @@ async function testNoAuth() {
     const data = await response.json();
     
     assert(response.status === 401, 'Status 401');
-    assert(data.success === false, 'Success false');
-    assert(data.error.includes('No autorizado'), 'Correct message');
+    assert(data.status === 'error', 'Status error');
+    assert(data.message, 'Correct message');
     
     return true;
   } catch (error) {
@@ -132,15 +132,15 @@ async function testNoAuth() {
 async function testNoToken() {
   log.info('\n--- TEST 4: No Token in Query (Should fail) ---');
   try {
-    const response = await fetch(`${API_URL}/api/auth/verify-email`, {
+    const response = await fetch(`${API_URL}/auth/verify-email`, {
       method: 'GET',
     });
 
     const data = await response.json();
     
     assert(response.status === 400, 'Status 400');
-    assert(data.success === false, 'Success false');
-    assert(data.error.includes('Token'), 'Message mentions token');
+    assert(data.status === 'error', 'Status error');
+    assert(data.message.includes('Token'), 'Message mentions token');
     
     return true;
   } catch (error) {
@@ -152,15 +152,15 @@ async function testNoToken() {
 async function testInvalidToken() {
   log.info('\n--- TEST 5: Invalid Token (Should fail) ---');
   try {
-    const response = await fetch(`${API_URL}/api/auth/verify-email?token=invalid_token_xyz123`, {
+    const response = await fetch(`${API_URL}/auth/verify-email?token=invalid_token_xyz123`, {
       method: 'GET',
     });
 
     const data = await response.json();
     
     assert(response.status === 400, 'Status 400');
-    assert(data.success === false, 'Success false');
-    assert(data.error.includes('invalido'), 'Message mentions invalid');
+    assert(data.status === 'error', 'Status error');
+    assert(data.message.includes('invalido'), 'Message mentions invalid');
     
     return true;
   } catch (error) {

--- a/tests/integration-v2.test.js
+++ b/tests/integration-v2.test.js
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 
-const BASE_URL = 'http://localhost:3000';
+const BASE_URL = (process.env.API_URL || 'http://localhost:3000').replace(/\/+$/, '');
 
 const colors = {
   reset: '\x1b[0m',
@@ -18,8 +18,8 @@ const colors = {
 
 const log = {
   test: (msg) => console.log(`${colors.cyan}✓ TEST: ${msg}${colors.reset}`),
-  pass: (msg) => console.log(`${colors.green}✅ PASS: ${msg}${colors.reset}`),
-  fail: (msg) => console.log(`${colors.red}❌ FAIL: ${msg}${colors.reset}`),
+  pass: (msg) => console.log(`${colors.green} PASS: ${msg}${colors.reset}`),
+  fail: (msg) => console.log(`${colors.red} FAIL: ${msg}${colors.reset}`),
   info: (msg) => console.log(`${colors.blue}ℹ INFO: ${msg}${colors.reset}`),
   section: (msg) => console.log(`\n${colors.cyan}═══════════════════════════════════\n  ${msg}\n═══════════════════════════════════${colors.reset}\n`),
 };
@@ -77,7 +77,7 @@ async function runTests() {
 
   await test('Registro de usuario exitoso', async () => {
     testEmail = `test-${Date.now()}@example.com`;
-    const res = await apiRequest('POST', '/api/auth/register', {
+    const res = await apiRequest('POST', '/auth/register', {
       nombre: 'Test',
       apellido: 'User',
       email: testEmail,
@@ -99,7 +99,7 @@ async function runTests() {
       return;
     }
     
-    const res = await apiRequest('POST', '/api/auth/login', {
+    const res = await apiRequest('POST', '/auth/login', {
       email: testEmail,
       password: 'TestPass123!',
     });
@@ -112,13 +112,13 @@ async function runTests() {
   // ─── 2. ENDPOINTS OTP ───
   log.section('2. ENDPOINTS OTP EMAIL VERIFICATION');
 
-  await test('GET /api/auth/send-verification-email devuelve 401 sin token', async () => {
-    const res = await apiRequest('POST', '/api/auth/send-verification-email', {});
+  await test('POST /auth/enviar-verificacion devuelve 401 sin token', async () => {
+    const res = await apiRequest('POST', '/auth/enviar-verificacion', {});
     assert.strictEqual(res.status, 401, `Expected 401, got ${res.status}`);
   });
 
-  await test('GET /api/auth/verify-email devuelve 400/404 sin parámetros', async () => {
-    const res = await apiRequest('GET', '/api/auth/verify-email');
+  await test('GET /auth/verify-email devuelve 400 sin parámetros', async () => {
+    const res = await apiRequest('GET', '/auth/verify-email');
     assert([400, 404].includes(res.status), `Expected 400/404, got ${res.status}`);
   });
 
@@ -126,7 +126,7 @@ async function runTests() {
   log.section('3. GET /api/reportes/MIS-REPORTES');
 
   await test('Acceso a mis-reportes requiere autenticación', async () => {
-    const res = await apiRequest('GET', '/api/reportes/mis-reportes');
+    const res = await apiRequest('GET', '/reportes/mis-reportes');
     assert.strictEqual(res.status, 401, `Expected 401, got ${res.status}`);
   });
 
@@ -136,7 +136,7 @@ async function runTests() {
       return;
     }
 
-    const res = await apiRequest('GET', '/api/reportes/mis-reportes', null, testToken);
+    const res = await apiRequest('GET', '/reportes/mis-reportes', null, testToken);
     assert.strictEqual(res.status, 200, `Expected 200, got ${res.status}`);
     assert(Array.isArray(res.data?.data?.reportes), 'Reportes debe ser array');
     assert(typeof res.data?.data?.total === 'number', 'Total es número');
@@ -153,7 +153,7 @@ async function runTests() {
       return;
     }
 
-    const res = await apiRequest('POST', '/api/reportes', {
+    const res = await apiRequest('POST', '/reportes', {
       tipo_contaminacion: 'inundacion',
       nivel_severidad: 'medio',
       titulo: 'Test Report Title',
@@ -166,7 +166,7 @@ async function runTests() {
     }, testToken);
 
     if (res.status === 201) {
-      testReporteId = res.data?.data?.id_reporte;
+      testReporteId = res.data?.data?.reporte?.id_reporte;
       log.info(`Reporte creado: ${testReporteId}`);
     }
   });
@@ -175,13 +175,13 @@ async function runTests() {
   log.section('5. ENDPOINTS ADICIONALES');
 
   await test('Health check está disponible', async () => {
-    const res = await apiRequest('GET', '/api/health');
+    const res = await apiRequest('GET', '/health');
     assert.strictEqual(res.status, 200, `Expected 200, got ${res.status}`);
     assert(res.data?.status, 'Health status disponible');
   });
 
-  await test('GET /api/reportes devuelve lista pública', async () => {
-    const res = await apiRequest('GET', '/api/reportes');
+  await test('GET /reportes devuelve lista pública', async () => {
+    const res = await apiRequest('GET', '/reportes');
     assert.strictEqual(res.status, 200, `Expected 200, got ${res.status}`);
     assert(Array.isArray(res.data?.data?.reportes), 'Reportes debe ser array');
   });

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -10,7 +10,7 @@
 
 import assert from 'assert';
 
-const BASE_URL = 'http://localhost:3000';
+const BASE_URL = (process.env.API_URL || 'http://localhost:3000').replace(/\/+$/, '');
 
 // Color codes for terminal output
 const colors = {
@@ -89,7 +89,7 @@ async function runTests() {
   log.section('1. REGISTRO Y AUTENTICACIÓN');
 
   await test('Registro de usuario exitoso', async () => {
-    const res = await apiRequest('POST', '/api/auth/register', {
+    const res = await apiRequest('POST', '/auth/register', {
       nombre: 'Test',
       apellido: 'User',
       email: `test-${Date.now()}@example.com`,
@@ -98,14 +98,14 @@ async function runTests() {
     
     log.info(`Registro response: status=${res.status}, data=${JSON.stringify(res.data)}`);
     assert.strictEqual(res.status, 201, `Expected 201, got ${res.status}`);
-    assert(res.data.usuario || res.data.data, 'Usuario creado');
-    assert(res.data.pendingEmailVerification === true || res.data.data?.pendingEmailVerification === true, 'Email verification pendiente');
+    assert(res.data.data?.user, 'Usuario creado');
+    assert(res.data.data?.pendingEmailVerification === true, 'Email verification pendiente');
     
-    testUserId = res.data.usuario?.id_usuario || res.data.data?.usuario?.id_usuario;
+    testUserId = res.data.data?.user?.id_usuario;
   });
 
   await test('Login exitoso', async () => {
-    const res = await apiRequest('POST', '/api/auth/login', {
+    const res = await apiRequest('POST', '/auth/login', {
       email: 'test-user@example.com',
       password: 'password123',
     });
@@ -118,36 +118,36 @@ async function runTests() {
   log.section('2. OTP EMAIL VERIFICATION');
 
   await test('Enviar verificación OTP requiere token', async () => {
-    const res = await apiRequest('POST', '/api/auth/send-verification-email', {});
+    const res = await apiRequest('POST', '/auth/enviar-verificacion', {});
     
     assert.strictEqual(res.status, 401, `Expected 401, got ${res.status}`);
-    assert(res.data.message.includes('No autorizado'), 'Mensaje de error correcto');
+    assert(res.data.message, 'Mensaje de error disponible');
   });
 
   await test('Verificación OTP con token inválido falla', async () => {
-    const res = await apiRequest('POST', '/api/auth/verify-email', 
+    const res = await apiRequest('POST', '/auth/verificar-email', 
       { otp_code: '123456' },
       'invalid-token'
     );
     
-    assert.strictEqual(res.status, 401, `Expected 401, got ${res.status}`);
+    assert.strictEqual(res.status, 403, `Expected 403, got ${res.status}`);
   });
 
   // ─── 3. GET /api/reportes/MIS-REPORTES ───
   log.section('3. GET /api/reportes/MIS-REPORTES');
 
   await test('Acceso a mis-reportes requiere autenticación', async () => {
-    const res = await apiRequest('GET', '/api/reportes/mis-reportes');
+    const res = await apiRequest('GET', '/reportes/mis-reportes');
     
     assert.strictEqual(res.status, 401, `Expected 401, got ${res.status}`);
-    assert(res.data.message.includes('No autorizado'), 'Mensaje de error correcto');
+    assert(res.data.message, 'Mensaje de error disponible');
   });
 
   // ─── 4. CREAR REPORTE PARA TESTS ───
   log.section('4. CREAR REPORTE DE PRUEBA');
 
   // Necesito un token válido. Voy a crear un usuario de prueba
-  let res = await apiRequest('POST', '/api/auth/register', {
+  let res = await apiRequest('POST', '/auth/register', {
     nombre: 'Report',
     apellido: 'Tester',
     email: `reporter-${Date.now()}@example.com`,
@@ -156,24 +156,27 @@ async function runTests() {
 
   if (res.status === 201) {
     // Intentar login con este usuario (usar email del registro)
-    const testEmail = res.data.usuario.email;
+    const testEmail = res.data.data.user.email;
     
-    res = await apiRequest('POST', '/api/auth/login', {
+    res = await apiRequest('POST', '/auth/login', {
       email: testEmail,
       password: 'TestPass123!',
     });
 
     if (res.status === 200) {
-      testToken = res.data.token;
+      testToken = res.data.data.token;
       log.info(`Token obtenido: ${testToken.substring(0, 20)}...`);
 
       // Crear un reporte
-      res = await apiRequest('POST', '/api/reportes', 
+      res = await apiRequest('POST', '/reportes', 
         {
-          id_categoria: 1,
+          tipo_contaminacion: 'agua',
+          nivel_severidad: 'medio',
           titulo: 'Test Report',
           descripcion: 'Test description',
-          ubicacion: 'Test Location',
+          direccion: 'Test Location',
+          municipio: 'Valledupar',
+          departamento: 'Cesar',
           latitud: 10.5,
           longitud: -73.5,
         },
@@ -181,7 +184,7 @@ async function runTests() {
       );
 
       if (res.status === 201) {
-        testReporteId = res.data.reporte.id_reporte;
+        testReporteId = res.data.data.reporte.id_reporte;
         log.info(`Reporte creado: ${testReporteId}`);
       }
     }
@@ -196,11 +199,11 @@ async function runTests() {
       return;
     }
 
-    const res = await apiRequest('GET', '/api/reportes/mis-reportes', null, testToken);
+    const res = await apiRequest('GET', '/reportes/mis-reportes', null, testToken);
     
     assert([200, 401].includes(res.status), `Expected 200 or 401, got ${res.status}`);
     if (res.status === 200) {
-      assert(Array.isArray(res.data.reportes) || res.data.reportes === undefined, 'Reportes debe ser array');
+      assert(Array.isArray(res.data.data?.reportes), 'Reportes debe ser array');
     }
   });
 
@@ -211,14 +214,14 @@ async function runTests() {
     }
 
     // Intentar cambiar estado (lo cual debería estar bloqueado después de pendiente)
-    const res = await apiRequest('PATCH', `/api/reportes/${testReporteId}`,
+    const res = await apiRequest('PATCH', `/reportes/${testReporteId}`,
       { estado: 'en_revision' },
       testToken
     );
 
     // Debería retornar 403 si el reporte ya no está en pendiente
     // O 200 si todavía está en pendiente (es válido cambiar)
-    assert([200, 403].includes(res.status), `Expected 200 or 403, got ${res.status}`);
+    assert([200, 400, 403].includes(res.status), `Expected 200, 400 or 403, got ${res.status}`);
   });
 
   // ─── 6. COMENTARIOS DE MODERACIÓN ───
@@ -231,7 +234,7 @@ async function runTests() {
     }
 
     // Intentar rechazar sin comentario
-    const res = await apiRequest('PATCH', `/api/reportes/${testReporteId}`,
+    const res = await apiRequest('PATCH', `/reportes/${testReporteId}`,
       { estado: 'rechazado' },
       testToken
     );
@@ -244,7 +247,7 @@ async function runTests() {
   log.section('7. ENDPOINTS ADICIONALES');
 
   await test('Health check está disponible', async () => {
-    const res = await apiRequest('GET', '/api/health');
+    const res = await apiRequest('GET', '/health');
     
     assert.strictEqual(res.status, 200, `Expected 200, got ${res.status}`);
     assert(res.data.status, 'Health status disponible');

--- a/tests/unit/backend-route-contract.test.js
+++ b/tests/unit/backend-route-contract.test.js
@@ -1,0 +1,131 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const backendDir = path.resolve(path.dirname(__filename), '../..');
+
+const read = (relativePath) => fs.readFile(path.join(backendDir, relativePath), 'utf8');
+
+const routePattern = ({ router, method, route }) => new RegExp(
+  `${router}\\.${method}\\(\\s*['"\`]${route.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}['"\`]`
+);
+
+test('app monta todos los routers principales sin prefijo interno obligatorio', async () => {
+  const source = await read('src/app.js');
+
+  for (const mount of [
+    '${apiPrefix}/health',
+    '${apiPrefix}/auth',
+    '${apiPrefix}/reportes',
+    '${apiPrefix}/categorias',
+    '${apiPrefix}/admin',
+    '${apiPrefix}/chatbot',
+    '${apiPrefix}/notificaciones',
+  ]) {
+    assert.ok(source.includes(`app.use(\`${mount}\``), mount);
+  }
+});
+
+test('rutas consumidas por el cliente estan declaradas en backend', async () => {
+  const routeFiles = {
+    healthRouter: await read('routes/health.routes.js'),
+    authRouter: await read('routes/auth.routes.js'),
+    categoriaRouter: await read('routes/categoria-riesgo.routes.js'),
+    reporteRouter: await read('routes/reporte.routes.js'),
+    adminRouter: await read('routes/admin.routes.js'),
+    chatbotRouter: await read('routes/chatbot.routes.js'),
+    notificacionRouter: await read('routes/notificacion.routes.js'),
+  };
+
+  const expectedRoutes = [
+    { router: 'healthRouter', method: 'get', route: '/' },
+    { router: 'authRouter', method: 'post', route: '/login' },
+    { router: 'authRouter', method: 'post', route: '/register' },
+    { router: 'authRouter', method: 'post', route: '/google' },
+    { router: 'authRouter', method: 'post', route: '/facebook' },
+    { router: 'authRouter', method: 'get', route: '/perfil' },
+    { router: 'authRouter', method: 'patch', route: '/perfil' },
+    { router: 'authRouter', method: 'patch', route: '/avatar' },
+    { router: 'authRouter', method: 'patch', route: '/cambiar-contrasena' },
+    { router: 'authRouter', method: 'patch', route: '/notificaciones' },
+    { router: 'authRouter', method: 'post', route: '/forgot-password' },
+    { router: 'authRouter', method: 'post', route: '/reset-password' },
+    { router: 'authRouter', method: 'post', route: '/enviar-verificacion' },
+    { router: 'authRouter', method: 'post', route: '/verificar-email' },
+    { router: 'categoriaRouter', method: 'get', route: '/' },
+    { router: 'categoriaRouter', method: 'get', route: '/:codigo' },
+    { router: 'reporteRouter', method: 'get', route: '/stats' },
+    { router: 'reporteRouter', method: 'get', route: '/stats/categoria' },
+    { router: 'reporteRouter', method: 'get', route: '/stats/timeline' },
+    { router: 'reporteRouter', method: 'get', route: '/stats/heatmap' },
+    { router: 'reporteRouter', method: 'get', route: '/stats/ia' },
+    { router: 'reporteRouter', method: 'post', route: '/' },
+    { router: 'reporteRouter', method: 'get', route: '/' },
+    { router: 'reporteRouter', method: 'get', route: '/:id' },
+    { router: 'reporteRouter', method: 'post', route: '/analizar-imagen' },
+    { router: 'reporteRouter', method: 'patch', route: '/:id' },
+    { router: 'reporteRouter', method: 'delete', route: '/:id' },
+    { router: 'reporteRouter', method: 'get', route: '/export' },
+    { router: 'reporteRouter', method: 'post', route: '/:id/like' },
+    { router: 'reporteRouter', method: 'get', route: '/trending' },
+    { router: 'reporteRouter', method: 'get', route: '/zonas-riesgo' },
+    { router: 'reporteRouter', method: 'get', route: '/alertas-predictivas' },
+    { router: 'reporteRouter', method: 'get', route: '/mis-reportes' },
+    { router: 'adminRouter', method: 'get', route: '/usuarios/stats' },
+    { router: 'adminRouter', method: 'get', route: '/usuarios' },
+    { router: 'adminRouter', method: 'get', route: '/usuarios/:id' },
+    { router: 'adminRouter', method: 'patch', route: '/usuarios/:id/rol' },
+    { router: 'adminRouter', method: 'patch', route: '/usuarios/:id/estado' },
+    { router: 'adminRouter', method: 'delete', route: '/usuarios/:id' },
+    { router: 'chatbotRouter', method: 'post', route: '/mensaje' },
+    { router: 'chatbotRouter', method: 'get', route: '/faqs' },
+    { router: 'notificacionRouter', method: 'get', route: '/' },
+    { router: 'notificacionRouter', method: 'get', route: '/contador' },
+    { router: 'notificacionRouter', method: 'post', route: '/fcm-token' },
+    { router: 'notificacionRouter', method: 'patch', route: '/:uuid/leida' },
+    { router: 'notificacionRouter', method: 'patch', route: '/marcar-todas' },
+    { router: 'notificacionRouter', method: 'delete', route: '/:uuid' },
+  ];
+
+  for (const expected of expectedRoutes) {
+    assert.match(
+      routeFiles[expected.router],
+      routePattern(expected),
+      `${expected.router}.${expected.method} ${expected.route}`
+    );
+  }
+});
+
+test('rutas privadas y administrativas declaran middleware de autenticacion y roles', async () => {
+  const adminRoutes = await read('routes/admin.routes.js');
+  const categoriaRoutes = await read('routes/categoria-riesgo.routes.js');
+  const notificacionRoutes = await read('routes/notificacion.routes.js');
+  const reporteRoutes = await read('routes/reporte.routes.js');
+  const authRoutes = await read('routes/auth.routes.js');
+
+  assert.match(adminRoutes, /adminRouter\.use\(verifyToken,\s*requireRoles\('admin'\)\)/);
+  assert.match(notificacionRoutes, /notificacionRouter\.use\(verifyToken\)/);
+
+  assert.match(categoriaRoutes, /categoriaRouter\.post\('\/',\s*verifyToken,\s*requireRoles\('admin'\)/);
+  assert.match(categoriaRoutes, /categoriaRouter\.patch\('\/:codigo',\s*verifyToken,\s*requireRoles\('admin'\)/);
+  assert.match(categoriaRoutes, /categoriaRouter\.patch\('\/:codigo\/estado',\s*verifyToken,\s*requireRoles\('admin'\)/);
+
+  assert.match(reporteRoutes, /reporteRouter\.get\('\/stats\/ia',\s*verifyToken,\s*requireRoles\('admin', 'moderador'\)/);
+  assert.match(reporteRoutes, /reporteRouter\.get\('\/zonas-riesgo',\s*verifyToken,\s*requireRoles\('admin', 'moderador'\)/);
+  assert.match(reporteRoutes, /reporteRouter\.get\('\/export',\s*verifyToken,\s*requireRoles\('admin', 'moderador'\)/);
+  assert.match(reporteRoutes, /reporteRouter\.get\('\/mis-reportes',\s*verifyToken/);
+  assert.match(reporteRoutes, /reporteRouter\.post\('\/analizar-imagen',\s*verifyToken/);
+  assert.match(reporteRoutes, /reporteRouter\.post\('\/:id\/like',[\s\S]*verifyToken/);
+  assert.match(reporteRoutes, /reporteRouter\.patch\('\/:id',[\s\S]*verifyToken/);
+  assert.match(reporteRoutes, /reporteRouter\.delete\('\/:id',[\s\S]*verifyToken/);
+
+  assert.match(authRoutes, /authRouter\.get\('\/perfil',\s*verifyToken/);
+  assert.match(authRoutes, /authRouter\.patch\('\/perfil',\s*verifyToken/);
+  assert.match(authRoutes, /authRouter\.patch\('\/avatar',\s*verifyToken/);
+  assert.match(authRoutes, /authRouter\.patch\('\/notificaciones',\s*verifyToken/);
+  assert.match(authRoutes, /authRouter\.post\('\/enviar-verificacion',\s*authRateLimit,\s*verifyToken/);
+  assert.match(authRoutes, /authRouter\.post\('\/verificar-email',\s*authRateLimit,\s*verifyToken/);
+});

--- a/tests/unit/database-schema.test.js
+++ b/tests/unit/database-schema.test.js
@@ -24,6 +24,7 @@ test('schema completo incluye tablas de soporte requeridas por el backend', asyn
     'reporte_likes',
     'reporte_vistas',
     'notificaciones',
+    'fcm_tokens',
   ]) {
     assert.match(schema, new RegExp(`CREATE TABLE IF NOT EXISTS ${table} \\(`));
   }
@@ -45,6 +46,7 @@ test('schema completo conserva columnas actuales de auth, IA y moderacion', asyn
     'ia_etiquetas JSON NULL',
     'ia_confianza DECIMAL(5, 2) NULL',
     'ia_procesado BOOLEAN DEFAULT FALSE',
+    'token_hash CHAR(64) NOT NULL',
   ]) {
     assert.ok(schema.includes(column), column);
   }

--- a/tests/unit/frontend-api-contract.test.js
+++ b/tests/unit/frontend-api-contract.test.js
@@ -53,6 +53,7 @@ const expectedFrontendContracts = [
   { method: 'get', path: '/chatbot/faqs' },
   { method: 'get', path: '/notificaciones' },
   { method: 'get', path: '/notificaciones/contador' },
+  { method: 'post', path: '/notificaciones/fcm-token' },
   { method: 'patch', path: '/notificaciones/${uuid}/leida' },
   { method: 'patch', path: '/notificaciones/marcar-todas' },
   { method: 'delete', path: '/notificaciones/${uuid}' },

--- a/tests/unit/notificacion.controller.test.js
+++ b/tests/unit/notificacion.controller.test.js
@@ -9,10 +9,13 @@ import {
   listarNotificaciones,
   marcarLeida,
   marcarTodasLeidas,
+  registrarFcmToken,
 } from '../../src/controllers/notificacion.controller.js';
+import { FcmTokenModel } from '../../src/models/fcm-token.model.js';
 import { updateReporte } from '../../src/controllers/reporte.controller.js';
 import { NotificacionModel } from '../../src/models/notificacion.model.js';
 import { ReporteModel } from '../../src/models/reporte.model.js';
+import { UsuarioModel } from '../../src/models/usuario.model.js';
 
 const createResponse = () => ({
   statusCode: null,
@@ -222,6 +225,7 @@ test('sin JWT todas las rutas de notificaciones responden 401', async () => {
     const cases = [
       ['GET', '/notificaciones'],
       ['GET', '/notificaciones/contador'],
+      ['POST', '/notificaciones/fcm-token'],
       ['PATCH', '/notificaciones/marcar-todas'],
       ['PATCH', '/notificaciones/notif-1/leida'],
       ['DELETE', '/notificaciones/notif-1'],
@@ -238,13 +242,71 @@ test('sin JWT todas las rutas de notificaciones responden 401', async () => {
   }
 });
 
+test('registrarFcmToken guarda token asociado al usuario autenticado', async (t) => {
+  t.mock.method(FcmTokenModel, 'registrar', async (payload) => ({
+    id_fcm_token: 12,
+    token_hash: 'hash-token',
+    registrado: true,
+    payload,
+  }));
+
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await registrarFcmToken(
+    {
+      user: { sub: 7 },
+      body: { token: 'fcm-token-valido-1234567890' },
+      headers: { 'user-agent': 'node-test' },
+    },
+    res,
+    next
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.message, 'Token FCM registrado.');
+  assert.equal(FcmTokenModel.registrar.mock.callCount(), 1);
+  assert.deepEqual(FcmTokenModel.registrar.mock.calls[0].arguments[0], {
+    id_usuario: 7,
+    token: 'fcm-token-valido-1234567890',
+    user_agent: 'node-test',
+  });
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('registrarFcmToken rechaza token ausente o invalido antes de guardar', async (t) => {
+  t.mock.method(FcmTokenModel, 'registrar', async () => {
+    throw new Error('No debe guardar tokens invalidos');
+  });
+
+  const cases = [
+    [{}, 'Token FCM requerido.'],
+    [{ token: 'corto' }, 'Token FCM invalido.'],
+    [{ token: 'token con espacios no valido 123456' }, 'Token FCM invalido.'],
+  ];
+
+  for (const [body, message] of cases) {
+    const res = createResponse();
+    await registrarFcmToken(
+      { user: { sub: 7 }, body, headers: {} },
+      res,
+      t.mock.fn()
+    );
+
+    assert.equal(res.statusCode, 400);
+    assert.equal(res.body.message, message);
+  }
+
+  assert.equal(FcmTokenModel.registrar.mock.callCount(), 0);
+});
+
 test('updateReporte genera notificacion al dueno cuando cambia estado o comentario', async (t) => {
   const reportes = [
     {
       id_reporte: 10,
       uuid: 'reporte-uuid',
       id_usuario: 7,
-      estado: 'pendiente',
+      estado: 'en_revision',
       titulo: 'Rio contaminado',
       comentario_moderacion: null,
     },
@@ -260,6 +322,10 @@ test('updateReporte genera notificacion al dueno cuando cambia estado o comentar
 
   t.mock.method(ReporteModel, 'findById', async () => reportes.shift());
   t.mock.method(ReporteModel, 'update', async () => true);
+  t.mock.method(UsuarioModel, 'findByIdWithDetails', async () => ({
+    id_usuario: 7,
+    notification_preferences: { report_updates: true },
+  }));
   t.mock.method(NotificacionModel, 'create', async () => ({ id_notificacion: 1, uuid: 'notif-1' }));
 
   const res = createResponse();
@@ -281,6 +347,55 @@ test('updateReporte genera notificacion al dueno cuando cambia estado o comentar
   assert.equal(NotificacionModel.create.mock.calls[0].arguments[0].id_usuario, 7);
   assert.equal(NotificacionModel.create.mock.calls[0].arguments[0].tipo, 'reporte_estado');
   assert.equal(NotificacionModel.create.mock.calls[1].arguments[0].tipo, 'reporte_comentario');
+});
+
+test('updateReporte respeta preferencia report_updates al crear notificaciones', async (t) => {
+  const reportes = [
+    {
+      id_reporte: 12,
+      uuid: 'reporte-uuid-3',
+      id_usuario: 7,
+      estado: 'en_revision',
+      titulo: 'Humo constante',
+      comentario_moderacion: null,
+    },
+    {
+      id_reporte: 12,
+      uuid: 'reporte-uuid-3',
+      id_usuario: 7,
+      estado: 'verificado',
+      titulo: 'Humo constante',
+      comentario_moderacion: null,
+    },
+  ];
+
+  t.mock.method(ReporteModel, 'findById', async () => reportes.shift());
+  t.mock.method(ReporteModel, 'update', async () => true);
+  t.mock.method(UsuarioModel, 'findByIdWithDetails', async () => ({
+    id_usuario: 7,
+    notification_preferences: { report_updates: false },
+  }));
+  t.mock.method(NotificacionModel, 'create', async () => {
+    throw new Error('No debe crear notificacion con report_updates desactivado');
+  });
+
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await updateReporte(
+    {
+      params: { id: '12' },
+      user: { sub: 99, rol: 'moderador' },
+      body: { estado: 'verificado' },
+    },
+    res,
+    next
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(UsuarioModel.findByIdWithDetails.mock.callCount(), 1);
+  assert.equal(NotificacionModel.create.mock.callCount(), 0);
+  assert.equal(next.mock.callCount(), 0);
 });
 
 test('fallo al crear notificacion no rompe updateReporte', async (t) => {
@@ -305,6 +420,10 @@ test('fallo al crear notificacion no rompe updateReporte', async (t) => {
 
   t.mock.method(ReporteModel, 'findById', async () => reportes.shift());
   t.mock.method(ReporteModel, 'update', async () => true);
+  t.mock.method(UsuarioModel, 'findByIdWithDetails', async () => ({
+    id_usuario: 7,
+    notification_preferences: { report_updates: true },
+  }));
   t.mock.method(NotificacionModel, 'create', async () => {
     throw new Error('tabla no disponible');
   });

--- a/tests/unit/prediccion-service.test.js
+++ b/tests/unit/prediccion-service.test.js
@@ -1,5 +1,8 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
   calcularAlertasPredictivas,
   calcularZonasRiesgo,
@@ -9,6 +12,9 @@ import {
   parseZonasParams,
 } from '../../src/services/prediccion.service.js';
 import { ReporteModel } from '../../src/models/reporte.model.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const backendDir = path.resolve(path.dirname(__filename), '../..');
 
 const reportesBase = [
   {
@@ -126,4 +132,41 @@ test('parseAlertasParams valida parametros geograficos y nivel', () => {
     () => parseZonasParams({ min_score: '101' }),
     /min_score debe ser un numero entre 0 y 100/
   );
+  assert.throws(
+    () => parseAlertasParams({ lat: '10.4' }),
+    /lat y lng deben enviarse juntos/
+  );
+  assert.throws(
+    () => parseAlertasParams({ radio_km: '20' }),
+    /radio_km requiere lat y lng/
+  );
+});
+
+test('ReporteModel.findParaPrediccion solo usa reportes moderados con ubicacion', async () => {
+  const source = await fs.readFile(
+    path.join(backendDir, 'src/models/reporte.model.js'),
+    'utf8'
+  );
+  const start = source.indexOf('findParaPrediccion: async');
+  const end = source.indexOf('findTrending: async', start);
+  const section = source.slice(start, end);
+
+  assert.match(section, /r\.deleted_at IS NULL/);
+  assert.match(section, /r\.latitud IS NOT NULL/);
+  assert.match(section, /r\.longitud IS NOT NULL/);
+  assert.match(section, /r\.estado IN \('verificado', 'en_proceso', 'resuelto'\)/);
+  assert.match(section, /r\.created_at >= \?/);
+  assert.match(section, /r\.tipo_contaminacion = \?/);
+});
+
+test('documentacion de prediccion conserva formula y estados admitidos', async () => {
+  const docs = await fs.readFile(
+    path.join(backendDir, 'docs/PREDICCION_ZONAS_RIESGO.md'),
+    'utf8'
+  );
+
+  assert.match(docs, /cantidad_reportes \* 16/);
+  assert.match(docs, /severidad_promedio \* 14/);
+  assert.match(docs, /recencia_promedio/);
+  assert.match(docs, /'verificado', 'en_proceso', 'resuelto'/);
 });

--- a/tests/unit/reporte-enum-validacion.test.js
+++ b/tests/unit/reporte-enum-validacion.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { updateReporte } from '../../src/controllers/reporte.controller.js';
 import { NotificacionModel } from '../../src/models/notificacion.model.js';
 import { ReporteModel } from '../../src/models/reporte.model.js';
+import { UsuarioModel } from '../../src/models/usuario.model.js';
 
 const createResponse = () => ({
   statusCode: null,
@@ -30,6 +31,10 @@ test('updateReporte acepta estado y nivel_severidad validos normalizados', async
     estado: 'pendiente',
   }));
   t.mock.method(ReporteModel, 'update', async () => true);
+  t.mock.method(UsuarioModel, 'findByIdWithDetails', async () => ({
+    id_usuario: 7,
+    notification_preferences: { report_updates: true },
+  }));
   t.mock.method(NotificacionModel, 'create', async () => ({ id_notificacion: 1, uuid: 'notif-1' }));
 
   const req = createModeratorRequest({
@@ -69,6 +74,63 @@ test('updateReporte rechaza estado invalido antes de actualizar', async (t) => {
   assert.equal(res.statusCode, 400);
   assert.equal(res.body.message, 'El estado debe ser uno de: pendiente, en_revision, verificado, en_proceso, rechazado, resuelto.');
   assert.equal(ReporteModel.update.mock.callCount(), 0);
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('updateReporte rechaza transicion de estado no permitida antes de actualizar', async (t) => {
+  t.mock.method(ReporteModel, 'findById', async () => ({
+    id_reporte: 15,
+    id_usuario: 7,
+    estado: 'pendiente',
+  }));
+  t.mock.method(ReporteModel, 'update', async () => {
+    throw new Error('No debe actualizar reportes con transicion invalida');
+  });
+
+  const req = createModeratorRequest({ estado: 'verificado' });
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await updateReporte(req, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.message, 'Transicion de estado no permitida: pendiente -> verificado.');
+  assert.equal(ReporteModel.update.mock.callCount(), 0);
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('updateReporte permite transicion valida entre estados de moderacion', async (t) => {
+  const reportes = [
+    {
+      id_reporte: 15,
+      id_usuario: 7,
+      estado: 'en_revision',
+    },
+    {
+      id_reporte: 15,
+      id_usuario: 7,
+      estado: 'verificado',
+    },
+  ];
+  t.mock.method(ReporteModel, 'findById', async () => reportes.shift());
+  t.mock.method(ReporteModel, 'update', async () => true);
+  t.mock.method(UsuarioModel, 'findByIdWithDetails', async () => ({
+    id_usuario: 7,
+    notification_preferences: { report_updates: true },
+  }));
+  t.mock.method(NotificacionModel, 'create', async () => ({ id_notificacion: 1, uuid: 'notif-1' }));
+
+  const req = createModeratorRequest({ estado: 'verificado' });
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await updateReporte(req, res, next);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(ReporteModel.update.mock.callCount(), 1);
+  assert.deepEqual(ReporteModel.update.mock.calls[0].arguments[1], {
+    estado: 'verificado',
+  });
   assert.equal(next.mock.callCount(), 0);
 });
 


### PR DESCRIPTION
# Closes #219 #220 #221 #222 #223 

## Descripción:
Se reforzó la lógica backend principal de Green Alert:

- Se implementó la máquina de estados de reportes en backend, evitando transiciones inválidas.
- Se agregó soporte para registrar tokens FCM con endpoint `POST /notificaciones/fcm-token`.
- Se creó la migración y modelo para almacenar tokens FCM por usuario.
- Se fortalecieron las notificaciones in-app, respetando preferencias del usuario.
- Se documentó y validó la lógica predictiva de zonas de riesgo.
- Se reforzaron validaciones para alertas predictivas con ubicación y radio.
- Se agregó cobertura de contrato para rutas backend, middlewares de autenticación y roles.
- Se actualizaron y agregaron pruebas unitarias.

Validación final: `npm run test:unit` pasó correctamente con `125` tests:

<img width="803" height="915" alt="image" src="https://github.com/user-attachments/assets/e03d49a0-8976-43d8-8cb9-3417b9298b94" />
