### PR TITLE
Issue 225: Agregar asignación automática de reportes a entidades

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   backend-validation:
@@ -18,21 +21,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
- 
-
-      - name: Cache npm
-        uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json', 'package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-npm-
- 
           cache: npm
- 
+          cache-dependency-path: package-lock.json
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Validate JavaScript syntax
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,8 @@ coverage/
 *.pem
 .cache/
 .output/
+repomix-output.xml
+repomix-output.*
 
 # Directorio temporal
 tmp/

--- a/DATABASE_SCHEMA_COMPLETE.sql
+++ b/DATABASE_SCHEMA_COMPLETE.sql
@@ -12,9 +12,27 @@
 -- DROP TABLE IF EXISTS reporte_likes;
 -- DROP TABLE IF EXISTS refresh_tokens;
 -- DROP TABLE IF EXISTS evidencias;
+-- DROP TABLE IF EXISTS reporte_entidades;
 -- DROP TABLE IF EXISTS reportes;
 -- DROP TABLE IF EXISTS categorias_riesgo;
 -- DROP TABLE IF EXISTS usuarios;
+-- DROP TABLE IF EXISTS entidades;
+
+-- ============================================================================
+-- TABLE: entidades
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS entidades (
+  id_entidad INT AUTO_INCREMENT PRIMARY KEY,
+  nombre VARCHAR(120) NOT NULL,
+  codigo VARCHAR(60) NOT NULL UNIQUE,
+  descripcion TEXT NULL,
+  activo BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+
+  INDEX idx_entidades_codigo (codigo),
+  INDEX idx_entidades_activo (activo)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- ============================================================================
 -- TABLE: usuarios
@@ -28,7 +46,8 @@ CREATE TABLE IF NOT EXISTS usuarios (
   apellido VARCHAR(100) NOT NULL,
   email VARCHAR(100) NOT NULL UNIQUE,
   password_hash VARCHAR(255) NULL,
-  rol ENUM('ciudadano', 'moderador', 'admin') DEFAULT 'ciudadano',
+  rol ENUM('ciudadano', 'moderador', 'admin', 'entidad') DEFAULT 'ciudadano',
+  id_entidad INT NULL,
   activo BOOLEAN DEFAULT TRUE,
   email_verificado BOOLEAN DEFAULT FALSE,
   avatar_url VARCHAR(255) NULL,
@@ -57,7 +76,10 @@ CREATE TABLE IF NOT EXISTS usuarios (
   INDEX idx_otp_code_hash (otp_code_hash),
   INDEX idx_otp_exp (otp_exp),
   INDEX idx_deleted_at (deleted_at),
-  INDEX idx_rol (rol)
+  INDEX idx_rol (rol),
+  INDEX idx_usuarios_id_entidad (id_entidad),
+  CONSTRAINT fk_usuarios_entidad FOREIGN KEY (id_entidad)
+    REFERENCES entidades(id_entidad) ON DELETE SET NULL ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- ============================================================================
@@ -129,6 +151,34 @@ CREATE TABLE IF NOT EXISTS reportes (
   INDEX idx_reportes_tipo_created_at (tipo_contaminacion, created_at),
   INDEX idx_reportes_latitud_longitud (latitud, longitud),
   SPATIAL INDEX idx_punto_geo (punto_geo)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ============================================================================
+-- TABLE: reporte_entidades
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS reporte_entidades (
+  id_reporte_entidad BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  id_reporte BIGINT UNSIGNED NOT NULL,
+  id_entidad INT NOT NULL,
+  tipo_asignacion ENUM('principal', 'apoyo') NOT NULL DEFAULT 'principal',
+  prioridad ENUM('baja', 'media', 'alta', 'critica') NOT NULL DEFAULT 'media',
+  estado_atencion ENUM('pendiente', 'en_atencion', 'atendido', 'cerrado') NOT NULL DEFAULT 'pendiente',
+  comentario TEXT NULL,
+  asignado_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  actualizado_at TIMESTAMP NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+
+  CONSTRAINT fk_reporte_entidades_reporte FOREIGN KEY (id_reporte)
+    REFERENCES reportes(id_reporte) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT fk_reporte_entidades_entidad FOREIGN KEY (id_entidad)
+    REFERENCES entidades(id_entidad) ON DELETE CASCADE ON UPDATE CASCADE,
+
+  UNIQUE KEY unique_reporte_entidad (id_reporte, id_entidad),
+  INDEX idx_reporte_entidades_reporte (id_reporte),
+  INDEX idx_reporte_entidades_entidad (id_entidad),
+  INDEX idx_reporte_entidades_tipo (tipo_asignacion),
+  INDEX idx_reporte_entidades_prioridad (prioridad),
+  INDEX idx_reporte_entidades_estado_atencion (estado_atencion),
+  INDEX idx_reporte_entidades_asignado_at (asignado_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- ============================================================================
@@ -236,7 +286,7 @@ CREATE TABLE IF NOT EXISTS notificaciones (
   id_notificacion BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   uuid VARCHAR(36) UNIQUE NOT NULL,
   id_usuario BIGINT UNSIGNED NOT NULL,
-  tipo ENUM('reporte_estado', 'reporte_comentario', 'reporte_creado', 'alerta_zona', 'sistema') NOT NULL,
+  tipo ENUM('reporte_estado', 'reporte_comentario', 'reporte_creado', 'reporte_asignado_entidad', 'alerta_zona', 'sistema') NOT NULL,
   titulo VARCHAR(150) NOT NULL,
   mensaje TEXT NOT NULL,
   referencia_tipo VARCHAR(30) NULL,
@@ -314,6 +364,15 @@ GROUP BY r.id_reporte, r.uuid, r.titulo, r.estado, r.municipio;
 -- ============================================================================
 -- SEED DATA (Sample categories)
 -- ============================================================================
+
+INSERT IGNORE INTO entidades
+(nombre, codigo, descripcion)
+VALUES
+('Bomberos', 'bomberos', 'Entidad encargada de la atencion de incendios, quemas activas, emergencias, explosiones, derrames peligrosos y materiales inflamables.'),
+('Corpoamazonia', 'corpoamazonia', 'Autoridad ambiental regional encargada de contaminacion ambiental, vertimientos, tala ilegal, deforestacion, fauna, flora, mineria ilegal y afectaciones a ecosistemas.'),
+('Gestion del Riesgo', 'gestion_riesgo', 'Entidad encargada de amenazas, emergencias, desastres naturales, avalanchas, deslizamientos, inundaciones, crecientes subitas, derrames graves y eventos criticos.'),
+('Secretaria de Salud', 'secretaria_salud', 'Entidad encargada de riesgos sanitarios, basuras con afectacion a la salud publica, aguas residuales, malos olores, residuos hospitalarios y proliferacion de vectores.'),
+('Alcaldia / Servicios Publicos', 'alcaldia_servicios_publicos', 'Entidad encargada de la atencion operativa de residuos urbanos, basura en via publica, escombros, alcantarillado, espacio publico y mantenimiento municipal.');
 
 INSERT IGNORE INTO categorias_riesgo 
 (id_categoria, codigo, nombre, descripcion, icono, color_hex, nivel_prioridad_default, activo) 

--- a/migrations/014_create_entidades_and_reporte_entidades.sql
+++ b/migrations/014_create_entidades_and_reporte_entidades.sql
@@ -1,0 +1,146 @@
+USE `green-alert`;
+
+CREATE TABLE IF NOT EXISTS entidades (
+  id_entidad INT AUTO_INCREMENT PRIMARY KEY,
+  nombre VARCHAR(120) NOT NULL,
+  codigo VARCHAR(60) NOT NULL UNIQUE,
+  descripcion TEXT NULL,
+  activo BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+  INDEX idx_entidades_codigo (codigo),
+  INDEX idx_entidades_activo (activo)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+INSERT INTO entidades (nombre, codigo, descripcion)
+VALUES
+(
+  'Bomberos',
+  'bomberos',
+  'Entidad encargada de la atencion de incendios, quemas activas, emergencias, explosiones, derrames peligrosos y materiales inflamables.'
+),
+(
+  'Corpoamazonia',
+  'corpoamazonia',
+  'Autoridad ambiental regional encargada de contaminacion ambiental, vertimientos, tala ilegal, deforestacion, fauna, flora, mineria ilegal y afectaciones a ecosistemas.'
+),
+(
+  'Gestion del Riesgo',
+  'gestion_riesgo',
+  'Entidad encargada de amenazas, emergencias, desastres naturales, avalanchas, deslizamientos, inundaciones, crecientes subitas, derrames graves y eventos criticos.'
+),
+(
+  'Secretaria de Salud',
+  'secretaria_salud',
+  'Entidad encargada de riesgos sanitarios, basuras con afectacion a la salud publica, aguas residuales, malos olores, residuos hospitalarios y proliferacion de vectores.'
+),
+(
+  'Alcaldia / Servicios Publicos',
+  'alcaldia_servicios_publicos',
+  'Entidad encargada de la atencion operativa de residuos urbanos, basura en via publica, escombros, alcantarillado, espacio publico y mantenimiento municipal.'
+)
+ON DUPLICATE KEY UPDATE
+  nombre = VALUES(nombre),
+  descripcion = VALUES(descripcion),
+  activo = TRUE,
+  updated_at = CURRENT_TIMESTAMP;
+
+SET @has_id_entidad = (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'usuarios'
+    AND COLUMN_NAME = 'id_entidad'
+);
+SET @sql = IF(
+  @has_id_entidad = 0,
+  'ALTER TABLE usuarios ADD COLUMN id_entidad INT NULL AFTER rol',
+  'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+ALTER TABLE usuarios
+  MODIFY rol ENUM('ciudadano', 'moderador', 'admin', 'entidad')
+  NOT NULL DEFAULT 'ciudadano';
+
+SET @has_idx_usuarios_entidad = (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'usuarios'
+    AND INDEX_NAME = 'idx_usuarios_id_entidad'
+);
+SET @sql = IF(
+  @has_idx_usuarios_entidad = 0,
+  'CREATE INDEX idx_usuarios_id_entidad ON usuarios(id_entidad)',
+  'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_fk_usuarios_entidad = (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
+  WHERE CONSTRAINT_SCHEMA = DATABASE()
+    AND CONSTRAINT_NAME = 'fk_usuarios_entidad'
+);
+SET @sql = IF(
+  @has_fk_usuarios_entidad = 0,
+  'ALTER TABLE usuarios ADD CONSTRAINT fk_usuarios_entidad FOREIGN KEY (id_entidad) REFERENCES entidades(id_entidad) ON DELETE SET NULL ON UPDATE CASCADE',
+  'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+CREATE TABLE IF NOT EXISTS reporte_entidades (
+  id_reporte_entidad BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  id_reporte BIGINT UNSIGNED NOT NULL,
+  id_entidad INT NOT NULL,
+
+  tipo_asignacion ENUM('principal', 'apoyo') NOT NULL DEFAULT 'principal',
+
+  prioridad ENUM('baja', 'media', 'alta', 'critica') NOT NULL DEFAULT 'media',
+
+  estado_atencion ENUM('pendiente', 'en_atencion', 'atendido', 'cerrado')
+    NOT NULL DEFAULT 'pendiente',
+
+  comentario TEXT NULL,
+
+  asignado_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  actualizado_at TIMESTAMP NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+
+  CONSTRAINT fk_reporte_entidades_reporte
+    FOREIGN KEY (id_reporte)
+    REFERENCES reportes(id_reporte)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE,
+
+  CONSTRAINT fk_reporte_entidades_entidad
+    FOREIGN KEY (id_entidad)
+    REFERENCES entidades(id_entidad)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE,
+
+  UNIQUE KEY unique_reporte_entidad (id_reporte, id_entidad),
+
+  INDEX idx_reporte_entidades_reporte (id_reporte),
+  INDEX idx_reporte_entidades_entidad (id_entidad),
+  INDEX idx_reporte_entidades_tipo (tipo_asignacion),
+  INDEX idx_reporte_entidades_prioridad (prioridad),
+  INDEX idx_reporte_entidades_estado_atencion (estado_atencion),
+  INDEX idx_reporte_entidades_asignado_at (asignado_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+ALTER TABLE notificaciones
+  MODIFY tipo ENUM(
+    'reporte_estado',
+    'reporte_comentario',
+    'reporte_creado',
+    'reporte_asignado_entidad',
+    'alerta_zona',
+    'sistema'
+  ) NOT NULL;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "nodemon src/server.js",
     "start": "node src/server.js",
     "test": "npm run test:unit",
-    "test:unit": "node --test tests/unit/*.test.js",
+    "test:unit": "node --test --test-concurrency=1 tests/unit/*.test.js",
     "test:legacy": "node tests/run-all.js",
     "test:email": "node tests/email/smtp-send.test.js"
   },

--- a/routes/entidad.routes.js
+++ b/routes/entidad.routes.js
@@ -1,0 +1,30 @@
+import { Router } from 'express';
+import { verifyToken, requireRoles } from '../middlewares/auth.middleware.js';
+import { validatePositiveIdParam } from '../middlewares/validate-id.middleware.js';
+import {
+  actualizarAtencionMiEntidad,
+  listarEntidades,
+  listarMisReportesEntidad,
+  obtenerMiReporteEntidad,
+} from '../src/controllers/entidad.controller.js';
+
+const entidadRouter = Router();
+
+entidadRouter.get('/', verifyToken, requireRoles('admin', 'moderador', 'entidad'), listarEntidades);
+entidadRouter.get('/mis-reportes', verifyToken, requireRoles('entidad'), listarMisReportesEntidad);
+entidadRouter.get(
+  '/mis-reportes/:id',
+  validatePositiveIdParam('id'),
+  verifyToken,
+  requireRoles('entidad'),
+  obtenerMiReporteEntidad
+);
+entidadRouter.patch(
+  '/mis-reportes/:id/atencion',
+  validatePositiveIdParam('id'),
+  verifyToken,
+  requireRoles('entidad'),
+  actualizarAtencionMiEntidad
+);
+
+export default entidadRouter;

--- a/src/app.js
+++ b/src/app.js
@@ -9,6 +9,7 @@ import categoriaRouter from '../routes/categoria-riesgo.routes.js';
 import adminRouter from '../routes/admin.routes.js';
 import chatbotRouter from '../routes/chatbot.routes.js';
 import notificacionRouter from '../routes/notificacion.routes.js';
+import entidadRouter from '../routes/entidad.routes.js';
 import { getCorsOptions, getHelmetOptions } from './config/security.config.js';
 import { getUploadDir } from './config/upload.config.js';
 import { getApiPrefix } from './config/api-prefix.config.js';
@@ -33,6 +34,7 @@ app.use(`${apiPrefix}/categorias`, categoriaRouter);
 app.use(`${apiPrefix}/admin`, adminRouter);
 app.use(`${apiPrefix}/chatbot`, chatbotRouter);
 app.use(`${apiPrefix}/notificaciones`, notificacionRouter);
+app.use(`${apiPrefix}/entidades`, entidadRouter);
 
  
 app.use(notFoundHandler);

--- a/src/controllers/admin.controller.js
+++ b/src/controllers/admin.controller.js
@@ -1,8 +1,9 @@
 import { UsuarioModel } from '../models/usuario.model.js';
 import { ReporteModel } from '../models/reporte.model.js';
+import { EntidadModel } from '../models/entidad.model.js';
 import { errorResponse, successResponse } from '../utils/response.js';
 
-const VALID_ROLES = ['ciudadano', 'moderador', 'admin'];
+const VALID_ROLES = ['ciudadano', 'moderador', 'admin', 'entidad'];
 
 const parseLimit = (value, fallback) => {
   const parsed = Number(value);
@@ -102,7 +103,7 @@ export const obtenerUsuario = async (req, res, next) => {
 export const cambiarRol = async (req, res, next) => {
   try {
     const id_usuario = Number(req.params.id);
-    const { rol } = req.body ?? {};
+    const { rol, id_entidad } = req.body ?? {};
     const currentUserId = req.user?.sub;
 
     if (!id_usuario) {
@@ -117,7 +118,20 @@ export const cambiarRol = async (req, res, next) => {
       return errorResponse(res, 'No puedes cambiar tu propio rol.', 403);
     }
 
-    const usuario = await UsuarioModel.updateRol(id_usuario, rol);
+    let entidadId = null;
+    if (rol === 'entidad') {
+      entidadId = Number(id_entidad);
+      if (!entidadId) {
+        return errorResponse(res, 'id_entidad es obligatorio para usuarios entidad.', 400);
+      }
+
+      const entidad = await EntidadModel.findById(entidadId);
+      if (!entidad || !entidad.activo) {
+        return errorResponse(res, 'La entidad no existe o esta inactiva.', 400);
+      }
+    }
+
+    const usuario = await UsuarioModel.updateRol(id_usuario, rol, entidadId);
     if (!usuario) {
       return errorResponse(res, 'Usuario no encontrado.', 404);
     }

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -74,6 +74,7 @@ const validateGeneratedToken = (token, secret, user) => {
     Number(decoded.sub) !== Number(user.id_usuario) ||
     decoded.email !== user.email ||
     decoded.rol !== user.rol ||
+    (user.id_entidad && Number(decoded.id_entidad) !== Number(user.id_entidad)) ||
     (user.uuid && decoded.uuid !== user.uuid)
   ) {
     const error = new Error('JWT generado no coincide con el usuario autenticado');
@@ -93,6 +94,7 @@ const buildToken = (user) => {
       sub: user.id_usuario,
       uuid: user.uuid,
       rol: user.rol,
+      id_entidad: user.id_entidad ?? null,
       email: user.email,
     },
     secret,
@@ -161,6 +163,7 @@ const toPublicUser = (user) => ({
   apellido: user.apellido,
   email: user.email,
   rol: user.rol,
+  id_entidad: user.id_entidad ?? null,
   activo: user.activo,
   email_verificado: user.email_verificado,
   avatar_url: user.avatar_url,

--- a/src/controllers/entidad.controller.js
+++ b/src/controllers/entidad.controller.js
@@ -1,0 +1,112 @@
+import { EntidadModel } from '../models/entidad.model.js';
+import { EvidenciaModel } from '../models/evidencia.model.js';
+import { ReporteEntidadModel } from '../models/reporte-entidad.model.js';
+import { errorResponse, successResponse } from '../utils/response.js';
+
+const getEntidadIdFromUser = (req) => Number(req.user?.id_entidad);
+
+export const listarEntidades = async (_req, res, next) => {
+  try {
+    const entidades = await EntidadModel.findActive();
+    return successResponse(
+      res,
+      { entidades, total: entidades.length },
+      'Entidades obtenidas correctamente.'
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const listarMisReportesEntidad = async (req, res, next) => {
+  try {
+    const idEntidad = getEntidadIdFromUser(req);
+    if (!idEntidad) {
+      return errorResponse(res, 'Usuario entidad sin entidad asignada.', 403);
+    }
+
+    const data = await ReporteEntidadModel.findByEntidad(idEntidad, {
+      prioridad: req.query?.prioridad,
+      estado_atencion: req.query?.estado_atencion,
+      tipo_asignacion: req.query?.tipo_asignacion,
+      categoria: req.query?.categoria,
+      severidad: req.query?.severidad,
+      limit: req.query?.limit,
+      offset: req.query?.offset,
+    });
+
+    return successResponse(res, data, 'Reportes asignados obtenidos correctamente.');
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const obtenerMiReporteEntidad = async (req, res, next) => {
+  try {
+    const idEntidad = getEntidadIdFromUser(req);
+    const idReporte = Number(req.params.id);
+
+    if (!idEntidad) {
+      return errorResponse(res, 'Usuario entidad sin entidad asignada.', 403);
+    }
+    if (!idReporte) {
+      return errorResponse(res, 'Id de reporte invalido.', 400);
+    }
+
+    const reporte = await ReporteEntidadModel.findReporteAsignadoByEntidad(idReporte, idEntidad);
+    if (!reporte) {
+      return errorResponse(res, 'Reporte asignado no encontrado.', 404);
+    }
+
+    const evidencias = await EvidenciaModel.findByReporte(idReporte);
+    return successResponse(
+      res,
+      { reporte, evidencias },
+      'Reporte asignado obtenido correctamente.'
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const actualizarAtencionMiEntidad = async (req, res, next) => {
+  try {
+    const idEntidad = getEntidadIdFromUser(req);
+    const idReporte = Number(req.params.id);
+    const { estado_atencion, comentario = null } = req.body ?? {};
+
+    if (!idEntidad) {
+      return errorResponse(res, 'Usuario entidad sin entidad asignada.', 403);
+    }
+    if (!idReporte) {
+      return errorResponse(res, 'Id de reporte invalido.', 400);
+    }
+    if (!ReporteEntidadModel.ESTADOS_ATENCION.includes(estado_atencion)) {
+      return errorResponse(
+        res,
+        `estado_atencion debe ser uno de: ${ReporteEntidadModel.ESTADOS_ATENCION.join(', ')}.`,
+        400
+      );
+    }
+
+    const asignacion = await ReporteEntidadModel.findOneByReporteAndEntidad(idReporte, idEntidad);
+    if (!asignacion) {
+      return errorResponse(res, 'Reporte asignado no encontrado.', 404);
+    }
+
+    await ReporteEntidadModel.updateEstadoAtencion(
+      asignacion.id_reporte_entidad,
+      estado_atencion,
+      typeof comentario === 'string' ? comentario.trim() || null : null
+    );
+
+    const reporte = await ReporteEntidadModel.findReporteAsignadoByEntidad(idReporte, idEntidad);
+    return successResponse(
+      res,
+      { reporte },
+      'Estado de atencion actualizado correctamente.'
+    );
+  } catch (error) {
+    return next(error);
+  }
+};

--- a/src/controllers/reporte.controller.js
+++ b/src/controllers/reporte.controller.js
@@ -9,9 +9,11 @@ import { CategoriaRiesgoModel } from '../models/categoria-riesgo.model.js';
 import { UsuarioModel }   from '../models/usuario.model.js';
 import { EvidenciaModel } from '../models/evidencia.model.js';
 import { LikeModel } from '../models/like.model.js';
+import { ReporteEntidadModel } from '../models/reporte-entidad.model.js';
 import { analyzeReporte } from '../services/ia.service.js';
 import { clasificarImagen } from '../services/clasificacion.service.js';
 import { invalidatePrediccionCache } from '../services/prediccion.service.js';
+import { AsignacionEntidadesService } from '../services/asignacion-entidades.service.js';
 import { errorResponse, successResponse } from '../utils/response.js';
 import { crearNotificacion } from './notificacion.controller.js';
 
@@ -342,6 +344,12 @@ export const createReporte = async (req, res, next) => {
       });
     }
 
+    try {
+      await AsignacionEntidadesService.asignarEntidadesAReporte(reporte);
+    } catch (error) {
+      console.error('[asignacion-entidades] no se pudo asignar reporte:', error.message);
+    }
+
     invalidatePrediccionCache();
     return successResponse(res, { reporte }, 'Reporte creado correctamente.', 201);
   } catch (error) {
@@ -352,6 +360,27 @@ export const createReporte = async (req, res, next) => {
 export const getReportes = async (req, res, next) => {
   try {
     const { estado, tipo_contaminacion, nivel_severidad, municipio, limit = 20, offset = 0 } = req.query;
+
+    if (req.user?.rol === 'entidad') {
+      if (!req.user.id_entidad) {
+        return errorResponse(res, 'Usuario entidad sin entidad asignada.', 403);
+      }
+
+      const data = await ReporteEntidadModel.findByEntidad(req.user.id_entidad, {
+        categoria: tipo_contaminacion,
+        severidad: nivel_severidad,
+        limit,
+        offset,
+      });
+
+      return successResponse(res, {
+        reportes: data.reportes,
+        total: data.total,
+        limit: data.limit,
+        offset: data.offset,
+      });
+    }
+
     const filters = {
       estado, tipo_contaminacion, nivel_severidad, municipio,
       limit: Number(limit),
@@ -798,6 +827,17 @@ export const deleteReporte = async (req, res, next) => {
 export const getReporteById = async (req, res, next) => {
   try {
     const id = Number(req.params.id);
+    if (req.user?.rol === 'entidad') {
+      if (!req.user.id_entidad) {
+        return errorResponse(res, 'Usuario entidad sin entidad asignada.', 403);
+      }
+
+      const asignado = await ReporteEntidadModel.findOneByReporteAndEntidad(id, req.user.id_entidad);
+      if (!asignado) {
+        return errorResponse(res, 'No tienes permiso para ver este reporte.', 403);
+      }
+    }
+
     const reporte = await ReporteModel.findById(id);
     if (!reporte) return errorResponse(res, 'Reporte no encontrado.', 404);
     await registerReporteView(req, id);

--- a/src/models/entidad.model.js
+++ b/src/models/entidad.model.js
@@ -1,0 +1,68 @@
+import pool from '../config/database.js';
+
+export const EntidadModel = {
+  findAll: async ({ activas } = {}) => {
+    const conditions = [];
+    const params = [];
+
+    if (activas === true) {
+      conditions.push('activo = 1');
+    } else if (activas === false) {
+      conditions.push('activo = 0');
+    }
+
+    const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+    const [rows] = await pool.execute(
+      `SELECT id_entidad, nombre, codigo, descripcion, activo, created_at, updated_at
+       FROM entidades
+       ${where}
+       ORDER BY nombre ASC`,
+      params
+    );
+
+    return rows;
+  },
+
+  findActive: async () => EntidadModel.findAll({ activas: true }),
+
+  findById: async (id_entidad) => {
+    const [rows] = await pool.execute(
+      `SELECT id_entidad, nombre, codigo, descripcion, activo, created_at, updated_at
+       FROM entidades
+       WHERE id_entidad = ?
+       LIMIT 1`,
+      [id_entidad]
+    );
+
+    return rows[0] ?? null;
+  },
+
+  findByCodigo: async (codigo) => {
+    const [rows] = await pool.execute(
+      `SELECT id_entidad, nombre, codigo, descripcion, activo, created_at, updated_at
+       FROM entidades
+       WHERE codigo = ?
+       LIMIT 1`,
+      [codigo]
+    );
+
+    return rows[0] ?? null;
+  },
+
+  findManyByCodigos: async (codigos = []) => {
+    const uniqueCodigos = [...new Set(codigos.filter(Boolean))];
+    if (uniqueCodigos.length === 0) return [];
+
+    const placeholders = uniqueCodigos.map(() => '?').join(', ');
+    const [rows] = await pool.execute(
+      `SELECT id_entidad, nombre, codigo, descripcion, activo
+       FROM entidades
+       WHERE activo = 1 AND codigo IN (${placeholders})`,
+      uniqueCodigos
+    );
+
+    return rows;
+  },
+};
+
+export default EntidadModel;

--- a/src/models/notificacion.model.js
+++ b/src/models/notificacion.model.js
@@ -12,21 +12,38 @@ export const NotificacionModel = {
     link = null,
   }) => {
     const uuid = randomUUID();
-    const [result] = await pool.execute(
-      `INSERT INTO notificaciones
-         (uuid, id_usuario, tipo, titulo, mensaje, referencia_tipo, referencia_uuid, link)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-      [
-        uuid,
-        id_usuario,
-        tipo,
-        titulo,
-        mensaje,
-        referencia_tipo,
-        referencia_uuid,
-        link,
-      ]
-    );
+    const params = [
+      uuid,
+      id_usuario,
+      tipo,
+      titulo,
+      mensaje,
+      referencia_tipo,
+      referencia_uuid,
+      link,
+    ];
+    let result;
+
+    try {
+      [result] = await pool.execute(
+        `INSERT INTO notificaciones
+           (uuid, id_usuario, tipo, titulo, mensaje, referencia_tipo, referencia_uuid, link)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        params
+      );
+    } catch (error) {
+      if (tipo === 'reporte_asignado_entidad') {
+        params[2] = 'sistema';
+        [result] = await pool.execute(
+          `INSERT INTO notificaciones
+             (uuid, id_usuario, tipo, titulo, mensaje, referencia_tipo, referencia_uuid, link)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+          params
+        );
+      } else {
+        throw error;
+      }
+    }
 
     return { id_notificacion: result.insertId, uuid };
   },

--- a/src/models/reporte-entidad.model.js
+++ b/src/models/reporte-entidad.model.js
@@ -1,0 +1,238 @@
+import pool from '../config/database.js';
+
+const ESTADOS_ATENCION = ['pendiente', 'en_atencion', 'atendido', 'cerrado'];
+
+const parseLimit = (value, fallback = 20) => {
+  const parsed = parseInt(value, 10);
+  return Math.max(1, Math.min(100, Number.isInteger(parsed) ? parsed : fallback));
+};
+
+const parseOffset = (value, fallback = 0) => {
+  const parsed = parseInt(value, 10);
+  return Math.max(0, Number.isInteger(parsed) ? parsed : fallback);
+};
+
+const buildEntidadReportesFilter = ({
+  id_entidad,
+  prioridad,
+  estado_atencion,
+  tipo_asignacion,
+  categoria,
+  severidad,
+} = {}) => {
+  const conditions = [
+    're.id_entidad = ?',
+    'r.deleted_at IS NULL',
+  ];
+  const params = [id_entidad];
+
+  if (prioridad) {
+    conditions.push('re.prioridad = ?');
+    params.push(prioridad);
+  }
+  if (estado_atencion) {
+    conditions.push('re.estado_atencion = ?');
+    params.push(estado_atencion);
+  }
+  if (tipo_asignacion) {
+    conditions.push('re.tipo_asignacion = ?');
+    params.push(tipo_asignacion);
+  }
+  if (categoria) {
+    conditions.push('r.tipo_contaminacion = ?');
+    params.push(categoria);
+  }
+  if (severidad) {
+    conditions.push('r.nivel_severidad = ?');
+    params.push(severidad);
+  }
+
+  return {
+    where: conditions.join(' AND '),
+    params,
+  };
+};
+
+const mapAsignacionRow = (row) => ({
+  id_reporte: row.id_reporte,
+  uuid: row.uuid,
+  titulo: row.titulo,
+  descripcion: row.descripcion,
+  categoria: row.tipo_contaminacion,
+  tipo_contaminacion: row.tipo_contaminacion,
+  subcategoria: row.subcategoria,
+  severidad: row.nivel_severidad,
+  nivel_severidad: row.nivel_severidad,
+  estado: row.estado,
+  latitud: row.latitud,
+  longitud: row.longitud,
+  direccion: row.direccion,
+  municipio: row.municipio,
+  departamento: row.departamento,
+  created_at: row.created_at,
+  updated_at: row.updated_at,
+  asignacion: {
+    id_reporte_entidad: row.id_reporte_entidad,
+    tipo_asignacion: row.tipo_asignacion,
+    prioridad: row.prioridad,
+    estado_atencion: row.estado_atencion,
+    comentario: row.comentario,
+    asignado_at: row.asignado_at,
+    actualizado_at: row.actualizado_at,
+  },
+  entidad: {
+    id_entidad: row.id_entidad,
+    codigo: row.entidad_codigo,
+    nombre: row.entidad_nombre,
+  },
+});
+
+export const ReporteEntidadModel = {
+  ESTADOS_ATENCION,
+
+  createAssignment: async ({
+    id_reporte,
+    id_entidad,
+    tipo_asignacion = 'principal',
+    prioridad = 'media',
+    estado_atencion = 'pendiente',
+    comentario = null,
+  }) => {
+    const [result] = await pool.execute(
+      `INSERT INTO reporte_entidades
+         (id_reporte, id_entidad, tipo_asignacion, prioridad, estado_atencion, comentario)
+       VALUES (?, ?, ?, ?, ?, ?)
+       ON DUPLICATE KEY UPDATE
+         tipo_asignacion = VALUES(tipo_asignacion),
+         prioridad = VALUES(prioridad),
+         actualizado_at = CURRENT_TIMESTAMP`,
+      [id_reporte, id_entidad, tipo_asignacion, prioridad, estado_atencion, comentario]
+    );
+
+    return result.insertId;
+  },
+
+  bulkCreateAssignments: async (assignments = []) => {
+    const created = [];
+    for (const assignment of assignments) {
+      const id = await ReporteEntidadModel.createAssignment(assignment);
+      created.push({ ...assignment, id_reporte_entidad: id || null });
+    }
+    return created;
+  },
+
+  findByReporte: async (id_reporte) => {
+    const [rows] = await pool.execute(
+      `SELECT re.id_reporte_entidad, re.id_reporte, re.id_entidad,
+              re.tipo_asignacion, re.prioridad, re.estado_atencion,
+              re.comentario, re.asignado_at, re.actualizado_at,
+              e.codigo AS entidad_codigo, e.nombre AS entidad_nombre
+       FROM reporte_entidades re
+       INNER JOIN entidades e ON e.id_entidad = re.id_entidad
+       WHERE re.id_reporte = ?
+       ORDER BY FIELD(re.tipo_asignacion, 'principal', 'apoyo'), re.asignado_at ASC`,
+      [id_reporte]
+    );
+
+    return rows;
+  },
+
+  findByEntidad: async (id_entidad, filtros = {}) => {
+    const limit = parseLimit(filtros.limit);
+    const offset = parseOffset(filtros.offset);
+    const { where, params } = buildEntidadReportesFilter({ id_entidad, ...filtros });
+
+    const [rows] = await pool.execute(
+      `SELECT r.id_reporte, r.uuid, r.titulo, r.descripcion,
+              r.tipo_contaminacion, r.subcategoria, r.nivel_severidad, r.estado,
+              r.latitud, r.longitud, r.direccion, r.municipio, r.departamento,
+              r.created_at, r.updated_at,
+              re.id_reporte_entidad, re.tipo_asignacion, re.prioridad,
+              re.estado_atencion, re.comentario, re.asignado_at, re.actualizado_at,
+              e.id_entidad, e.codigo AS entidad_codigo, e.nombre AS entidad_nombre
+       FROM reporte_entidades re
+       INNER JOIN reportes r ON r.id_reporte = re.id_reporte
+       INNER JOIN entidades e ON e.id_entidad = re.id_entidad
+       WHERE ${where}
+       ORDER BY
+         FIELD(re.prioridad, 'critica', 'alta', 'media', 'baja'),
+         re.asignado_at DESC
+       LIMIT ${limit} OFFSET ${offset}`,
+      params
+    );
+
+    const [[meta]] = await pool.execute(
+      `SELECT COUNT(*) AS total
+       FROM reporte_entidades re
+       INNER JOIN reportes r ON r.id_reporte = re.id_reporte
+       WHERE ${where}`,
+      params
+    );
+
+    return {
+      reportes: rows.map(mapAsignacionRow),
+      total: Number(meta?.total) || 0,
+      limit,
+      offset,
+    };
+  },
+
+  findOneByReporteAndEntidad: async (id_reporte, id_entidad) => {
+    const [rows] = await pool.execute(
+      `SELECT re.id_reporte_entidad, re.id_reporte, re.id_entidad,
+              re.tipo_asignacion, re.prioridad, re.estado_atencion,
+              re.comentario, re.asignado_at, re.actualizado_at,
+              e.codigo AS entidad_codigo, e.nombre AS entidad_nombre
+       FROM reporte_entidades re
+       INNER JOIN entidades e ON e.id_entidad = re.id_entidad
+       WHERE re.id_reporte = ? AND re.id_entidad = ?
+       LIMIT 1`,
+      [id_reporte, id_entidad]
+    );
+
+    return rows[0] ?? null;
+  },
+
+  findReporteAsignadoByEntidad: async (id_reporte, id_entidad) => {
+    const [rows] = await pool.execute(
+      `SELECT r.id_reporte, r.uuid, r.titulo, r.descripcion,
+              r.tipo_contaminacion, r.subcategoria, r.nivel_severidad, r.estado,
+              r.latitud, r.longitud, r.direccion, r.municipio, r.departamento,
+              r.created_at, r.updated_at,
+              re.id_reporte_entidad, re.tipo_asignacion, re.prioridad,
+              re.estado_atencion, re.comentario, re.asignado_at, re.actualizado_at,
+              e.id_entidad, e.codigo AS entidad_codigo, e.nombre AS entidad_nombre
+       FROM reporte_entidades re
+       INNER JOIN reportes r ON r.id_reporte = re.id_reporte
+       INNER JOIN entidades e ON e.id_entidad = re.id_entidad
+       WHERE re.id_reporte = ? AND re.id_entidad = ? AND r.deleted_at IS NULL
+       LIMIT 1`,
+      [id_reporte, id_entidad]
+    );
+
+    return rows[0] ? mapAsignacionRow(rows[0]) : null;
+  },
+
+  updateEstadoAtencion: async (id_reporte_entidad, estado_atencion, comentario = null) => {
+    const [result] = await pool.execute(
+      `UPDATE reporte_entidades
+       SET estado_atencion = ?, comentario = ?, actualizado_at = CURRENT_TIMESTAMP
+       WHERE id_reporte_entidad = ?`,
+      [estado_atencion, comentario, id_reporte_entidad]
+    );
+
+    return result.affectedRows > 0;
+  },
+
+  removeAssignment: async (id_reporte, id_entidad) => {
+    const [result] = await pool.execute(
+      `DELETE FROM reporte_entidades
+       WHERE id_reporte = ? AND id_entidad = ?`,
+      [id_reporte, id_entidad]
+    );
+
+    return result.affectedRows > 0;
+  },
+};
+
+export default ReporteEntidadModel;

--- a/src/models/usuario.model.js
+++ b/src/models/usuario.model.js
@@ -43,8 +43,9 @@ export const UsuarioModel = {
     );
     const googleId = await UsuarioModel._optionalColumnSelect('google_id');
     const facebookId = await UsuarioModel._optionalColumnSelect('facebook_id');
+    const idEntidad = await UsuarioModel._optionalColumnSelect('id_entidad');
 
-    return `${UsuarioModel._publicUserFields}, ${notificationPreferences}, ${googleId}, ${facebookId}`;
+    return `${UsuarioModel._publicUserFields}, ${idEntidad}, ${notificationPreferences}, ${googleId}, ${facebookId}`;
   },
   
     // Busca un usuario por su email 
@@ -182,13 +183,21 @@ export const UsuarioModel = {
   
    //Crea un nuevo usuario.
    
-  create: async ({ nombre, apellido, email, password_hash, rol = 'ciudadano', telefono = null }) => {
+  create: async ({ nombre, apellido, email, password_hash, rol = 'ciudadano', telefono = null, id_entidad = null }) => {
     const uuid = randomUUID();
-    const [result] = await pool.execute(
-      `INSERT INTO usuarios (uuid, nombre, apellido, email, password_hash, rol, telefono)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
-      [uuid, nombre, apellido, email, password_hash, rol, telefono]
-    );
+    const hasEntidad = await columnExists('usuarios', 'id_entidad');
+
+    const [result] = hasEntidad
+      ? await pool.execute(
+        `INSERT INTO usuarios (uuid, nombre, apellido, email, password_hash, rol, id_entidad, telefono)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        [uuid, nombre, apellido, email, password_hash, rol, id_entidad, telefono]
+      )
+      : await pool.execute(
+        `INSERT INTO usuarios (uuid, nombre, apellido, email, password_hash, rol, telefono)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        [uuid, nombre, apellido, email, password_hash, rol, telefono]
+      );
     return result.insertId;
   },
 
@@ -371,19 +380,47 @@ export const UsuarioModel = {
   },
 
   // Actualiza rol del usuario
-  updateRol: async (id_usuario, rol) => {
-    const [result] = await pool.execute(
-      `UPDATE usuarios
-       SET rol = ?, updated_at = NOW()
-       WHERE id_usuario = ? AND deleted_at IS NULL`,
-      [rol, id_usuario]
-    );
+  updateRol: async (id_usuario, rol, id_entidad = null) => {
+    const hasEntidad = await columnExists('usuarios', 'id_entidad');
+
+    const [result] = hasEntidad
+      ? await pool.execute(
+        `UPDATE usuarios
+         SET rol = ?, id_entidad = ?, updated_at = NOW()
+         WHERE id_usuario = ? AND deleted_at IS NULL`,
+        [rol, rol === 'entidad' ? id_entidad : null, id_usuario]
+      )
+      : await pool.execute(
+        `UPDATE usuarios
+         SET rol = ?, updated_at = NOW()
+         WHERE id_usuario = ? AND deleted_at IS NULL`,
+        [rol, id_usuario]
+      );
 
     if (result.affectedRows === 0) {
       return null;
     }
 
     return UsuarioModel.findByIdWithDetails(id_usuario);
+  },
+
+  findActiveByEntidad: async (id_entidad) => {
+    if (!await columnExists('usuarios', 'id_entidad')) {
+      return [];
+    }
+
+    const publicFields = await UsuarioModel._publicUserSelect();
+    const [rows] = await pool.execute(
+      `SELECT ${publicFields}
+       FROM usuarios
+       WHERE rol = 'entidad'
+         AND id_entidad = ?
+         AND activo = 1
+         AND deleted_at IS NULL`,
+      [id_entidad]
+    );
+
+    return rows;
   },
 
   // Activa o desactiva usuario
@@ -410,6 +447,7 @@ export const UsuarioModel = {
          SUM(CASE WHEN rol = 'ciudadano' THEN 1 ELSE 0 END) AS ciudadanos,
          SUM(CASE WHEN rol = 'moderador' THEN 1 ELSE 0 END) AS moderadores,
          SUM(CASE WHEN rol = 'admin' THEN 1 ELSE 0 END) AS admins,
+         SUM(CASE WHEN rol = 'entidad' THEN 1 ELSE 0 END) AS entidades,
          SUM(CASE WHEN activo = 1 THEN 1 ELSE 0 END) AS activos,
          SUM(CASE WHEN activo = 0 THEN 1 ELSE 0 END) AS inactivos,
          SUM(CASE WHEN created_at >= DATE_FORMAT(CURRENT_DATE, '%Y-%m-01') THEN 1 ELSE 0 END) AS nuevos_este_mes

--- a/src/services/asignacion-entidades.service.js
+++ b/src/services/asignacion-entidades.service.js
@@ -1,0 +1,223 @@
+import { EntidadModel } from '../models/entidad.model.js';
+import { ReporteEntidadModel } from '../models/reporte-entidad.model.js';
+import { UsuarioModel } from '../models/usuario.model.js';
+import { crearNotificacion } from '../controllers/notificacion.controller.js';
+
+const normalize = (value) => (
+  typeof value === 'string'
+    ? value
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '_')
+        .replace(/^_+|_+$/g, '')
+    : ''
+);
+
+const normalizeText = (value) => (
+  typeof value === 'string'
+    ? value.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase()
+    : ''
+);
+
+const isHighSeverity = (reporte) => ['alto', 'critico'].includes(normalize(reporte?.nivel_severidad));
+
+export const REGLAS_ASIGNACION_ENTIDADES = [
+  {
+    match: { categoria: ['incendios_forestales'], subcategoria: ['incendio_activo'] },
+    keywords: ['incendio', 'llamas', 'fuego', 'humo por incendio', 'explosion', 'explosiones'],
+    principal: 'bomberos',
+    apoyo: ['gestion_riesgo', 'corpoamazonia'],
+    prioridad: 'critica',
+  },
+  {
+    match: { subcategoria: ['quema_a_cielo_abierto', 'quema_de_bosques', 'rastrojos_quemados'] },
+    keywords: ['quema', 'humo'],
+    principal: 'bomberos',
+    apoyo: ['corpoamazonia', 'secretaria_salud'],
+    prioridad: 'alta',
+  },
+  {
+    match: { categoria: ['deforestacion'], subcategoria: ['tala_ilegal'] },
+    keywords: ['tala', 'arbol', 'deforestacion'],
+    principal: 'corpoamazonia',
+    apoyo: (reporte) => (isHighSeverity(reporte) ? ['gestion_riesgo'] : []),
+    prioridad: 'alta',
+  },
+  {
+    match: { categoria: ['residuos'], subcategoria: ['basura_en_via_publica', 'escombros', 'vertedero_ilegal'] },
+    keywords: ['basura', 'escombros', 'puntos criticos de residuos', 'recoleccion de residuos'],
+    principal: 'alcaldia_servicios_publicos',
+    apoyo: ['secretaria_salud'],
+    prioridad: 'media',
+  },
+  {
+    match: { subcategoria: ['residuos_peligrosos', 'residuos_hospitalarios'] },
+    keywords: ['hospitalario', 'residuos peligrosos', 'residuo peligroso'],
+    principal: 'secretaria_salud',
+    apoyo: ['corpoamazonia', 'alcaldia_servicios_publicos'],
+    prioridad: 'alta',
+  },
+  {
+    match: {
+      categoria: ['avalanchas_fluviotorrenciales'],
+      subcategoria: ['deslizamiento_de_tierra', 'derrumbe_de_talud', 'creciente_subita'],
+    },
+    keywords: ['deslizamiento', 'derrumbe', 'avalancha', 'creciente', 'inundacion'],
+    principal: 'gestion_riesgo',
+    apoyo: ['bomberos', 'alcaldia_servicios_publicos'],
+    prioridad: 'critica',
+  },
+  {
+    match: { subcategoria: ['represamiento_de_rio'] },
+    keywords: ['represamiento', 'represamiento rio'],
+    principal: 'gestion_riesgo',
+    apoyo: ['corpoamazonia', 'bomberos'],
+    prioridad: 'critica',
+  },
+  {
+    match: { subcategoria: ['derrame_de_combustible'] },
+    keywords: ['derrame', 'petroleo', 'gasolina', 'combustible'],
+    principal: 'gestion_riesgo',
+    apoyo: ['bomberos', 'corpoamazonia'],
+    prioridad: 'critica',
+  },
+  {
+    match: { subcategoria: ['derrame_de_quimicos'] },
+    keywords: ['quimico', 'emergencia quimica', 'materiales inflamables'],
+    principal: 'gestion_riesgo',
+    apoyo: ['bomberos', 'corpoamazonia'],
+    prioridad: 'critica',
+  },
+  {
+    match: { subcategoria: ['vertimiento_industrial'] },
+    keywords: ['vertimiento', 'vertidos ilegales'],
+    principal: 'corpoamazonia',
+    apoyo: (reporte) => (isHighSeverity(reporte) ? ['gestion_riesgo'] : []),
+    prioridad: 'alta',
+  },
+  {
+    match: { subcategoria: ['aguas_residuales'] },
+    keywords: ['aguas negras', 'alcantarilla', 'aguas residuales'],
+    principal: 'alcaldia_servicios_publicos',
+    apoyo: ['secretaria_salud', 'corpoamazonia'],
+    prioridad: 'media',
+  },
+  {
+    match: { subcategoria: ['olores_ofensivos'] },
+    keywords: ['mal olor', 'olores', 'olores ofensivos'],
+    principal: 'secretaria_salud',
+    apoyo: ['corpoamazonia'],
+    prioridad: 'media',
+  },
+  {
+    match: { subcategoria: ['contaminacion_por_mineria'] },
+    keywords: ['mineria', 'mineria ilegal'],
+    principal: 'corpoamazonia',
+    apoyo: (reporte) => (isHighSeverity(reporte) ? ['gestion_riesgo'] : []),
+    prioridad: 'alta',
+  },
+  {
+    match: { categoria: ['agua', 'aire', 'suelo'] },
+    keywords: ['agua contaminada', 'contaminacion', 'fauna', 'flora', 'ecosistema'],
+    principal: 'corpoamazonia',
+    apoyo: [],
+    prioridad: 'media',
+  },
+  {
+    match: { categoria: ['otro'] },
+    keywords: [],
+    principal: 'corpoamazonia',
+    apoyo: [],
+    prioridad: 'media',
+  },
+];
+
+const matchesRule = (rule, reporte) => {
+  const categoria = normalize(reporte?.tipo_contaminacion ?? reporte?.categoria);
+  const subcategoria = normalize(reporte?.subcategoria);
+  const text = normalizeText([
+    reporte?.titulo,
+    reporte?.descripcion,
+    reporte?.subcategoria,
+  ].filter(Boolean).join(' '));
+
+  const categoriaMatch = rule.match?.categoria?.includes(categoria);
+  const subcategoriaMatch = subcategoria && rule.match?.subcategoria?.includes(subcategoria);
+  const keywordMatch = rule.keywords?.some((keyword) => text.includes(normalizeText(keyword)));
+
+  return Boolean(categoriaMatch || subcategoriaMatch || keywordMatch);
+};
+
+export const resolverAsignacionesEntidades = (reporte) => {
+  const rule = REGLAS_ASIGNACION_ENTIDADES.find((item) => matchesRule(item, reporte))
+    ?? REGLAS_ASIGNACION_ENTIDADES[REGLAS_ASIGNACION_ENTIDADES.length - 1];
+  const apoyo = typeof rule.apoyo === 'function' ? rule.apoyo(reporte) : rule.apoyo;
+  const codigos = [rule.principal, ...apoyo].filter(Boolean);
+
+  return [...new Set(codigos)].map((codigo, index) => ({
+    codigo,
+    tipo_asignacion: index === 0 ? 'principal' : 'apoyo',
+    prioridad: rule.prioridad,
+  }));
+};
+
+const notificarUsuariosEntidad = async ({ reporte, entidad, prioridad }) => {
+  const usuarios = await UsuarioModel.findActiveByEntidad(entidad.id_entidad);
+  const critica = prioridad === 'critica';
+
+  for (const usuario of usuarios) {
+    await crearNotificacion({
+      id_usuario: usuario.id_usuario,
+      tipo: 'reporte_asignado_entidad',
+      titulo: critica ? 'Nuevo reporte critico asignado' : 'Nuevo reporte asignado',
+      mensaje: critica
+        ? 'Nuevo reporte critico asignado a tu entidad.'
+        : 'Nuevo reporte asignado a tu entidad.',
+      referencia_tipo: 'reporte',
+      referencia_uuid: reporte.uuid,
+      link: `/reports/${reporte.uuid ?? reporte.id_reporte}`,
+    });
+  }
+};
+
+export const asignarEntidadesAReporte = async (reporte) => {
+  if (!reporte?.id_reporte) return [];
+
+  const asignacionesResueltas = resolverAsignacionesEntidades(reporte);
+  const entidades = await EntidadModel.findManyByCodigos(
+    asignacionesResueltas.map((item) => item.codigo)
+  );
+  const entidadByCodigo = new Map(entidades.map((entidad) => [entidad.codigo, entidad]));
+
+  const assignments = asignacionesResueltas
+    .map((item) => {
+      const entidad = entidadByCodigo.get(item.codigo);
+      if (!entidad) return null;
+
+      return {
+        id_reporte: reporte.id_reporte,
+        id_entidad: entidad.id_entidad,
+        tipo_asignacion: item.tipo_asignacion,
+        prioridad: item.prioridad,
+        entidad,
+      };
+    })
+    .filter(Boolean);
+
+  await ReporteEntidadModel.bulkCreateAssignments(assignments);
+
+  for (const assignment of assignments) {
+    await notificarUsuariosEntidad({
+      reporte,
+      entidad: assignment.entidad,
+      prioridad: assignment.prioridad,
+    });
+  }
+
+  return assignments;
+};
+
+export const AsignacionEntidadesService = {
+  asignarEntidadesAReporte,
+};

--- a/tests/unit/asignacion-entidades-service.test.js
+++ b/tests/unit/asignacion-entidades-service.test.js
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolverAsignacionesEntidades } from '../../src/services/asignacion-entidades.service.js';
+
+const codigos = (reporte) => resolverAsignacionesEntidades(reporte).map((item) => item.codigo);
+const principal = (reporte) => resolverAsignacionesEntidades(reporte)[0];
+
+test('asigna incendio forestal a Bomberos como principal', () => {
+  const reporte = {
+    tipo_contaminacion: 'incendios_forestales',
+    subcategoria: 'Incendio activo',
+    nivel_severidad: 'critico',
+    titulo: 'Incendio forestal activo',
+    descripcion: 'Se observan llamas y humo.',
+  };
+
+  assert.deepEqual(codigos(reporte), ['bomberos', 'gestion_riesgo', 'corpoamazonia']);
+  assert.equal(principal(reporte).prioridad, 'critica');
+});
+
+test('asigna derrame de combustible a Gestion del Riesgo con apoyos', () => {
+  const reporte = {
+    tipo_contaminacion: 'suelo',
+    subcategoria: 'Derrame de combustible',
+    nivel_severidad: 'critico',
+    titulo: 'Derrame de gasolina',
+    descripcion: 'Hay combustible cerca de viviendas.',
+  };
+
+  assert.deepEqual(codigos(reporte), ['gestion_riesgo', 'bomberos', 'corpoamazonia']);
+  assert.equal(principal(reporte).prioridad, 'critica');
+});
+
+test('asigna basura comun a Alcaldia y Servicios Publicos', () => {
+  const reporte = {
+    tipo_contaminacion: 'residuos',
+    subcategoria: 'Basura en via publica',
+    nivel_severidad: 'medio',
+    titulo: 'Basura acumulada',
+    descripcion: 'Punto critico de residuos.',
+  };
+
+  assert.deepEqual(codigos(reporte), ['alcaldia_servicios_publicos', 'secretaria_salud']);
+  assert.equal(principal(reporte).prioridad, 'media');
+});
+
+test('no duplica entidades cuando palabra clave y categoria coinciden', () => {
+  const reporte = {
+    tipo_contaminacion: 'incendios_forestales',
+    subcategoria: 'Incendio activo',
+    nivel_severidad: 'critico',
+    titulo: 'Incendio con fuego y humo',
+    descripcion: 'Incendio activo.',
+  };
+
+  const asignaciones = resolverAsignacionesEntidades(reporte);
+  assert.equal(new Set(asignaciones.map((item) => item.codigo)).size, asignaciones.length);
+});

--- a/tests/unit/backend-route-contract.test.js
+++ b/tests/unit/backend-route-contract.test.js
@@ -24,6 +24,7 @@ test('app monta todos los routers principales sin prefijo interno obligatorio', 
     '${apiPrefix}/admin',
     '${apiPrefix}/chatbot',
     '${apiPrefix}/notificaciones',
+    '${apiPrefix}/entidades',
   ]) {
     assert.ok(source.includes(`app.use(\`${mount}\``), mount);
   }
@@ -38,6 +39,7 @@ test('rutas consumidas por el cliente estan declaradas en backend', async () => 
     adminRouter: await read('routes/admin.routes.js'),
     chatbotRouter: await read('routes/chatbot.routes.js'),
     notificacionRouter: await read('routes/notificacion.routes.js'),
+    entidadRouter: await read('routes/entidad.routes.js'),
   };
 
   const expectedRoutes = [
@@ -88,6 +90,10 @@ test('rutas consumidas por el cliente estan declaradas en backend', async () => 
     { router: 'notificacionRouter', method: 'patch', route: '/:uuid/leida' },
     { router: 'notificacionRouter', method: 'patch', route: '/marcar-todas' },
     { router: 'notificacionRouter', method: 'delete', route: '/:uuid' },
+    { router: 'entidadRouter', method: 'get', route: '/' },
+    { router: 'entidadRouter', method: 'get', route: '/mis-reportes' },
+    { router: 'entidadRouter', method: 'get', route: '/mis-reportes/:id' },
+    { router: 'entidadRouter', method: 'patch', route: '/mis-reportes/:id/atencion' },
   ];
 
   for (const expected of expectedRoutes) {
@@ -103,11 +109,16 @@ test('rutas privadas y administrativas declaran middleware de autenticacion y ro
   const adminRoutes = await read('routes/admin.routes.js');
   const categoriaRoutes = await read('routes/categoria-riesgo.routes.js');
   const notificacionRoutes = await read('routes/notificacion.routes.js');
+  const entidadRoutes = await read('routes/entidad.routes.js');
   const reporteRoutes = await read('routes/reporte.routes.js');
   const authRoutes = await read('routes/auth.routes.js');
 
   assert.match(adminRoutes, /adminRouter\.use\(verifyToken,\s*requireRoles\('admin'\)\)/);
   assert.match(notificacionRoutes, /notificacionRouter\.use\(verifyToken\)/);
+  assert.match(entidadRoutes, /entidadRouter\.get\('\/',\s*verifyToken,\s*requireRoles\('admin', 'moderador', 'entidad'\)/);
+  assert.match(entidadRoutes, /entidadRouter\.get\('\/mis-reportes',\s*verifyToken,\s*requireRoles\('entidad'\)/);
+  assert.match(entidadRoutes, /entidadRouter\.get\([\s\S]*'\/mis-reportes\/:id'[\s\S]*verifyToken[\s\S]*requireRoles\('entidad'\)/);
+  assert.match(entidadRoutes, /entidadRouter\.patch\([\s\S]*'\/mis-reportes\/:id\/atencion'[\s\S]*verifyToken[\s\S]*requireRoles\('entidad'\)/);
 
   assert.match(categoriaRoutes, /categoriaRouter\.post\('\/',\s*verifyToken,\s*requireRoles\('admin'\)/);
   assert.match(categoriaRoutes, /categoriaRouter\.patch\('\/:codigo',\s*verifyToken,\s*requireRoles\('admin'\)/);

--- a/tests/unit/clasificacion-ia.test.js
+++ b/tests/unit/clasificacion-ia.test.js
@@ -8,6 +8,7 @@ import { analizarImagen, createReporte } from '../../src/controllers/reporte.con
 import { CategoriaRiesgoModel } from '../../src/models/categoria-riesgo.model.js';
 import { EvidenciaModel } from '../../src/models/evidencia.model.js';
 import { normalizeReporteIA, ReporteModel } from '../../src/models/reporte.model.js';
+import { AsignacionEntidadesService } from '../../src/services/asignacion-entidades.service.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const testsDir = path.dirname(__filename);
@@ -51,6 +52,7 @@ const mockReporteCreate = (t) => {
   }));
   t.mock.method(ReporteModel, 'updateIaAnalysis', async () => true);
   t.mock.method(EvidenciaModel, 'create', async () => 1);
+  t.mock.method(AsignacionEntidadesService, 'asignarEntidadesAReporte', async () => []);
 };
 
 test('clasificarImagen devuelve contrato esperado con fallback deterministico', async () => {

--- a/tests/unit/database-schema.test.js
+++ b/tests/unit/database-schema.test.js
@@ -17,8 +17,10 @@ test('schema completo incluye tablas de soporte requeridas por el backend', asyn
 
   for (const table of [
     'usuarios',
+    'entidades',
     'categorias_riesgo',
     'reportes',
+    'reporte_entidades',
     'evidencias',
     'refresh_tokens',
     'reporte_likes',
@@ -36,6 +38,8 @@ test('schema completo conserva columnas actuales de auth, IA y moderacion', asyn
   for (const column of [
     'google_id VARCHAR(255) UNIQUE NULL',
     'facebook_id VARCHAR(255) UNIQUE NULL',
+    "rol ENUM('ciudadano', 'moderador', 'admin', 'entidad')",
+    'id_entidad INT NULL',
     'notification_preferences JSON NULL',
     'avatar_url VARCHAR(255) NULL',
     'email_verificado BOOLEAN DEFAULT FALSE',
@@ -47,6 +51,9 @@ test('schema completo conserva columnas actuales de auth, IA y moderacion', asyn
     'ia_confianza DECIMAL(5, 2) NULL',
     'ia_procesado BOOLEAN DEFAULT FALSE',
     'token_hash CHAR(64) NOT NULL',
+    "tipo_asignacion ENUM('principal', 'apoyo')",
+    "estado_atencion ENUM('pendiente', 'en_atencion', 'atendido', 'cerrado')",
+    "tipo ENUM('reporte_estado', 'reporte_comentario', 'reporte_creado', 'reporte_asignado_entidad', 'alerta_zona', 'sistema')",
   ]) {
     assert.ok(schema.includes(column), column);
   }
@@ -71,4 +78,5 @@ test('migraciones no tienen numeracion duplicada ni scripts sueltos de notificac
   assert.deepEqual(duplicateNumbers, []);
   assert.equal(files.includes('create_notificaciones.sql'), false);
   assert.equal(files.includes('012_create_notificaciones.sql'), true);
+  assert.equal(files.includes('014_create_entidades_and_reporte_entidades.sql'), true);
 });

--- a/tests/unit/reporte-categoria-validacion.test.js
+++ b/tests/unit/reporte-categoria-validacion.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { createReporte } from '../../src/controllers/reporte.controller.js';
 import { CategoriaRiesgoModel } from '../../src/models/categoria-riesgo.model.js';
 import { ReporteModel } from '../../src/models/reporte.model.js';
+import { AsignacionEntidadesService } from '../../src/services/asignacion-entidades.service.js';
 
 const createMockResponse = () => ({
   statusCode: null,
@@ -61,6 +62,7 @@ test('createReporte crea reporte cuando la categoria existe y esta activa', asyn
     estado: 'pendiente',
   }));
   t.mock.method(ReporteModel, 'updateIaAnalysis', async () => true);
+  t.mock.method(AsignacionEntidadesService, 'asignarEntidadesAReporte', async () => []);
 
   const req = createValidRequest();
   const res = createMockResponse();

--- a/tests/unit/reporte-upload-evidencias.test.js
+++ b/tests/unit/reporte-upload-evidencias.test.js
@@ -5,6 +5,7 @@ import { createReporte } from '../../src/controllers/reporte.controller.js';
 import { CategoriaRiesgoModel } from '../../src/models/categoria-riesgo.model.js';
 import { EvidenciaModel } from '../../src/models/evidencia.model.js';
 import { ReporteModel } from '../../src/models/reporte.model.js';
+import { AsignacionEntidadesService } from '../../src/services/asignacion-entidades.service.js';
 
 const createResponse = () => ({
   statusCode: null,
@@ -57,6 +58,7 @@ const mockSuccessfulCreate = (t) => {
   }));
   t.mock.method(ReporteModel, 'updateIaAnalysis', async () => true);
   t.mock.method(EvidenciaModel, 'create', async () => 1);
+  t.mock.method(AsignacionEntidadesService, 'asignarEntidadesAReporte', async () => []);
 };
 
 test('createReporte guarda multiples imagenes con metadata y orden', async (t) => {


### PR DESCRIPTION
# Closes #225 

## Descripción
Este PR implementa en el backend la asignación automática de reportes ambientales a entidades responsables. Se agrega el rol `entidad`, el esquema de base de datos para entidades y asignaciones, modelos, rutas y un servicio de reglas que determina la entidad principal y las entidades de apoyo según categoría, subcategoría, severidad, título y descripción del reporte. También se restringe el acceso de usuarios entidad para que solo puedan consultar reportes asignados a su institución y actualizar su propio estado de atención, sin modificar el estado general de moderación. Además, se agregan notificaciones para entidades asignadas, se actualiza el esquema consolidado, se ajustan pruebas unitarias y se estabiliza el CI del backend para ejecutar la suite de tests de forma confiable.

<img width="751" height="912" alt="image" src="https://github.com/user-attachments/assets/53657c74-1898-4f58-bb1b-cb345f87ef80" />
