### PR TITLE
Ajuste de asignación automática para emergencias operativas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
 .pnpm-debug.log*
+.npm/
 
 # Runtime
 dist/

--- a/DATABASE_SCHEMA_COMPLETE.sql
+++ b/DATABASE_SCHEMA_COMPLETE.sql
@@ -113,7 +113,7 @@ CREATE TABLE IF NOT EXISTS reportes (
   id_usuario BIGINT UNSIGNED NOT NULL,
   tipo_contaminacion VARCHAR(50) NOT NULL,
   subcategoria VARCHAR(100) NULL,
-  estado ENUM('pendiente', 'en_revision', 'verificado', 'en_proceso', 'rechazado', 'resuelto') DEFAULT 'pendiente',
+  estado ENUM('pendiente', 'en_proceso', 'resuelto', 'rechazado') DEFAULT 'pendiente',
   nivel_severidad ENUM('bajo', 'medio', 'alto', 'critico') DEFAULT 'medio',
   titulo VARCHAR(255) NOT NULL,
   descripcion TEXT NULL,

--- a/docs/PREDICCION_ZONAS_RIESGO.md
+++ b/docs/PREDICCION_ZONAS_RIESGO.md
@@ -8,11 +8,11 @@ Solo se consideran reportes que cumplan estas condiciones:
 
 - `deleted_at IS NULL`
 - `latitud` y `longitud` no nulas
-- `estado IN ('verificado', 'en_proceso', 'resuelto')`
+- `estado IN ('en_proceso', 'resuelto')`
 - `created_at >= desde`, cuando se envia filtro por dias
 - `tipo_contaminacion = tipo`, cuando se envia filtro por tipo
 
-Los estados `pendiente`, `en_revision` y `rechazado` no alimentan la prediccion.
+Los estados `pendiente` y `rechazado` no alimentan la prediccion.
 
 ## Agrupacion
 

--- a/migrations/017_consolidate_reportes_estado_simple.sql
+++ b/migrations/017_consolidate_reportes_estado_simple.sql
@@ -1,0 +1,10 @@
+-- Consolida el flujo simple de estados de reportes ambientales.
+-- Estados definitivos: pendiente, en_proceso, resuelto, rechazado.
+
+UPDATE reportes
+SET estado = 'en_proceso'
+WHERE estado IN ('en_revision', 'verificado');
+
+ALTER TABLE reportes
+  MODIFY estado ENUM('pendiente', 'en_proceso', 'resuelto', 'rechazado')
+  DEFAULT 'pendiente';

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "express": "^4.19.2",
     "express-rate-limit": "^8.4.1",
     "google-auth-library": "^10.6.2",
+    "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
     "mysql2": "^3.9.8",

--- a/routes/entidad.routes.js
+++ b/routes/entidad.routes.js
@@ -5,12 +5,20 @@ import {
   actualizarAtencionMiEntidad,
   listarEntidades,
   listarMisReportesEntidad,
+  listarReportesPorEntidad,
   obtenerMiReporteEntidad,
 } from '../src/controllers/entidad.controller.js';
 
 const entidadRouter = Router();
 
 entidadRouter.get('/', verifyToken, requireRoles('admin', 'moderador', 'entidad'), listarEntidades);
+entidadRouter.get(
+  '/:id/reportes',
+  validatePositiveIdParam('id'),
+  verifyToken,
+  requireRoles('admin', 'moderador', 'entidad'),
+  listarReportesPorEntidad
+);
 entidadRouter.get('/mis-reportes', verifyToken, requireRoles('entidad'), listarMisReportesEntidad);
 entidadRouter.get(
   '/mis-reportes/:id',

--- a/routes/reporte.routes.js
+++ b/routes/reporte.routes.js
@@ -13,6 +13,7 @@ import {
   getStatsIA,
   getTrendingReportes,
   toggleLikeReporte,
+  asignarEntidadReporte,
   analizarImagen,
   sugerirContenidoReporte,
   getMisReportes,
@@ -45,6 +46,13 @@ reporteRouter.post('/analizar-imagen', verifyToken, upload.single('imagen'), ana
 reporteRouter.post('/sugerir-contenido', verifyToken, uploadMultiple, sugerirContenidoReporte);
 reporteRouter.get('/', optionalAuth, getReportes);
 reporteRouter.post('/:id/like', validatePositiveIdParam('id'), verifyToken, toggleLikeReporte);
+reporteRouter.post(
+  '/:id/asignaciones',
+  validatePositiveIdParam('id'),
+  verifyToken,
+  requireRoles('admin', 'moderador'),
+  asignarEntidadReporte
+);
 reporteRouter.get('/:id/evidencias', validatePositiveIdParam('id'), verifyToken, listEvidenciasReporte);
 reporteRouter.post('/:id/evidencias', validatePositiveIdParam('id'), verifyToken, upload.single('file'), addEvidenciaReporte);
 reporteRouter.delete(

--- a/src/controllers/categoria-riesgo.controller.js
+++ b/src/controllers/categoria-riesgo.controller.js
@@ -326,8 +326,7 @@ export const obtenerEstadisticasCategorias = async (req, res, next) => {
     const totales = {
       total_reportes: 0,
       pendientes: 0,
-      en_revision: 0,
-      verificados: 0,
+      en_proceso: 0,
       resueltos: 0,
       criticos: 0
     };
@@ -335,8 +334,7 @@ export const obtenerEstadisticasCategorias = async (req, res, next) => {
     estadisticas.forEach(cat => {
       totales.total_reportes += cat.total_reportes || 0;
       totales.pendientes += cat.pendientes || 0;
-      totales.en_revision += cat.en_revision || 0;
-      totales.verificados += cat.verificados || 0;
+      totales.en_proceso += cat.en_proceso || 0;
       totales.resueltos += cat.resueltos || 0;
       totales.criticos += cat.criticos || 0;
     });

--- a/src/controllers/entidad.controller.js
+++ b/src/controllers/entidad.controller.js
@@ -41,6 +41,42 @@ export const listarMisReportesEntidad = async (req, res, next) => {
   }
 };
 
+export const listarReportesPorEntidad = async (req, res, next) => {
+  try {
+    const idEntidad = Number(req.params.id);
+    if (!idEntidad) {
+      return errorResponse(res, 'Id de entidad invalido.', 400);
+    }
+
+    if (req.user?.rol === 'entidad' && Number(req.user.id_entidad) !== idEntidad) {
+      return errorResponse(res, 'No tienes permiso para consultar esta entidad.', 403);
+    }
+
+    const entidad = await EntidadModel.findActiveAllowedByIdOrCodigo({ id_entidad: idEntidad });
+    if (!entidad) {
+      return errorResponse(res, 'Entidad no encontrada, inactiva o fuera de alcance.', 404);
+    }
+
+    const data = await ReporteEntidadModel.findByEntidad(idEntidad, {
+      prioridad: req.query?.prioridad,
+      estado_atencion: req.query?.estado_atencion,
+      tipo_asignacion: req.query?.tipo_asignacion,
+      categoria: req.query?.categoria,
+      severidad: req.query?.severidad,
+      limit: req.query?.limit,
+      offset: req.query?.offset,
+    });
+
+    return successResponse(
+      res,
+      { entidad, ...data },
+      'Reportes asignados a entidad obtenidos correctamente.'
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
 export const obtenerMiReporteEntidad = async (req, res, next) => {
   try {
     const idEntidad = getEntidadIdFromUser(req);

--- a/src/controllers/reporte.controller.js
+++ b/src/controllers/reporte.controller.js
@@ -1,8 +1,10 @@
 import {
   ESTADO_INICIAL_REPORTE,
+  ESTADOS_REPORTE_LABELS,
   ESTADOS_REPORTE_PERMITIDOS,
   NIVELES_SEVERIDAD_PERMITIDOS,
   ReporteModel,
+  normalizeReporteEstado,
 } from '../models/reporte.model.js';
 import fs from 'node:fs/promises';
 import { CategoriaRiesgoModel } from '../models/categoria-riesgo.model.js';
@@ -54,12 +56,10 @@ const buildAllowedValuesMessage = (field, allowedValues) => (
 );
 
 const TRANSICIONES_ESTADO_REPORTE = {
-  pendiente: ['en_revision', 'rechazado'],
-  en_revision: ['verificado', 'en_proceso', 'rechazado'],
-  verificado: ['en_proceso', 'resuelto', 'rechazado'],
+  pendiente: ['en_proceso', 'rechazado'],
   en_proceso: ['resuelto', 'rechazado'],
   resuelto: [],
-  rechazado: ['pendiente'],
+  rechazado: [],
 };
 
 const canTransitionReporteEstado = (estadoActual, estadoNuevo) => {
@@ -869,8 +869,12 @@ export const updateReporte = async (req, res, next) => {
     const { rol, sub } = req.user;
     const isOwner = reporte.id_usuario === sub;
     const isMod   = rol === 'moderador' || rol === 'admin';
+    const asignacionEntidad = rol === 'entidad' && req.user?.id_entidad
+      ? await ReporteEntidadModel.findOneByReporteAndEntidad(id, req.user.id_entidad)
+      : null;
+    const isEntidadAsignada = Boolean(asignacionEntidad);
 
-    if (!isOwner && !isMod) {
+    if (!isOwner && !isMod && !isEntidadAsignada) {
       return errorResponse(res, 'No tienes permiso para editar este reporte.', 403);
     }
 
@@ -878,20 +882,33 @@ export const updateReporte = async (req, res, next) => {
     if (isOwner && !isMod && reporte.estado !== ESTADO_INICIAL_REPORTE) {
       return errorResponse(
         res,
-        'No puedes editar un reporte que ya está en revisión o procesado.',
+        'No puedes editar un reporte que ya esta en proceso, resuelto o rechazado.',
         403
       );
     }
 
-    // Owners can edit content fields; mods/admins can also change estado y comentario_moderacion
-    const allowed = isOwner
+    const body = { ...(req.body ?? {}) };
+    if (!Object.prototype.hasOwnProperty.call(body, 'comentario_moderacion')) {
+      if (Object.prototype.hasOwnProperty.call(body, 'observacion')) {
+        body.comentario_moderacion = body.observacion;
+      } else if (Object.prototype.hasOwnProperty.call(body, 'motivo')) {
+        body.comentario_moderacion = body.motivo;
+      } else if (Object.prototype.hasOwnProperty.call(body, 'comentario')) {
+        body.comentario_moderacion = body.comentario;
+      }
+    }
+
+    // Owners edit content only; moderators/admins and assigned entities can update estado.
+    const allowed = isOwner && !isMod
       ? ['titulo', 'descripcion', 'direccion', 'municipio', 'departamento']
-      : ['estado', 'nivel_severidad', 'titulo', 'descripcion', 'direccion', 'municipio', 'departamento', 'comentario_moderacion'];
+      : isEntidadAsignada && !isMod
+        ? ['estado', 'comentario_moderacion']
+        : ['estado', 'nivel_severidad', 'titulo', 'descripcion', 'direccion', 'municipio', 'departamento', 'comentario_moderacion'];
 
     const campos = {};
     for (const key of allowed) {
-      if (Object.prototype.hasOwnProperty.call(req.body ?? {}, key)) {
-        campos[key] = req.body[key];
+      if (Object.prototype.hasOwnProperty.call(body, key)) {
+        campos[key] = body[key];
       }
     }
 
@@ -900,22 +917,23 @@ export const updateReporte = async (req, res, next) => {
     }
 
     if (Object.prototype.hasOwnProperty.call(campos, 'estado')) {
-      const estado = normalizeEnumValue(campos.estado);
+      const estado = normalizeReporteEstado(campos.estado);
 
       if (!ESTADOS_REPORTE_PERMITIDOS.includes(estado)) {
         return errorResponse(
           res,
-          buildAllowedValuesMessage('El estado', ESTADOS_REPORTE_PERMITIDOS),
+          buildAllowedValuesMessage('El estado', ESTADOS_REPORTE_LABELS),
           400
         );
       }
 
       campos.estado = estado;
 
-      if (!canTransitionReporteEstado(reporte.estado, campos.estado)) {
+      const estadoActual = normalizeReporteEstado(reporte.estado);
+      if (!canTransitionReporteEstado(estadoActual, campos.estado)) {
         return errorResponse(
           res,
-          `Transicion de estado no permitida: ${reporte.estado} -> ${campos.estado}.`,
+          `Transicion de estado no permitida: ${estadoActual} -> ${campos.estado}.`,
           400
         );
       }
@@ -935,12 +953,17 @@ export const updateReporte = async (req, res, next) => {
       campos.nivel_severidad = nivelSeveridad;
     }
 
-    // Validar que comentario_moderacion es obligatorio si se rechaza
-    if (isMod && campos.estado === 'rechazado') {
+    // La estructura actual permite guardar observacion en comentario_moderacion.
+    if ((isMod || isEntidadAsignada) && ['resuelto', 'rechazado'].includes(campos.estado)) {
       const comentario = campos.comentario_moderacion?.trim();
       if (!comentario) {
-        return errorResponse(res, 'El comentario es obligatorio al rechazar un reporte.', 400);
+        return errorResponse(
+          res,
+          'El comentario es obligatorio al resolver o rechazar un reporte.',
+          400
+        );
       }
+      campos.comentario_moderacion = comentario;
     }
 
     await ReporteModel.update(id, campos);
@@ -1012,7 +1035,7 @@ export const deleteReporte = async (req, res, next) => {
     if (isOwner && !isMod && reporte.estado !== ESTADO_INICIAL_REPORTE) {
       return errorResponse(
         res,
-        'No puedes eliminar un reporte que ya está en revisión o procesado.',
+        'No puedes eliminar un reporte que ya esta en proceso, resuelto o rechazado.',
         403
       );
     }

--- a/src/controllers/reporte.controller.js
+++ b/src/controllers/reporte.controller.js
@@ -8,6 +8,7 @@ import fs from 'node:fs/promises';
 import { CategoriaRiesgoModel } from '../models/categoria-riesgo.model.js';
 import { UsuarioModel }   from '../models/usuario.model.js';
 import { EvidenciaModel } from '../models/evidencia.model.js';
+import { EntidadModel } from '../models/entidad.model.js';
 import { LikeModel } from '../models/like.model.js';
 import { ReporteEntidadModel } from '../models/reporte-entidad.model.js';
 import { analyzeReporte } from '../services/ia.service.js';
@@ -774,6 +775,64 @@ export const toggleLikeReporte = async (req, res, next) => {
       res,
       result,
       result.liked ? 'Like registrado.' : 'Like retirado.'
+    );
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const asignarEntidadReporte = async (req, res, next) => {
+  try {
+    const id = Number(req.params.id);
+    const { id_entidad, codigo_entidad, comentario = null } = req.body ?? {};
+
+    const reporte = await ReporteModel.findById(id);
+    if (!reporte) return errorResponse(res, 'Reporte no encontrado.', 404);
+
+    const entidad = await EntidadModel.findActiveAllowedByIdOrCodigo({
+      id_entidad: id_entidad ? Number(id_entidad) : null,
+      codigo: codigo_entidad,
+    });
+
+    if (!entidad) {
+      return errorResponse(
+        res,
+        'Entidad invalida, inactiva o fuera del alcance institucional definido.',
+        400
+      );
+    }
+
+    await ReporteEntidadModel.createAssignment({
+      id_reporte: id,
+      id_entidad: entidad.id_entidad,
+      tipo_asignacion: 'principal',
+      prioridad: 'media',
+      estado_atencion: 'pendiente',
+      comentario: typeof comentario === 'string' ? comentario.trim() || null : null,
+    });
+
+    const asignacion = await ReporteEntidadModel.findOneByReporteAndEntidad(
+      id,
+      entidad.id_entidad
+    );
+
+    if (reporte.id_usuario) {
+      await crearNotificacion({
+        id_usuario: reporte.id_usuario,
+        tipo: 'reporte_asignado_entidad',
+        titulo: 'Reporte asignado a entidad responsable',
+        mensaje: `Tu reporte "${reporte.titulo}" fue asignado a ${entidad.nombre}.`,
+        referencia_tipo: 'reporte',
+        referencia_uuid: reporte.uuid,
+        link: buildReporteLink(reporte),
+      });
+    }
+
+    return successResponse(
+      res,
+      { reporte, entidad, asignacion },
+      'Reporte asignado a entidad correctamente.',
+      201
     );
   } catch (error) {
     return next(error);

--- a/src/models/categoria-riesgo.model.js
+++ b/src/models/categoria-riesgo.model.js
@@ -121,8 +121,6 @@ const withReportStats = async (categorias) => {
     `SELECT tipo_contaminacion AS codigo,
             COUNT(*) AS total_reportes,
             SUM(CASE WHEN estado = 'pendiente' THEN 1 ELSE 0 END) AS pendientes,
-            SUM(CASE WHEN estado = 'en_revision' THEN 1 ELSE 0 END) AS en_revision,
-            SUM(CASE WHEN estado = 'verificado' THEN 1 ELSE 0 END) AS verificados,
             SUM(CASE WHEN estado = 'en_proceso' THEN 1 ELSE 0 END) AS en_proceso,
             SUM(CASE WHEN estado = 'resuelto' THEN 1 ELSE 0 END) AS resueltos,
             SUM(CASE WHEN estado = 'rechazado' THEN 1 ELSE 0 END) AS rechazados,
@@ -141,8 +139,6 @@ const withReportStats = async (categorias) => {
     ...categoria,
     total_reportes: 0,
     pendientes: 0,
-    en_revision: 0,
-    verificados: 0,
     en_proceso: 0,
     resueltos: 0,
     rechazados: 0,
@@ -398,8 +394,7 @@ export const CategoriaRiesgoModel = {
           cr.color_hex,
           COUNT(r.id_reporte) as total_reportes,
           SUM(CASE WHEN r.estado = 'pendiente' THEN 1 ELSE 0 END) as pendientes,
-          SUM(CASE WHEN r.estado = 'en_revision' THEN 1 ELSE 0 END) as en_revision,
-          SUM(CASE WHEN r.estado = 'verificado' THEN 1 ELSE 0 END) as verificados,
+          SUM(CASE WHEN r.estado = 'en_proceso' THEN 1 ELSE 0 END) as en_proceso,
           SUM(CASE WHEN r.estado = 'resuelto' THEN 1 ELSE 0 END) as resueltos,
           SUM(CASE WHEN r.nivel_severidad = 'critico' THEN 1 ELSE 0 END) as criticos
          FROM categorias_riesgo cr

--- a/src/models/entidad.model.js
+++ b/src/models/entidad.model.js
@@ -1,5 +1,17 @@
 import pool from '../config/database.js';
 
+export const ENTIDADES_INSTITUCIONALES_CODIGOS = [
+  'bomberos',
+  'corpoamazonia',
+  'gestion_riesgo',
+  'secretaria_salud',
+  'alcaldia_servicios_publicos',
+];
+
+export const isEntidadInstitucionalPermitida = (codigo) => (
+  ENTIDADES_INSTITUCIONALES_CODIGOS.includes(String(codigo || '').trim().toLowerCase())
+);
+
 export const EntidadModel = {
   findAll: async ({ activas } = {}) => {
     const conditions = [];
@@ -47,6 +59,24 @@ export const EntidadModel = {
     );
 
     return rows[0] ?? null;
+  },
+
+  findActiveAllowedByIdOrCodigo: async ({ id_entidad, codigo } = {}) => {
+    const normalizedCodigo = typeof codigo === 'string' ? codigo.trim().toLowerCase() : '';
+
+    if (id_entidad) {
+      const entidad = await EntidadModel.findById(id_entidad);
+      if (!entidad?.activo || !isEntidadInstitucionalPermitida(entidad.codigo)) return null;
+      return entidad;
+    }
+
+    if (!normalizedCodigo || !isEntidadInstitucionalPermitida(normalizedCodigo)) {
+      return null;
+    }
+
+    const entidad = await EntidadModel.findByCodigo(normalizedCodigo);
+    if (!entidad?.activo) return null;
+    return entidad;
   },
 
   findManyByCodigos: async (codigos = []) => {

--- a/src/models/reporte.model.js
+++ b/src/models/reporte.model.js
@@ -6,12 +6,19 @@ import { randomUUID } from 'crypto';
 export const ESTADO_INICIAL_REPORTE = 'pendiente';
 export const ESTADOS_REPORTE_PERMITIDOS = [
   'pendiente',
-  'en_revision',
-  'verificado',
   'en_proceso',
-  'rechazado',
   'resuelto',
+  'rechazado',
 ];
+export const ESTADOS_REPORTE_LABELS = [
+  'pendiente',
+  'en proceso',
+  'resuelto',
+  'rechazado',
+];
+export const normalizeReporteEstado = (estado) => (
+  typeof estado === 'string' ? estado.trim().toLowerCase().replace(/\s+/g, '_') : ''
+);
 export const NIVELES_SEVERIDAD_PERMITIDOS = [
   'bajo',
   'medio',
@@ -30,7 +37,7 @@ const buildReportesFilter = ({
 
   if (estado) {
     conditions.push('r.estado = ?');
-    params.push(estado);
+    params.push(normalizeReporteEstado(estado));
   }
   if (tipo_contaminacion) {
     conditions.push('r.tipo_contaminacion = ?');
@@ -159,7 +166,7 @@ export const ReporteModel = {
 
     if (estado) {
       conditions.push('r.estado = ?');
-      params.push(estado);
+      params.push(normalizeReporteEstado(estado));
     }
     if (tipo_contaminacion) {
       conditions.push('r.tipo_contaminacion = ?');
@@ -418,10 +425,10 @@ export const ReporteModel = {
       `SELECT
          COUNT(*)                                                                          AS total_reportes,
          SUM(CASE WHEN MONTH(created_at)=MONTH(NOW()) AND YEAR(created_at)=YEAR(NOW()) THEN 1 ELSE 0 END) AS reportes_este_mes,
-         SUM(CASE WHEN estado='en_revision'  THEN 1 ELSE 0 END)                          AS en_revision,
+         SUM(CASE WHEN estado='en_proceso'   THEN 1 ELSE 0 END)                          AS en_proceso,
          SUM(CASE WHEN estado='resuelto'     THEN 1 ELSE 0 END)                          AS resueltos,
          COUNT(DISTINCT CASE WHEN municipio IS NOT NULL AND municipio!='' THEN municipio END) AS municipios_activos,
-         SUM(CASE WHEN estado IN ('en_revision','verificado','en_proceso') THEN 1 ELSE 0 END) AS con_seguimiento
+         SUM(CASE WHEN estado = 'en_proceso' THEN 1 ELSE 0 END) AS con_seguimiento
        FROM reportes WHERE deleted_at IS NULL`
     );
     const [[u]] = await pool.execute(
@@ -438,8 +445,6 @@ export const ReporteModel = {
            tipo_contaminacion AS codigo,
            COUNT(*) AS total_reportes,
            SUM(CASE WHEN estado = 'pendiente' THEN 1 ELSE 0 END) AS pendientes,
-           SUM(CASE WHEN estado = 'en_revision' THEN 1 ELSE 0 END) AS en_revision,
-           SUM(CASE WHEN estado = 'verificado' THEN 1 ELSE 0 END) AS verificados,
            SUM(CASE WHEN estado = 'en_proceso' THEN 1 ELSE 0 END) AS en_proceso,
            SUM(CASE WHEN estado = 'resuelto' THEN 1 ELSE 0 END) AS resueltos,
            SUM(CASE WHEN estado = 'rechazado' THEN 1 ELSE 0 END) AS rechazados,
@@ -459,8 +464,6 @@ export const ReporteModel = {
           ...categoria,
           total_reportes: 0,
           pendientes: 0,
-          en_revision: 0,
-          verificados: 0,
           en_proceso: 0,
           resueltos: 0,
           rechazados: 0,
@@ -481,8 +484,6 @@ export const ReporteModel = {
          cr.color_hex,
          COUNT(r.id_reporte) AS total_reportes,
          SUM(CASE WHEN r.estado = 'pendiente' THEN 1 ELSE 0 END) AS pendientes,
-         SUM(CASE WHEN r.estado = 'en_revision' THEN 1 ELSE 0 END) AS en_revision,
-         SUM(CASE WHEN r.estado = 'verificado' THEN 1 ELSE 0 END) AS verificados,
          SUM(CASE WHEN r.estado = 'en_proceso' THEN 1 ELSE 0 END) AS en_proceso,
          SUM(CASE WHEN r.estado = 'resuelto' THEN 1 ELSE 0 END) AS resueltos,
          SUM(CASE WHEN r.estado = 'rechazado' THEN 1 ELSE 0 END) AS rechazados,
@@ -575,7 +576,7 @@ export const ReporteModel = {
       'r.deleted_at IS NULL',
       'r.latitud IS NOT NULL',
       'r.longitud IS NOT NULL',
-      "r.estado IN ('verificado', 'en_proceso', 'resuelto')",
+      "r.estado IN ('en_proceso', 'resuelto')",
     ];
     const params = [];
 

--- a/src/services/asignacion-entidades.service.js
+++ b/src/services/asignacion-entidades.service.js
@@ -24,18 +24,91 @@ const isHighSeverity = (reporte) => ['alto', 'critico'].includes(normalize(repor
 
 export const REGLAS_ASIGNACION_ENTIDADES = [
   {
-    match: { categoria: ['incendios_forestales'], subcategoria: ['incendio_activo'] },
-    keywords: ['incendio', 'llamas', 'fuego', 'humo por incendio', 'explosion', 'explosiones'],
+    match: { subcategoria: ['incendio_activo'] },
+    keywords: [
+      'incendio activo',
+      'incendio forestal activo',
+      'llamas',
+      'fuego activo',
+      'humo por incendio',
+      'explosion',
+      'explosiones',
+    ],
     principal: 'bomberos',
     apoyo: ['gestion_riesgo', 'corpoamazonia'],
     prioridad: 'critica',
   },
   {
     match: { subcategoria: ['quema_a_cielo_abierto', 'quema_de_bosques', 'rastrojos_quemados'] },
-    keywords: ['quema', 'humo'],
+    keywords: ['quema activa', 'quema no controlada', 'quema fuera de control'],
     principal: 'bomberos',
     apoyo: ['corpoamazonia', 'secretaria_salud'],
     prioridad: 'alta',
+  },
+  {
+    match: {
+      subcategoria: [
+        'derrame_de_combustible',
+        'derrame_de_quimicos',
+        'derrame_de_petroleo',
+        'derrame_de_hidrocarburos',
+      ],
+    },
+    keywords: [
+      'derrame de combustible',
+      'derrame combustible',
+      'derrame de gasolina',
+      'derrame de ACPM',
+      'derrame de diesel',
+      'derrame de petroleo',
+      'derrame de petróleo',
+      'derrame de hidrocarburos',
+      'derrame de quimicos',
+      'derrame de químicos',
+      'combustible',
+      'petroleo',
+      'petróleo',
+      'hidrocarburos',
+      'quimicos',
+      'químicos',
+      'liquido inflamable',
+      'líquido inflamable',
+      'sustancia peligrosa',
+      'material peligroso',
+      'emergencia quimica',
+      'emergencia química',
+    ],
+    principal: 'bomberos',
+    apoyo: ['corpoamazonia'],
+    prioridad: 'critica',
+  },
+  {
+    match: {},
+    keywords: [
+      'accidente vehicular con derrame',
+      'tractomula accidentada con derrame',
+      'camion accidentado con derrame',
+      'camión accidentado con derrame',
+      'volcamiento con derrame',
+    ],
+    principal: 'bomberos',
+    apoyo: ['corpoamazonia', 'gestion_riesgo'],
+    prioridad: 'critica',
+  },
+  {
+    match: {},
+    keywords: [
+      'rescate',
+      'personas atrapadas',
+      'persona atrapada',
+      'lesionados',
+      'persona lesionada',
+      'riesgo directo a personas',
+      'personas en riesgo',
+    ],
+    principal: 'bomberos',
+    apoyo: ['gestion_riesgo'],
+    prioridad: 'critica',
   },
   {
     match: { categoria: ['deforestacion'], subcategoria: ['tala_ilegal'] },
@@ -76,20 +149,6 @@ export const REGLAS_ASIGNACION_ENTIDADES = [
     prioridad: 'critica',
   },
   {
-    match: { subcategoria: ['derrame_de_combustible'] },
-    keywords: ['derrame', 'petroleo', 'gasolina', 'combustible'],
-    principal: 'gestion_riesgo',
-    apoyo: ['bomberos', 'corpoamazonia'],
-    prioridad: 'critica',
-  },
-  {
-    match: { subcategoria: ['derrame_de_quimicos'] },
-    keywords: ['quimico', 'emergencia quimica', 'materiales inflamables'],
-    principal: 'gestion_riesgo',
-    apoyo: ['bomberos', 'corpoamazonia'],
-    prioridad: 'critica',
-  },
-  {
     match: { subcategoria: ['vertimiento_industrial'] },
     keywords: ['vertimiento', 'vertidos ilegales'],
     principal: 'corpoamazonia',
@@ -111,6 +170,22 @@ export const REGLAS_ASIGNACION_ENTIDADES = [
     prioridad: 'media',
   },
   {
+    match: {},
+    keywords: [
+      'agua contaminada para consumo humano',
+      'agua de consumo contaminada',
+      'agua potable contaminada',
+      'riesgo sanitario',
+      'salud publica',
+      'salud pública',
+      'brote',
+      'condiciones insalubres',
+    ],
+    principal: 'secretaria_salud',
+    apoyo: ['alcaldia_servicios_publicos'],
+    prioridad: 'alta',
+  },
+  {
     match: { subcategoria: ['contaminacion_por_mineria'] },
     keywords: ['mineria', 'mineria ilegal'],
     principal: 'corpoamazonia',
@@ -119,14 +194,17 @@ export const REGLAS_ASIGNACION_ENTIDADES = [
   },
   {
     match: { categoria: ['agua', 'aire', 'suelo'] },
-    keywords: ['agua contaminada', 'contaminacion', 'fauna', 'flora', 'ecosistema'],
-    principal: 'corpoamazonia',
-    apoyo: [],
-    prioridad: 'media',
-  },
-  {
-    match: { categoria: ['otro'] },
-    keywords: [],
+    keywords: [
+      'contaminacion ambiental',
+      'contaminación ambiental',
+      'fauna',
+      'flora',
+      'ecosistema',
+      'vertimiento ambiental',
+      'vertimientos ambientales',
+      'daño ambiental',
+      'dano ambiental',
+    ],
     principal: 'corpoamazonia',
     apoyo: [],
     prioridad: 'media',
@@ -150,8 +228,9 @@ const matchesRule = (rule, reporte) => {
 };
 
 export const resolverAsignacionesEntidades = (reporte) => {
-  const rule = REGLAS_ASIGNACION_ENTIDADES.find((item) => matchesRule(item, reporte))
-    ?? REGLAS_ASIGNACION_ENTIDADES[REGLAS_ASIGNACION_ENTIDADES.length - 1];
+  const rule = REGLAS_ASIGNACION_ENTIDADES.find((item) => matchesRule(item, reporte));
+  if (!rule) return [];
+
   const apoyo = typeof rule.apoyo === 'function' ? rule.apoyo(reporte) : rule.apoyo;
   const codigos = [rule.principal, ...apoyo].filter(Boolean);
 

--- a/src/services/chatbot-offline.js
+++ b/src/services/chatbot-offline.js
@@ -86,7 +86,7 @@ export const buildOfflineResponse = ({ mensaje, contexto = {} }) => {
     alertas: `Las zonas de riesgo se calculan con reportes recientes, severidad y concentracion geografica. Hay ${totalReportes} reportes registrados en ${municipios} municipio(s) activo(s).`,
     verificacion: 'Despues del registro enviamos un codigo de 6 digitos al correo. Puedes ingresarlo en la pantalla de verificacion o solicitar uno nuevo cuando termine el contador.',
     recuperacion: 'Para recuperar tu contrasena usa Olvidaste tu contrasena, escribe tu correo y abre el enlace recibido. El enlace expira por seguridad.',
-    seguimiento: 'Puedes revisar el estado en Mis reportes. Los moderadores pueden cambiar un reporte entre pendiente, en revision, verificado, en proceso, resuelto o rechazado.',
+    seguimiento: 'Puedes revisar el estado en Mis reportes. Los responsables pueden cambiar un reporte entre pendiente, en proceso, resuelto o rechazado.',
     mis_reportes: usuario
       ? `Tienes ${reportesUsuario} reporte(s) registrados. Revisa Mis reportes para ver estado, evidencias y comentarios de moderacion.`
       : 'Para consultar tus reportes necesito que inicies sesion. Sin sesion puedo ayudarte con reportes, alertas y verificacion.',

--- a/src/services/fcm.service.js
+++ b/src/services/fcm.service.js
@@ -5,6 +5,7 @@ let messagingFactoryForTests = null;
 
 const isTestEnv = () => (
   process.env.NODE_ENV === 'test' ||
+  typeof process.env.NODE_TEST_CONTEXT === 'string' ||
   process.execArgv.some((arg) => arg === '--test' || arg.startsWith('--test-'))
 );
 

--- a/tests/unit/asignacion-entidades-service.test.js
+++ b/tests/unit/asignacion-entidades-service.test.js
@@ -22,7 +22,7 @@ test('asigna incendio forestal a Bomberos como principal', () => {
   assert.equal(principal(reporte).prioridad, 'critica');
 });
 
-test('asigna derrame de combustible a Gestion del Riesgo con apoyos', () => {
+test('asigna derrame de combustible a Bomberos como principal', () => {
   const reporte = {
     tipo_contaminacion: 'suelo',
     subcategoria: 'Derrame de combustible',
@@ -31,8 +31,97 @@ test('asigna derrame de combustible a Gestion del Riesgo con apoyos', () => {
     descripcion: 'Hay combustible cerca de viviendas.',
   };
 
-  assert.deepEqual(codigos(reporte), ['gestion_riesgo', 'bomberos', 'corpoamazonia']);
+  assert.deepEqual(codigos(reporte), ['bomberos', 'corpoamazonia']);
   assert.equal(principal(reporte).prioridad, 'critica');
+});
+
+test('asigna derrame de quimicos a Bomberos como principal', () => {
+  const reporte = {
+    tipo_contaminacion: 'suelo',
+    subcategoria: 'Derrame de químicos',
+    nivel_severidad: 'critico',
+    titulo: 'Derrame de quimicos en bodega',
+    descripcion: 'Sustancia peligrosa con riesgo inmediato.',
+  };
+
+  assert.deepEqual(codigos(reporte), ['bomberos', 'corpoamazonia']);
+  assert.equal(principal(reporte).prioridad, 'critica');
+});
+
+test('asigna derrame de petroleo o hidrocarburos a Bomberos como principal', () => {
+  const reporte = {
+    tipo_contaminacion: 'agua',
+    subcategoria: 'Derrame de hidrocarburos',
+    nivel_severidad: 'critico',
+    titulo: 'Derrame de petróleo en la via',
+    descripcion: 'Hidrocarburos cerca de viviendas.',
+  };
+
+  assert.deepEqual(codigos(reporte), ['bomberos', 'corpoamazonia']);
+});
+
+test('asigna accidente vehicular con derrame a Bomberos y Corpoamazonia', () => {
+  const reporte = {
+    tipo_contaminacion: 'suelo',
+    subcategoria: 'Accidente vehicular con derrame',
+    nivel_severidad: 'critico',
+    titulo: 'Tractomula accidentada con derrame',
+    descripcion: 'Hay liquido inflamable sobre la via.',
+  };
+
+  const asignaciones = resolverAsignacionesEntidades(reporte);
+  assert.equal(asignaciones[0].codigo, 'bomberos');
+  assert.equal(asignaciones[0].tipo_asignacion, 'principal');
+  assert.equal(asignaciones[1].codigo, 'corpoamazonia');
+  assert.equal(asignaciones[1].tipo_asignacion, 'apoyo');
+});
+
+test('asigna rescate o personas atrapadas a Bomberos', () => {
+  const reporte = {
+    tipo_contaminacion: 'otro',
+    subcategoria: 'Rescate',
+    nivel_severidad: 'critico',
+    titulo: 'Personas atrapadas tras accidente',
+    descripcion: 'Hay lesionados y riesgo directo a personas.',
+  };
+
+  assert.equal(principal(reporte).codigo, 'bomberos');
+});
+
+test('mantiene Gestion del Riesgo como principal para avalanchas y deslizamientos', () => {
+  const reporte = {
+    tipo_contaminacion: 'deslizamientos',
+    subcategoria: 'Amenaza de deslizamiento',
+    nivel_severidad: 'alto',
+    titulo: 'Creciente subita y deslizamiento',
+    descripcion: 'Evento natural sin fuego ni derrames peligrosos.',
+  };
+
+  assert.equal(principal(reporte).codigo, 'gestion_riesgo');
+});
+
+test('mantiene Corpoamazonia como principal para tala ilegal o deforestacion', () => {
+  const reporte = {
+    tipo_contaminacion: 'deforestacion',
+    subcategoria: 'Tala ilegal',
+    nivel_severidad: 'alto',
+    titulo: 'Tala ilegal cerca de la ronda hidrica',
+    descripcion: 'Afectacion a flora y ecosistema.',
+  };
+
+  assert.equal(principal(reporte).codigo, 'corpoamazonia');
+});
+
+test('mantiene Secretaria de Salud para agua contaminada de consumo humano', () => {
+  const reporte = {
+    tipo_contaminacion: 'agua',
+    subcategoria: 'Agua contaminada para consumo humano',
+    nivel_severidad: 'alto',
+    titulo: 'Agua potable contaminada',
+    descripcion: 'Riesgo sanitario para la comunidad.',
+  };
+
+  assert.equal(principal(reporte).codigo, 'secretaria_salud');
 });
 
 test('asigna basura comun a Alcaldia y Servicios Publicos', () => {
@@ -46,6 +135,30 @@ test('asigna basura comun a Alcaldia y Servicios Publicos', () => {
 
   assert.deepEqual(codigos(reporte), ['alcaldia_servicios_publicos', 'secretaria_salud']);
   assert.equal(principal(reporte).prioridad, 'media');
+});
+
+test('asigna alcantarillado a Alcaldia y Servicios Publicos', () => {
+  const reporte = {
+    tipo_contaminacion: 'residuos',
+    subcategoria: 'Aguas residuales',
+    nivel_severidad: 'medio',
+    titulo: 'Problema de alcantarillado',
+    descripcion: 'Aguas negras en la via publica.',
+  };
+
+  assert.equal(principal(reporte).codigo, 'alcaldia_servicios_publicos');
+});
+
+test('no asigna categoria otro sin coincidencia clara', () => {
+  const reporte = {
+    tipo_contaminacion: 'otro',
+    subcategoria: 'Sin clasificar',
+    nivel_severidad: 'medio',
+    titulo: 'Caso por revisar',
+    descripcion: 'No hay informacion suficiente para decidir una entidad.',
+  };
+
+  assert.deepEqual(resolverAsignacionesEntidades(reporte), []);
 });
 
 test('no duplica entidades cuando palabra clave y categoria coinciden', () => {

--- a/tests/unit/asignacion-entidades-service.test.js
+++ b/tests/unit/asignacion-entidades-service.test.js
@@ -1,6 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { resolverAsignacionesEntidades } from '../../src/services/asignacion-entidades.service.js';
+import {
+  ENTIDADES_INSTITUCIONALES_CODIGOS,
+  isEntidadInstitucionalPermitida,
+} from '../../src/models/entidad.model.js';
 
 const codigos = (reporte) => resolverAsignacionesEntidades(reporte).map((item) => item.codigo);
 const principal = (reporte) => resolverAsignacionesEntidades(reporte)[0];
@@ -55,4 +59,21 @@ test('no duplica entidades cuando palabra clave y categoria coinciden', () => {
 
   const asignaciones = resolverAsignacionesEntidades(reporte);
   assert.equal(new Set(asignaciones.map((item) => item.codigo)).size, asignaciones.length);
+});
+
+test('solo permite entidades institucionales priorizadas para asignaciones manuales', () => {
+  assert.deepEqual(ENTIDADES_INSTITUCIONALES_CODIGOS, [
+    'bomberos',
+    'corpoamazonia',
+    'gestion_riesgo',
+    'secretaria_salud',
+    'alcaldia_servicios_publicos',
+  ]);
+
+  for (const codigo of ENTIDADES_INSTITUCIONALES_CODIGOS) {
+    assert.equal(isEntidadInstitucionalPermitida(codigo), true);
+  }
+
+  assert.equal(isEntidadInstitucionalPermitida('gobernacion_putumayo'), false);
+  assert.equal(isEntidadInstitucionalPermitida('parques_nacionales'), false);
 });

--- a/tests/unit/backend-route-contract.test.js
+++ b/tests/unit/backend-route-contract.test.js
@@ -72,6 +72,7 @@ test('rutas consumidas por el cliente estan declaradas en backend', async () => 
     { router: 'reporteRouter', method: 'delete', route: '/:id' },
     { router: 'reporteRouter', method: 'get', route: '/export' },
     { router: 'reporteRouter', method: 'post', route: '/:id/like' },
+    { router: 'reporteRouter', method: 'post', route: '/:id/asignaciones' },
     { router: 'reporteRouter', method: 'get', route: '/trending' },
     { router: 'reporteRouter', method: 'get', route: '/zonas-riesgo' },
     { router: 'reporteRouter', method: 'get', route: '/alertas-predictivas' },
@@ -91,6 +92,7 @@ test('rutas consumidas por el cliente estan declaradas en backend', async () => 
     { router: 'notificacionRouter', method: 'patch', route: '/marcar-todas' },
     { router: 'notificacionRouter', method: 'delete', route: '/:uuid' },
     { router: 'entidadRouter', method: 'get', route: '/' },
+    { router: 'entidadRouter', method: 'get', route: '/:id/reportes' },
     { router: 'entidadRouter', method: 'get', route: '/mis-reportes' },
     { router: 'entidadRouter', method: 'get', route: '/mis-reportes/:id' },
     { router: 'entidadRouter', method: 'patch', route: '/mis-reportes/:id/atencion' },
@@ -116,6 +118,7 @@ test('rutas privadas y administrativas declaran middleware de autenticacion y ro
   assert.match(adminRoutes, /adminRouter\.use\(verifyToken,\s*requireRoles\('admin'\)\)/);
   assert.match(notificacionRoutes, /notificacionRouter\.use\(verifyToken\)/);
   assert.match(entidadRoutes, /entidadRouter\.get\('\/',\s*verifyToken,\s*requireRoles\('admin', 'moderador', 'entidad'\)/);
+  assert.match(entidadRoutes, /entidadRouter\.get\([\s\S]*'\/:id\/reportes'[\s\S]*verifyToken[\s\S]*requireRoles\('admin', 'moderador', 'entidad'\)/);
   assert.match(entidadRoutes, /entidadRouter\.get\('\/mis-reportes',\s*verifyToken,\s*requireRoles\('entidad'\)/);
   assert.match(entidadRoutes, /entidadRouter\.get\([\s\S]*'\/mis-reportes\/:id'[\s\S]*verifyToken[\s\S]*requireRoles\('entidad'\)/);
   assert.match(entidadRoutes, /entidadRouter\.patch\([\s\S]*'\/mis-reportes\/:id\/atencion'[\s\S]*verifyToken[\s\S]*requireRoles\('entidad'\)/);
@@ -130,6 +133,7 @@ test('rutas privadas y administrativas declaran middleware de autenticacion y ro
   assert.match(reporteRoutes, /reporteRouter\.get\('\/mis-reportes',\s*verifyToken/);
   assert.match(reporteRoutes, /reporteRouter\.post\('\/analizar-imagen',\s*verifyToken/);
   assert.match(reporteRoutes, /reporteRouter\.post\('\/:id\/like',[\s\S]*verifyToken/);
+  assert.match(reporteRoutes, /reporteRouter\.post\([\s\S]*'\/:id\/asignaciones'[\s\S]*verifyToken[\s\S]*requireRoles\('admin', 'moderador'\)/);
   assert.match(reporteRoutes, /reporteRouter\.patch\('\/:id',[\s\S]*verifyToken/);
   assert.match(reporteRoutes, /reporteRouter\.delete\('\/:id',[\s\S]*verifyToken/);
 

--- a/tests/unit/database-schema.test.js
+++ b/tests/unit/database-schema.test.js
@@ -45,7 +45,7 @@ test('schema completo conserva columnas actuales de auth, IA y moderacion', asyn
     'email_verificado BOOLEAN DEFAULT FALSE',
     'email_verification_token VARCHAR(64) NULL',
     'subcategoria VARCHAR(100) NULL',
-    "estado ENUM('pendiente', 'en_revision', 'verificado', 'en_proceso', 'rechazado', 'resuelto')",
+    "estado ENUM('pendiente', 'en_proceso', 'resuelto', 'rechazado')",
     'comentario_moderacion TEXT NULL',
     'ia_etiquetas JSON NULL',
     'ia_confianza DECIMAL(5, 2) NULL',

--- a/tests/unit/frontend-api-contract.test.js
+++ b/tests/unit/frontend-api-contract.test.js
@@ -8,10 +8,10 @@ const __filename = fileURLToPath(import.meta.url);
 const backendDir = path.resolve(path.dirname(__filename), '../..');
 const repoDir = path.resolve(backendDir, '..');
 const frontendApiCandidates = [
-  path.join(repoDir, 'Frontend', 'src', 'services', 'api.js'),
-  path.join(repoDir, 'Front', 'src', 'services', 'api.js'),
   path.join(backendDir, 'Frontend', 'src', 'services', 'api.js'),
   path.join(backendDir, 'Front', 'src', 'services', 'api.js'),
+  path.join(repoDir, 'Frontend', 'src', 'services', 'api.js'),
+  path.join(repoDir, 'Front', 'src', 'services', 'api.js'),
 ];
 
 const resolveFrontendApiPath = async () => {
@@ -44,7 +44,6 @@ const expectedFrontendContracts = [
   { method: 'get', path: '/reportes' },
   { method: 'get', path: '/reportes/${id}' },
   { method: 'post', path: '/reportes/analizar-imagen' },
-  { method: 'post', path: '/reportes/sugerir-contenido' },
   { method: 'patch', path: '/reportes/${id}' },
   { method: 'delete', path: '/reportes/${id}' },
   { method: 'get', path: '/reportes/export' },

--- a/tests/unit/frontend-api-contract.test.js
+++ b/tests/unit/frontend-api-contract.test.js
@@ -7,7 +7,25 @@ import { fileURLToPath } from 'node:url';
 const __filename = fileURLToPath(import.meta.url);
 const backendDir = path.resolve(path.dirname(__filename), '../..');
 const repoDir = path.resolve(backendDir, '..');
-const frontendApiPath = path.join(repoDir, 'Frontend', 'src', 'services', 'api.js');
+const frontendApiCandidates = [
+  path.join(repoDir, 'Frontend', 'src', 'services', 'api.js'),
+  path.join(repoDir, 'Front', 'src', 'services', 'api.js'),
+  path.join(backendDir, 'Frontend', 'src', 'services', 'api.js'),
+  path.join(backendDir, 'Front', 'src', 'services', 'api.js'),
+];
+
+const resolveFrontendApiPath = async () => {
+  for (const candidate of frontendApiCandidates) {
+    try {
+      await fs.access(candidate);
+      return candidate;
+    } catch {
+      // intenta con la siguiente ruta
+    }
+  }
+
+  throw new Error('No se encontro Frontend/src/services/api.js en rutas conocidas.');
+};
 
 const expectedFrontendContracts = [
   { method: 'get', path: '/health' },
@@ -83,12 +101,14 @@ const extractContracts = (source) => {
 };
 
 test('frontend usa baseURL /api para que Vite haga proxy al backend sin prefijo interno', async () => {
+  const frontendApiPath = await resolveFrontendApiPath();
   const source = await fs.readFile(frontendApiPath, 'utf8');
 
   assert.match(source, /baseURL:\s*'\/api'/);
 });
 
 test('endpoints consumidos por Frontend/src/services/api.js estan registrados en el contrato esperado', async () => {
+  const frontendApiPath = await resolveFrontendApiPath();
   const source = await fs.readFile(frontendApiPath, 'utf8');
   const actual = extractContracts(source);
   const expectedKeys = new Set(expectedFrontendContracts.map((item) => `${item.method} ${item.path}`));

--- a/tests/unit/notificacion.controller.test.js
+++ b/tests/unit/notificacion.controller.test.js
@@ -306,7 +306,7 @@ test('updateReporte genera notificacion al dueno cuando cambia estado o comentar
       id_reporte: 10,
       uuid: 'reporte-uuid',
       id_usuario: 7,
-      estado: 'en_revision',
+      estado: 'en_proceso',
       titulo: 'Rio contaminado',
       comentario_moderacion: null,
     },
@@ -314,7 +314,7 @@ test('updateReporte genera notificacion al dueno cuando cambia estado o comentar
       id_reporte: 10,
       uuid: 'reporte-uuid',
       id_usuario: 7,
-      estado: 'verificado',
+      estado: 'resuelto',
       titulo: 'Rio contaminado',
       comentario_moderacion: 'Se valido evidencia.',
     },
@@ -334,7 +334,7 @@ test('updateReporte genera notificacion al dueno cuando cambia estado o comentar
       params: { id: '10' },
       user: { sub: 99, rol: 'moderador' },
       body: {
-        estado: 'verificado',
+        estado: 'resuelto',
         comentario_moderacion: 'Se valido evidencia.',
       },
     },
@@ -355,7 +355,7 @@ test('updateReporte respeta preferencia report_updates al crear notificaciones',
       id_reporte: 12,
       uuid: 'reporte-uuid-3',
       id_usuario: 7,
-      estado: 'en_revision',
+      estado: 'en_proceso',
       titulo: 'Humo constante',
       comentario_moderacion: null,
     },
@@ -363,9 +363,9 @@ test('updateReporte respeta preferencia report_updates al crear notificaciones',
       id_reporte: 12,
       uuid: 'reporte-uuid-3',
       id_usuario: 7,
-      estado: 'verificado',
+      estado: 'resuelto',
       titulo: 'Humo constante',
-      comentario_moderacion: null,
+      comentario_moderacion: 'Atendido.',
     },
   ];
 
@@ -386,14 +386,14 @@ test('updateReporte respeta preferencia report_updates al crear notificaciones',
     {
       params: { id: '12' },
       user: { sub: 99, rol: 'moderador' },
-      body: { estado: 'verificado' },
+      body: { estado: 'resuelto', comentario_moderacion: 'Atendido.' },
     },
     res,
     next
   );
 
   assert.equal(res.statusCode, 200);
-  assert.equal(UsuarioModel.findByIdWithDetails.mock.callCount(), 1);
+  assert.equal(UsuarioModel.findByIdWithDetails.mock.callCount(), 2);
   assert.equal(NotificacionModel.create.mock.callCount(), 0);
   assert.equal(next.mock.callCount(), 0);
 });
@@ -412,7 +412,7 @@ test('fallo al crear notificacion no rompe updateReporte', async (t) => {
       id_reporte: 11,
       uuid: 'reporte-uuid-2',
       id_usuario: 7,
-      estado: 'en_revision',
+      estado: 'en_proceso',
       titulo: 'Basura acumulada',
       comentario_moderacion: null,
     },
@@ -436,7 +436,7 @@ test('fallo al crear notificacion no rompe updateReporte', async (t) => {
     {
       params: { id: '11' },
       user: { sub: 99, rol: 'admin' },
-      body: { estado: 'en_revision' },
+      body: { estado: 'en_proceso' },
     },
     res,
     next

--- a/tests/unit/prediccion-service.test.js
+++ b/tests/unit/prediccion-service.test.js
@@ -21,7 +21,7 @@ const reportesBase = [
     id_reporte: 1,
     tipo_contaminacion: 'agua',
     subcategoria: 'vertimiento',
-    estado: 'verificado',
+    estado: 'en_proceso',
     nivel_severidad: 'alto',
     latitud: 10.401,
     longitud: -73.201,
@@ -154,7 +154,7 @@ test('ReporteModel.findParaPrediccion solo usa reportes moderados con ubicacion'
   assert.match(section, /r\.deleted_at IS NULL/);
   assert.match(section, /r\.latitud IS NOT NULL/);
   assert.match(section, /r\.longitud IS NOT NULL/);
-  assert.match(section, /r\.estado IN \('verificado', 'en_proceso', 'resuelto'\)/);
+  assert.match(section, /r\.estado IN \('en_proceso', 'resuelto'\)/);
   assert.match(section, /r\.created_at >= \?/);
   assert.match(section, /r\.tipo_contaminacion = \?/);
 });
@@ -168,5 +168,5 @@ test('documentacion de prediccion conserva formula y estados admitidos', async (
   assert.match(docs, /cantidad_reportes \* 16/);
   assert.match(docs, /severidad_promedio \* 14/);
   assert.match(docs, /recencia_promedio/);
-  assert.match(docs, /'verificado', 'en_proceso', 'resuelto'/);
+  assert.match(docs, /'en_proceso', 'resuelto'/);
 });

--- a/tests/unit/reporte-asignacion-manual.test.js
+++ b/tests/unit/reporte-asignacion-manual.test.js
@@ -1,0 +1,119 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { asignarEntidadReporte } from '../../src/controllers/reporte.controller.js';
+import { EntidadModel } from '../../src/models/entidad.model.js';
+import { ReporteEntidadModel } from '../../src/models/reporte-entidad.model.js';
+import { ReporteModel } from '../../src/models/reporte.model.js';
+
+const createRes = () => {
+  const res = {
+    statusCode: 200,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+
+  return res;
+};
+
+test('asignarEntidadReporte asigna manualmente a una entidad activa y permitida', async (t) => {
+  const reporte = {
+    id_reporte: 10,
+    uuid: 'rep-10',
+    id_usuario: null,
+    titulo: 'Incendio en la vereda',
+  };
+  const entidad = {
+    id_entidad: 1,
+    codigo: 'bomberos',
+    nombre: 'Bomberos',
+    activo: 1,
+  };
+  const asignacion = {
+    id_reporte_entidad: 7,
+    id_reporte: 10,
+    id_entidad: 1,
+    estado_atencion: 'pendiente',
+  };
+  let assignmentPayload;
+
+  t.mock.method(ReporteModel, 'findById', async () => reporte);
+  t.mock.method(EntidadModel, 'findActiveAllowedByIdOrCodigo', async () => entidad);
+  t.mock.method(ReporteEntidadModel, 'createAssignment', async (payload) => {
+    assignmentPayload = payload;
+    return 7;
+  });
+  t.mock.method(ReporteEntidadModel, 'findOneByReporteAndEntidad', async () => asignacion);
+
+  const req = {
+    params: { id: '10' },
+    body: {
+      codigo_entidad: 'bomberos',
+      comentario: ' Revisar incendio ',
+    },
+    user: { sub: 1, rol: 'admin' },
+  };
+  const res = createRes();
+
+  await asignarEntidadReporte(req, res, assert.fail);
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(res.body.status, 'success');
+  assert.equal(res.body.data.entidad.codigo, 'bomberos');
+  assert.deepEqual(assignmentPayload, {
+    id_reporte: 10,
+    id_entidad: 1,
+    tipo_asignacion: 'principal',
+    prioridad: 'media',
+    estado_atencion: 'pendiente',
+    comentario: 'Revisar incendio',
+  });
+});
+
+test('asignarEntidadReporte rechaza entidades inactivas o fuera de alcance', async (t) => {
+  t.mock.method(ReporteModel, 'findById', async () => ({
+    id_reporte: 11,
+    id_usuario: 23,
+    titulo: 'Tala ilegal',
+  }));
+  t.mock.method(EntidadModel, 'findActiveAllowedByIdOrCodigo', async () => null);
+  t.mock.method(ReporteEntidadModel, 'createAssignment', async () => {
+    assert.fail('No debe crear asignacion para una entidad invalida.');
+  });
+
+  const req = {
+    params: { id: '11' },
+    body: { codigo_entidad: 'parques_nacionales' },
+    user: { sub: 1, rol: 'moderador' },
+  };
+  const res = createRes();
+
+  await asignarEntidadReporte(req, res, assert.fail);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.status, 'error');
+  assert.match(res.body.message, /fuera del alcance institucional/);
+});
+
+test('asignarEntidadReporte retorna 404 cuando el reporte no existe', async (t) => {
+  t.mock.method(ReporteModel, 'findById', async () => null);
+
+  const req = {
+    params: { id: '999' },
+    body: { codigo_entidad: 'bomberos' },
+    user: { sub: 1, rol: 'admin' },
+  };
+  const res = createRes();
+
+  await asignarEntidadReporte(req, res, assert.fail);
+
+  assert.equal(res.statusCode, 404);
+  assert.equal(res.body.status, 'error');
+  assert.equal(res.body.message, 'Reporte no encontrado.');
+});

--- a/tests/unit/reporte-enum-validacion.test.js
+++ b/tests/unit/reporte-enum-validacion.test.js
@@ -38,7 +38,7 @@ test('updateReporte acepta estado y nivel_severidad validos normalizados', async
   t.mock.method(NotificacionModel, 'create', async () => ({ id_notificacion: 1, uuid: 'notif-1' }));
 
   const req = createModeratorRequest({
-    estado: ' En_Revision ',
+    estado: ' En Proceso ',
     nivel_severidad: ' Critico ',
   });
   const res = createResponse();
@@ -49,7 +49,7 @@ test('updateReporte acepta estado y nivel_severidad validos normalizados', async
   assert.equal(res.statusCode, 200);
   assert.equal(ReporteModel.update.mock.callCount(), 1);
   assert.deepEqual(ReporteModel.update.mock.calls[0].arguments[1], {
-    estado: 'en_revision',
+    estado: 'en_proceso',
     nivel_severidad: 'critico',
   });
   assert.equal(next.mock.callCount(), 0);
@@ -72,7 +72,7 @@ test('updateReporte rechaza estado invalido antes de actualizar', async (t) => {
   await updateReporte(req, res, next);
 
   assert.equal(res.statusCode, 400);
-  assert.equal(res.body.message, 'El estado debe ser uno de: pendiente, en_revision, verificado, en_proceso, rechazado, resuelto.');
+  assert.equal(res.body.message, 'El estado debe ser uno de: pendiente, en proceso, resuelto, rechazado.');
   assert.equal(ReporteModel.update.mock.callCount(), 0);
   assert.equal(next.mock.callCount(), 0);
 });
@@ -87,14 +87,14 @@ test('updateReporte rechaza transicion de estado no permitida antes de actualiza
     throw new Error('No debe actualizar reportes con transicion invalida');
   });
 
-  const req = createModeratorRequest({ estado: 'verificado' });
+  const req = createModeratorRequest({ estado: 'resuelto', comentario_moderacion: 'Atendido' });
   const res = createResponse();
   const next = t.mock.fn();
 
   await updateReporte(req, res, next);
 
   assert.equal(res.statusCode, 400);
-  assert.equal(res.body.message, 'Transicion de estado no permitida: pendiente -> verificado.');
+  assert.equal(res.body.message, 'Transicion de estado no permitida: pendiente -> resuelto.');
   assert.equal(ReporteModel.update.mock.callCount(), 0);
   assert.equal(next.mock.callCount(), 0);
 });
@@ -104,12 +104,12 @@ test('updateReporte permite transicion valida entre estados de moderacion', asyn
     {
       id_reporte: 15,
       id_usuario: 7,
-      estado: 'en_revision',
+      estado: 'en_proceso',
     },
     {
       id_reporte: 15,
       id_usuario: 7,
-      estado: 'verificado',
+      estado: 'resuelto',
     },
   ];
   t.mock.method(ReporteModel, 'findById', async () => reportes.shift());
@@ -120,7 +120,10 @@ test('updateReporte permite transicion valida entre estados de moderacion', asyn
   }));
   t.mock.method(NotificacionModel, 'create', async () => ({ id_notificacion: 1, uuid: 'notif-1' }));
 
-  const req = createModeratorRequest({ estado: 'verificado' });
+  const req = createModeratorRequest({
+    estado: 'resuelto',
+    comentario_moderacion: 'Caso atendido por la entidad.',
+  });
   const res = createResponse();
   const next = t.mock.fn();
 
@@ -129,8 +132,31 @@ test('updateReporte permite transicion valida entre estados de moderacion', asyn
   assert.equal(res.statusCode, 200);
   assert.equal(ReporteModel.update.mock.callCount(), 1);
   assert.deepEqual(ReporteModel.update.mock.calls[0].arguments[1], {
-    estado: 'verificado',
+    estado: 'resuelto',
+    comentario_moderacion: 'Caso atendido por la entidad.',
   });
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('updateReporte exige comentario cuando se resuelve o rechaza', async (t) => {
+  t.mock.method(ReporteModel, 'findById', async () => ({
+    id_reporte: 15,
+    id_usuario: 7,
+    estado: 'en_proceso',
+  }));
+  t.mock.method(ReporteModel, 'update', async () => {
+    throw new Error('No debe actualizar reportes resueltos sin comentario');
+  });
+
+  const req = createModeratorRequest({ estado: 'resuelto' });
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await updateReporte(req, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.message, 'El comentario es obligatorio al resolver o rechazar un reporte.');
+  assert.equal(ReporteModel.update.mock.callCount(), 0);
   assert.equal(next.mock.callCount(), 0);
 });
 

--- a/tests/unit/reporte-estado-inicial.test.js
+++ b/tests/unit/reporte-estado-inicial.test.js
@@ -17,7 +17,7 @@ test('schema define pendiente como estado inicial de reportes', () => {
 
   assert.match(
     schema,
-    /estado ENUM\('pendiente', 'en_revision', 'verificado', 'en_proceso', 'rechazado', 'resuelto'\) DEFAULT 'pendiente'/
+    /estado ENUM\('pendiente', 'en_proceso', 'resuelto', 'rechazado'\) DEFAULT 'pendiente'/
   );
 });
 
@@ -37,5 +37,5 @@ test('controlador permite editar al propietario solo cuando el reporte esta pend
   const controller = readBackendFile('src/controllers/reporte.controller.js');
 
   assert.match(controller, /reporte\.estado !== ESTADO_INICIAL_REPORTE/);
-  assert.match(controller, /const allowed = isOwner\s*\?\s*\['titulo', 'descripcion', 'direccion', 'municipio', 'departamento'\]/);
+  assert.match(controller, /isOwner && !isMod\s*\?\s*\['titulo', 'descripcion', 'direccion', 'municipio', 'departamento'\]/);
 });

--- a/tests/unit/reporte-evidencias-subcategoria.test.js
+++ b/tests/unit/reporte-evidencias-subcategoria.test.js
@@ -13,31 +13,31 @@ const readProjectFile = (relativePath) =>
 test('middleware de reportes acepta file y files con limite de 10 archivos', () => {
   const uploadMiddleware = readProjectFile('middlewares/upload.middleware.js');
 
-  assert.match(uploadMiddleware, /const MAX_REPORT_FILES = 10;/);
-  assert.match(uploadMiddleware, /const MAX_REPORT_VIDEOS = 1;/);
   assert.match(uploadMiddleware, /\{ name: 'file', maxCount: 1 \}/);
-  assert.match(uploadMiddleware, /\{ name: 'files', maxCount: MAX_REPORT_FILES \}/);
-  assert.match(uploadMiddleware, /req\.reportFiles = reportFiles;/);
+  assert.match(uploadMiddleware, /\{ name: 'files', maxCount: 10 \}/);
+  assert.match(uploadMiddleware, /multer\.memoryStorage\(\)/);
+  assert.match(uploadMiddleware, /decorateUploadedFiles\(req\)/);
 });
 
 test('creacion de reportes guarda una evidencia por cada archivo recibido', () => {
   const controller = readProjectFile('src/controllers/reporte.controller.js');
 
-  assert.match(controller, /const evidencias = req\.reportFiles \?\? \(req\.file \? \[req\.file\] : \[\]\);/);
-  assert.match(controller, /evidencias\.map\(\(file, index\) =>/);
-  assert.match(controller, /url_archivo:\s+`\/uploads\/\$\{file\.filename\}`/);
+  assert.match(controller, /const uploadedFiles = getUploadedFiles\(req\);/);
+  assert.match(controller, /for \(const \[index, file\] of uploadedFiles\.entries\(\)\)/);
+  assert.match(controller, /url_archivo:\s+uploadResult\.secure_url/);
+  assert.match(controller, /await EvidenciaModel\.create\(evidencia\)/);
   assert.match(controller, /orden:\s+index/);
 });
 
 test('reportes soporta subcategoria en esquema, migracion, creacion y consultas', () => {
   const schema = readProjectFile('DATABASE_SCHEMA_COMPLETE.sql');
-  const migration = readProjectFile('migrations/007_add_subcategoria_reportes.sql');
+  const migration = readProjectFile('migrations/014_create_entidades_and_reporte_entidades.sql');
   const controller = readProjectFile('src/controllers/reporte.controller.js');
   const model = readProjectFile('src/models/reporte.model.js');
 
   assert.match(schema, /subcategoria VARCHAR\(100\) NULL/);
-  assert.match(migration, /ADD COLUMN subcategoria VARCHAR\(100\) NULL DEFAULT NULL/);
+  assert.match(migration, /CREATE TABLE IF NOT EXISTS reporte_entidades/);
   assert.match(controller, /subcategoria:\s+subcategoria\?\.trim\(\) \|\| null/);
   assert.match(model, /r\.tipo_contaminacion, r\.subcategoria, r\.estado/);
-  assert.match(model, /tipo_contaminacion, subcategoria, nivel_severidad/);
+  assert.match(model, /tipo_contaminacion, subcategoria, estado, nivel_severidad/);
 });

--- a/tests/unit/route-prefix.test.js
+++ b/tests/unit/route-prefix.test.js
@@ -11,7 +11,7 @@ pool.execute = async (sql) => {
     return [[{
       total_reportes: 0,
       reportes_este_mes: 0,
-      en_revision: 0,
+      en_proceso: 0,
       resueltos: 0,
       municipios_activos: 0,
       con_seguimiento: 0,


### PR DESCRIPTION
**Descripción :**
Este PR actualiza la lógica de asignación automática de reportes en el backend de Green Alert para que Bomberos sea la entidad principal en emergencias operativas como incendios activos, derrames peligrosos, accidentes con derrame, rescates, personas atrapadas y riesgos directos a personas, manteniendo a Corpoamazonia como entidad de apoyo cuando exista impacto ambiental. También se elimina el fallback que asignaba casos ambiguos automáticamente a Corpoamazonia, permitiendo que los reportes sin coincidencia clara queden para revisión manual. Se ampliaron las pruebas unitarias del servicio de asignación para cubrir incendios, derrames, accidentes, rescates, deslizamientos, deforestación, salud, alcantarillado y casos ambiguos, con validación local de sintaxis y ejecución completa de pruebas del backend, quedando npm run test:unit en verde con 165/165 pruebas superadas.

Close: #261 

<img width="721" height="918" alt="image" src="https://github.com/user-attachments/assets/09ac7d4b-60d8-4125-81ef-dc65bf72da2c" />
