### PR TITLE
Completa flujo backend de entidades, alertas y asignaciones con prioridad

### DIFF
--- a/docs/integracion-frontend-entidades.md
+++ b/docs/integracion-frontend-entidades.md
@@ -1,0 +1,401 @@
+# Integracion frontend para entidades, reportes y alertas
+
+Esta guia documenta los contratos actuales del backend para construir el panel de usuario entidad en Green Alert. No se debe enviar `id_entidad` desde el frontend para consultar datos propios: el backend siempre toma la entidad desde el JWT (`id_entidad` o `entidad_id`).
+
+## Base URL
+
+El backend monta las rutas con `API_PREFIX`. Si `API_PREFIX` esta vacio, las rutas reales son `/entidades/...`. En el frontend actual puede usarse `/api` si Vite esta configurado como proxy hacia el backend.
+
+Ejemplo:
+
+```js
+const API_BASE = '/api';
+const token = localStorage.getItem('token');
+
+const response = await fetch(`${API_BASE}/entidades/mis-reportes`, {
+  headers: { Authorization: `Bearer ${token}` },
+});
+```
+
+## Entidades activas
+
+Las entidades institucionales disponibles para esta fase son:
+
+| Codigo | Nombre |
+| --- | --- |
+| `bomberos` | Bomberos |
+| `corpoamazonia` | Corpoamazonia |
+| `gestion_riesgo` | Gestion del Riesgo |
+| `secretaria_salud` | Secretaria de Salud |
+| `alcaldia_servicios_publicos` | Alcaldia / Servicios Publicos |
+
+## Reglas funcionales generales
+
+| Caso reportado | Entidad esperada |
+| --- | --- |
+| Incendios activos, rescates, accidentes con derrame, derrames peligrosos, personas atrapadas o riesgo directo a personas | Bomberos |
+| Impacto ambiental, deforestacion, vertimientos, contaminacion, fauna o flora | Corpoamazonia |
+| Avalanchas, crecientes, inundaciones, deslizamientos y amenazas naturales | Gestion del Riesgo |
+| Riesgo sanitario, agua de consumo contaminada, residuos hospitalarios o salud publica | Secretaria de Salud |
+| Basuras comunes, escombros, alcantarillado y servicios publicos | Alcaldia / Servicios Publicos |
+| Casos ambiguos o sin regla clara | Revision manual |
+
+Las asignaciones pueden tener prioridad `baja`, `media`, `alta` o `critica`. Las alertas persistentes por entidad se crean solo para asignaciones `alta` y `critica`.
+
+## Seguridad
+
+Todos los endpoints de `mis-reportes` y `mis-alertas` requieren:
+
+- Header `Authorization: Bearer <jwt>`.
+- Rol `entidad`.
+- Usuario entidad con `id_entidad` o `entidad_id` en el token.
+
+El frontend no debe enviar ni confiar en `id_entidad` para estos endpoints. Si el usuario intenta manipular query params o body con otra entidad, el backend los ignora en los endpoints propios.
+
+Errores comunes:
+
+| Estado | Caso | Mensaje esperado |
+| --- | --- | --- |
+| `401` | Token ausente | `acceso denegado. token no proporcionado.` |
+| `403` | Token invalido o expirado | `token invalido o expirado.` |
+| `403` | Rol distinto de `entidad` | `acceso denegado. rol no autorizado.` |
+| `403` | Usuario entidad sin entidad asociada | `Usuario entidad sin entidad asignada.` |
+| `404` | Alerta o reporte no pertenece a la entidad | `Alerta de entidad no encontrada.` o `Reporte asignado no encontrado.` |
+
+## Reportes asignados
+
+### GET `/entidades/mis-reportes`
+
+Lista reportes asignados a la entidad autenticada.
+
+Query params soportados:
+
+- `prioridad`
+- `estado_atencion`
+- `tipo_asignacion`
+- `categoria`
+- `severidad`
+- `limit`
+- `offset`
+
+Respuesta esperada:
+
+```json
+{
+  "status": "success",
+  "message": "Reportes asignados obtenidos correctamente.",
+  "data": {
+    "reportes": [
+      {
+        "id_reporte": 101,
+        "uuid": "uuid-reporte",
+        "titulo": "Derrame de combustible",
+        "descripcion": "Derrame cerca al rio",
+        "categoria": "suelo",
+        "tipo_contaminacion": "suelo",
+        "subcategoria": "derrame_de_combustible",
+        "severidad": "critico",
+        "nivel_severidad": "critico",
+        "estado": "pendiente",
+        "latitud": 1.15,
+        "longitud": -76.65,
+        "direccion": "Via principal",
+        "municipio": "Mocoa",
+        "departamento": "Putumayo",
+        "created_at": "2026-06-01T10:00:00.000Z",
+        "updated_at": "2026-06-01T10:00:00.000Z",
+        "asignacion": {
+          "id_reporte_entidad": 70,
+          "tipo_asignacion": "principal",
+          "prioridad": "critica",
+          "estado_atencion": "pendiente",
+          "comentario": null,
+          "asignado_at": "2026-06-01T10:05:00.000Z",
+          "actualizado_at": null
+        },
+        "entidad": {
+          "id_entidad": 1,
+          "codigo": "bomberos",
+          "nombre": "Bomberos"
+        }
+      }
+    ],
+    "total": 1,
+    "limit": 20,
+    "offset": 0
+  }
+}
+```
+
+Ejemplo frontend:
+
+```js
+export async function getMisReportesEntidad(token, filtros = {}) {
+  const params = new URLSearchParams(filtros);
+  const response = await fetch(`/api/entidades/mis-reportes?${params}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!response.ok) throw await response.json();
+  return response.json();
+}
+```
+
+### GET `/entidades/mis-reportes/:id`
+
+Obtiene el detalle de un reporte asignado a la entidad autenticada e incluye evidencias.
+
+### PATCH `/entidades/mis-reportes/:id/atencion`
+
+Actualiza el estado de atencion de la asignacion de la entidad autenticada.
+
+Body:
+
+```json
+{
+  "estado_atencion": "en_atencion",
+  "comentario": "Equipo en desplazamiento."
+}
+```
+
+Estados aceptados: `pendiente`, `en_atencion`, `atendido`, `cerrado`.
+
+## Alertas persistentes por entidad
+
+Las alertas se crean automaticamente cuando una asignacion de reporte tiene prioridad `alta` o `critica`.
+
+- `critica` crea `tipo_alerta: reporte_critico_asignado`.
+- `alta` crea `tipo_alerta: reporte_prioritario_asignado`.
+- `media` y `baja` no crean alerta persistente.
+
+### GET `/entidades/mis-alertas`
+
+Lista todas las alertas de la entidad autenticada.
+
+Query params:
+
+- `limit`
+- `offset`
+
+Respuesta esperada:
+
+```json
+{
+  "status": "success",
+  "message": "Alertas de entidad obtenidas correctamente.",
+  "data": {
+    "alertas": [
+      {
+        "id_alerta_entidad": 12,
+        "uuid": "uuid-alerta",
+        "id_reporte_entidad": 70,
+        "id_reporte": 101,
+        "id_entidad": 1,
+        "tipo_alerta": "reporte_critico_asignado",
+        "prioridad": "critica",
+        "titulo": "Reporte critico asignado",
+        "mensaje": "Se asigno un reporte critico a tu entidad: suelo.",
+        "leida": false,
+        "leida_at": null,
+        "leida_por": null,
+        "metadata": {
+          "reporte_uuid": "uuid-reporte",
+          "tipo_asignacion": "principal",
+          "entidad_codigo": "bomberos",
+          "entidad_nombre": "Bomberos"
+        },
+        "created_at": "2026-06-01T10:05:00.000Z",
+        "updated_at": "2026-06-01T10:05:00.000Z",
+        "reporte": {
+          "titulo": "Derrame de combustible",
+          "descripcion": "Derrame cerca al rio",
+          "categoria": "suelo",
+          "subcategoria": "derrame_de_combustible",
+          "nivel_severidad": "critico",
+          "estado": "pendiente",
+          "municipio": "Mocoa",
+          "departamento": "Putumayo",
+          "latitud": 1.15,
+          "longitud": -76.65
+        }
+      }
+    ],
+    "meta": {
+      "total": 1,
+      "no_leidas": 1,
+      "limit": 20,
+      "offset": 0
+    }
+  }
+}
+```
+
+### GET `/entidades/mis-alertas/no-leidas`
+
+Lista solo alertas no leidas de la entidad autenticada. Usa la misma estructura de respuesta que `/mis-alertas`, filtrando `leida: false`.
+
+### GET `/entidades/mis-alertas/no-leidas/count`
+
+Devuelve el contador de alertas no leidas.
+
+```json
+{
+  "status": "success",
+  "message": "ok",
+  "data": {
+    "no_leidas": 3
+  }
+}
+```
+
+### PATCH `/entidades/mis-alertas/:id/leer`
+
+Marca una alerta propia como leida. `:id` es `id_alerta_entidad`, no `uuid`.
+
+Respuesta:
+
+```json
+{
+  "status": "success",
+  "message": "Alerta marcada como leida.",
+  "data": {
+    "id_alerta_entidad": 12
+  }
+}
+```
+
+Si la alerta no pertenece a la entidad autenticada, el backend responde `404`.
+
+### PATCH `/entidades/mis-alertas/leer-todas`
+
+Marca todas las alertas no leidas de la entidad autenticada.
+
+Respuesta:
+
+```json
+{
+  "status": "success",
+  "message": "Alertas de entidad marcadas como leidas.",
+  "data": {
+    "actualizadas": 4
+  }
+}
+```
+
+Ejemplo frontend para marcar:
+
+```js
+export async function marcarAlertaLeida(token, idAlerta) {
+  const response = await fetch(`/api/entidades/mis-alertas/${idAlerta}/leer`, {
+    method: 'PATCH',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!response.ok) throw await response.json();
+  return response.json();
+}
+```
+
+## Socket.IO
+
+El backend usa Socket.IO para eventos en tiempo real. El frontend debe enviar el JWT al conectar y no debe elegir sala manualmente.
+
+Instalacion sugerida en frontend:
+
+```bash
+npm install socket.io-client
+```
+
+Conexion:
+
+```js
+import { io } from 'socket.io-client';
+
+const socket = io('http://localhost:3000', {
+  auth: { token },
+});
+
+socket.on('connect_error', (error) => {
+  console.error(error.message);
+});
+```
+
+Reglas:
+
+- El backend valida el JWT.
+- Si el token falta, la conexion falla con `token requerido`.
+- Si el token es invalido, la conexion falla con `token invalido`.
+- Si el usuario tiene rol `entidad`, el backend lo une automaticamente a `entidad:<id>`.
+- El frontend no debe emitir eventos para unirse a salas ni enviar `id_entidad`.
+
+Evento recibido:
+
+```js
+socket.on('reporte:critico_asignado', (payload) => {
+  // Actualizar contador, mostrar alerta visual y recargar datos si aplica.
+});
+```
+
+Payload esperado:
+
+```json
+{
+  "reporte": {
+    "id_reporte": 101,
+    "uuid": "uuid-reporte",
+    "titulo": "Derrame de combustible",
+    "descripcion": "Derrame cerca al rio",
+    "categoria": "suelo",
+    "subcategoria": "derrame_de_combustible",
+    "nivel_severidad": "critico",
+    "estado": "pendiente",
+    "created_at": "2026-06-01T10:00:00.000Z",
+    "latitud": 1.15,
+    "longitud": -76.65,
+    "municipio": "Mocoa",
+    "departamento": "Putumayo",
+    "direccion": "Via principal"
+  },
+  "asignacion": {
+    "tipo_asignacion": "principal",
+    "prioridad": "critica",
+    "asignado_at": "2026-06-01T10:05:00.000Z"
+  },
+  "entidad": {
+    "id_entidad": 1,
+    "codigo": "bomberos",
+    "nombre": "Bomberos"
+  }
+}
+```
+
+Socket.IO solo emite para prioridad `critica`. Las alertas persistentes se crean para `alta` y `critica`, incluso si no hay clientes conectados.
+
+## Flujo recomendado para frontend
+
+1. Al iniciar sesion como usuario entidad, guardar el JWT con el patron actual del frontend.
+2. Cargar reportes con `GET /entidades/mis-reportes`.
+3. Cargar contador con `GET /entidades/mis-alertas/no-leidas/count`.
+4. Cargar alertas con `GET /entidades/mis-alertas/no-leidas` o `GET /entidades/mis-alertas`.
+5. Conectar Socket.IO usando el JWT.
+6. Escuchar `reporte:critico_asignado`.
+7. Cuando llegue el evento, actualizar badge, mostrar alerta visual y recargar reportes/alertas si aplica.
+8. Marcar una alerta como leida cuando el usuario la abra.
+9. Permitir marcar todas como leidas desde el panel.
+
+## Recomendaciones de UI
+
+- Mostrar un badge con el numero de alertas no leidas.
+- Crear un panel de alertas separado del listado de reportes.
+- Diferenciar visualmente reportes `critica`, `alta` y normales.
+- Mostrar prioridad, categoria, subcategoria, ubicacion, fecha y estado de atencion.
+- No exponer filtros por `id_entidad` en la UI de usuario entidad.
+- Si el backend devuelve `403`, cerrar sesion o mostrar que el usuario no tiene permisos.
+- Si el backend devuelve `Usuario entidad sin entidad asignada.`, mostrar un mensaje operativo para contactar al administrador.
+
+## Puntos pendientes
+
+- Implementar las vistas frontend del panel de entidad.
+- Validar visualmente los nombres finales de campos que usara cada componente.
+- Ajustar el diseno del panel de alertas y badges.
+- Probar manualmente login, carga inicial, lectura de alertas y evento Socket.IO contra backend local.

--- a/docs/integracion-frontend-entidades.md
+++ b/docs/integracion-frontend-entidades.md
@@ -1,4 +1,4 @@
-# Integracion frontend para entidades, reportes y alertas
+# Integracion frontend para entidades, reportes, asignaciones y alertas
 
 Esta guia documenta los contratos actuales del backend para construir el panel de usuario entidad en Green Alert. No se debe enviar `id_entidad` desde el frontend para consultar datos propios: el backend siempre toma la entidad desde el JWT (`id_entidad` o `entidad_id`).
 
@@ -49,18 +49,23 @@ Todos los endpoints de `mis-reportes` y `mis-alertas` requieren:
 - Header `Authorization: Bearer <jwt>`.
 - Rol `entidad`.
 - Usuario entidad con `id_entidad` o `entidad_id` en el token.
+- Entidad asociada existente, activa y permitida.
 
 El frontend no debe enviar ni confiar en `id_entidad` para estos endpoints. Si el usuario intenta manipular query params o body con otra entidad, el backend los ignora en los endpoints propios.
+
+La entidad autenticada solo puede ver sus propios reportes y alertas. Si la entidad esta inactiva, no existe o no esta dentro de las entidades permitidas de esta fase, el backend rechaza la operacion. Las entidades inactivas tampoco pueden recibir asignaciones manuales.
 
 Errores comunes:
 
 | Estado | Caso | Mensaje esperado |
 | --- | --- | --- |
-| `401` | Token ausente | `acceso denegado. token no proporcionado.` |
-| `403` | Token invalido o expirado | `token invalido o expirado.` |
+| `400` | Prioridad de asignacion invalida | `La prioridad debe ser uno de: baja, media, alta, critica.` |
+| `401` | Token ausente o invalido | `acceso denegado. token no proporcionado.` o error de token invalido |
 | `403` | Rol distinto de `entidad` | `acceso denegado. rol no autorizado.` |
 | `403` | Usuario entidad sin entidad asociada | `Usuario entidad sin entidad asignada.` |
-| `404` | Alerta o reporte no pertenece a la entidad | `Alerta de entidad no encontrada.` o `Reporte asignado no encontrado.` |
+| `403` | Entidad inactiva, inexistente o fuera de alcance | `Entidad asociada no encontrada, inactiva o fuera de alcance.` |
+| `403` | Entidad sin permisos para una accion administrativa | `acceso denegado. rol no autorizado.` |
+| `404` | Reporte, entidad, asignacion o alerta no encontrada | `Reporte no encontrado.`, `Entidad no encontrada o inactiva.`, `Reporte asignado no encontrado.` o `Alerta de entidad no encontrada.` |
 
 ## Reportes asignados
 
@@ -159,6 +164,79 @@ Body:
 ```
 
 Estados aceptados: `pendiente`, `en_atencion`, `atendido`, `cerrado`.
+
+## Asignacion manual de reportes
+
+### POST `/reportes/:id/asignaciones`
+
+Asigna manualmente un reporte ambiental a una entidad responsable. Este endpoint es administrativo: requiere JWT y rol `admin` o `moderador`. Las entidades con rol `entidad` no deben consumirlo.
+
+`:id` corresponde a `id_reporte`.
+
+Body minimo compatible:
+
+```json
+{
+  "id_entidad": 1
+}
+```
+
+Body con prioridad:
+
+```json
+{
+  "id_entidad": 1,
+  "tipo_asignacion": "principal",
+  "prioridad": "critica"
+}
+```
+
+Campos relevantes:
+
+| Campo | Requerido | Valores | Nota |
+| --- | --- | --- | --- |
+| `id_entidad` | Si | ID de entidad activa y permitida | La entidad debe existir, estar activa y pertenecer al alcance actual. |
+| `tipo_asignacion` | No | `principal`, `secundaria` | Si no se envia, el backend conserva su comportamiento actual. |
+| `prioridad` | No | `baja`, `media`, `alta`, `critica` | Si no se envia, el backend usa `media` por defecto para mantener compatibilidad. |
+
+Comportamiento por prioridad:
+
+| Prioridad | Comportamiento |
+| --- | --- |
+| `baja` | Crea la asignacion normal. No genera alerta persistente. |
+| `media` | Crea la asignacion normal. Es el valor por defecto. No genera alerta persistente. |
+| `alta` | Crea la asignacion y genera alerta persistente para la entidad. |
+| `critica` | Crea la asignacion, genera alerta persistente y emite Socket.IO `reporte:critico_asignado`. |
+
+Validaciones esperadas:
+
+- El reporte debe existir.
+- La entidad debe existir, estar activa y estar permitida.
+- La prioridad debe ser una de `baja`, `media`, `alta` o `critica`.
+- Solo `admin` y `moderador` pueden asignar reportes.
+- Una entidad inactiva no puede recibir asignaciones.
+
+Respuesta esperada:
+
+```json
+{
+  "status": "success",
+  "message": "Entidad asignada al reporte correctamente.",
+  "data": {
+    "asignacion": {
+      "id_reporte_entidad": 70,
+      "id_reporte": 101,
+      "id_entidad": 1,
+      "tipo_asignacion": "principal",
+      "prioridad": "critica",
+      "estado_atencion": "pendiente",
+      "comentario": null,
+      "asignado_por": 5,
+      "asignado_at": "2026-06-01T10:05:00.000Z"
+    }
+  }
+}
+```
 
 ## Alertas persistentes por entidad
 
@@ -266,6 +344,12 @@ Respuesta:
 
 Si la alerta no pertenece a la entidad autenticada, el backend responde `404`.
 
+### PATCH `/entidades/mis-alertas/:id`
+
+Alias de `PATCH /entidades/mis-alertas/:id/leer`.
+
+Tiene el mismo comportamiento: marca una alerta propia como leida usando `id_alerta_entidad`. Se documenta para que el frontend pueda usar cualquiera de las dos rutas sin cambiar la logica de integracion.
+
 ### PATCH `/entidades/mis-alertas/leer-todas`
 
 Marca todas las alertas no leidas de la entidad autenticada.
@@ -371,7 +455,21 @@ Payload esperado:
 
 Socket.IO solo emite para prioridad `critica`. Las alertas persistentes se crean para `alta` y `critica`, incluso si no hay clientes conectados.
 
-## Flujo recomendado para frontend
+## Endpoints finales para usuario entidad
+
+| Metodo | Ruta | Uso |
+| --- | --- | --- |
+| `GET` | `/entidades/mis-reportes` | Listar reportes asignados a la entidad autenticada. |
+| `GET` | `/entidades/mis-reportes/:id` | Consultar detalle de un reporte propio asignado. |
+| `PATCH` | `/entidades/mis-reportes/:id/atencion` | Actualizar estado de atencion de una asignacion propia. |
+| `GET` | `/entidades/mis-alertas` | Listar alertas propias. |
+| `GET` | `/entidades/mis-alertas/no-leidas` | Listar alertas propias no leidas. |
+| `GET` | `/entidades/mis-alertas/no-leidas/count` | Obtener contador de alertas propias no leidas. |
+| `PATCH` | `/entidades/mis-alertas/:id/leer` | Marcar alerta propia como leida. |
+| `PATCH` | `/entidades/mis-alertas/:id` | Alias para marcar alerta propia como leida. |
+| `PATCH` | `/entidades/mis-alertas/leer-todas` | Marcar todas las alertas propias como leidas. |
+
+## Flujo sugerido para frontend
 
 1. Al iniciar sesion como usuario entidad, guardar el JWT con el patron actual del frontend.
 2. Cargar reportes con `GET /entidades/mis-reportes`.
@@ -383,7 +481,7 @@ Socket.IO solo emite para prioridad `critica`. Las alertas persistentes se crean
 8. Marcar una alerta como leida cuando el usuario la abra.
 9. Permitir marcar todas como leidas desde el panel.
 
-## Recomendaciones de UI
+## Recomendaciones para el equipo frontend
 
 - Mostrar un badge con el numero de alertas no leidas.
 - Crear un panel de alertas separado del listado de reportes.
@@ -392,6 +490,8 @@ Socket.IO solo emite para prioridad `critica`. Las alertas persistentes se crean
 - No exponer filtros por `id_entidad` en la UI de usuario entidad.
 - Si el backend devuelve `403`, cerrar sesion o mostrar que el usuario no tiene permisos.
 - Si el backend devuelve `Usuario entidad sin entidad asignada.`, mostrar un mensaje operativo para contactar al administrador.
+- Consumir `PATCH /entidades/mis-alertas/:id/leer` o su alias `PATCH /entidades/mis-alertas/:id` con la misma logica de marcado como leida.
+- Para pantallas administrativas de asignacion, enviar `prioridad` solo cuando el usuario elija un valor distinto al comportamiento por defecto `media`.
 
 ## Puntos pendientes
 

--- a/routes/entidad.routes.js
+++ b/routes/entidad.routes.js
@@ -50,6 +50,13 @@ entidadRouter.patch(
   requireRoles('entidad'),
   marcarMiAlertaEntidadLeida
 );
+entidadRouter.patch(
+  '/mis-alertas/:id',
+  validatePositiveIdParam('id'),
+  verifyToken,
+  requireRoles('entidad'),
+  marcarMiAlertaEntidadLeida
+);
 entidadRouter.get('/mis-reportes', verifyToken, requireRoles('entidad'), listarMisReportesEntidad);
 entidadRouter.get(
   '/mis-reportes/:id',

--- a/src/controllers/entidad.controller.js
+++ b/src/controllers/entidad.controller.js
@@ -12,6 +12,22 @@ import { errorResponse, successResponse } from '../utils/response.js';
 
 const getEntidadIdFromUser = (req) => Number(req.user?.id_entidad ?? req.user?.entidad_id);
 
+const getEntidadActivaFromUser = async (req, res) => {
+  const idEntidad = getEntidadIdFromUser(req);
+  if (!idEntidad) {
+    errorResponse(res, 'Usuario entidad sin entidad asignada.', 403);
+    return null;
+  }
+
+  const entidad = await EntidadModel.findActiveAllowedByIdOrCodigo({ id_entidad: idEntidad });
+  if (!entidad) {
+    errorResponse(res, 'Entidad asociada no encontrada, inactiva o fuera de alcance.', 403);
+    return null;
+  }
+
+  return entidad;
+};
+
 export const listarEntidades = async (_req, res, next) => {
   try {
     const entidades = await EntidadModel.findActive();
@@ -27,12 +43,10 @@ export const listarEntidades = async (_req, res, next) => {
 
 export const listarMisReportesEntidad = async (req, res, next) => {
   try {
-    const idEntidad = getEntidadIdFromUser(req);
-    if (!idEntidad) {
-      return errorResponse(res, 'Usuario entidad sin entidad asignada.', 403);
-    }
+    const entidad = await getEntidadActivaFromUser(req, res);
+    if (!entidad) return null;
 
-    const data = await ReporteEntidadModel.findByEntidad(idEntidad, {
+    const data = await ReporteEntidadModel.findByEntidad(entidad.id_entidad, {
       prioridad: req.query?.prioridad,
       estado_atencion: req.query?.estado_atencion,
       tipo_asignacion: req.query?.tipo_asignacion,
@@ -86,17 +100,15 @@ export const listarReportesPorEntidad = async (req, res, next) => {
 
 export const obtenerMiReporteEntidad = async (req, res, next) => {
   try {
-    const idEntidad = getEntidadIdFromUser(req);
+    const entidad = await getEntidadActivaFromUser(req, res);
     const idReporte = Number(req.params.id);
 
-    if (!idEntidad) {
-      return errorResponse(res, 'Usuario entidad sin entidad asignada.', 403);
-    }
+    if (!entidad) return null;
     if (!idReporte) {
       return errorResponse(res, 'Id de reporte invalido.', 400);
     }
 
-    const reporte = await ReporteEntidadModel.findReporteAsignadoByEntidad(idReporte, idEntidad);
+    const reporte = await ReporteEntidadModel.findReporteAsignadoByEntidad(idReporte, entidad.id_entidad);
     if (!reporte) {
       return errorResponse(res, 'Reporte asignado no encontrado.', 404);
     }
@@ -114,13 +126,11 @@ export const obtenerMiReporteEntidad = async (req, res, next) => {
 
 export const actualizarAtencionMiEntidad = async (req, res, next) => {
   try {
-    const idEntidad = getEntidadIdFromUser(req);
+    const entidad = await getEntidadActivaFromUser(req, res);
     const idReporte = Number(req.params.id);
     const { estado_atencion, comentario = null } = req.body ?? {};
 
-    if (!idEntidad) {
-      return errorResponse(res, 'Usuario entidad sin entidad asignada.', 403);
-    }
+    if (!entidad) return null;
     if (!idReporte) {
       return errorResponse(res, 'Id de reporte invalido.', 400);
     }
@@ -132,7 +142,7 @@ export const actualizarAtencionMiEntidad = async (req, res, next) => {
       );
     }
 
-    const asignacion = await ReporteEntidadModel.findOneByReporteAndEntidad(idReporte, idEntidad);
+    const asignacion = await ReporteEntidadModel.findOneByReporteAndEntidad(idReporte, entidad.id_entidad);
     if (!asignacion) {
       return errorResponse(res, 'Reporte asignado no encontrado.', 404);
     }
@@ -143,7 +153,7 @@ export const actualizarAtencionMiEntidad = async (req, res, next) => {
       typeof comentario === 'string' ? comentario.trim() || null : null
     );
 
-    const reporte = await ReporteEntidadModel.findReporteAsignadoByEntidad(idReporte, idEntidad);
+    const reporte = await ReporteEntidadModel.findReporteAsignadoByEntidad(idReporte, entidad.id_entidad);
     return successResponse(
       res,
       { reporte },
@@ -156,12 +166,10 @@ export const actualizarAtencionMiEntidad = async (req, res, next) => {
 
 export const listarMisAlertasEntidad = async (req, res, next) => {
   try {
-    const idEntidad = getEntidadIdFromUser(req);
-    if (!idEntidad) {
-      return errorResponse(res, 'Usuario entidad sin entidad asignada.', 403);
-    }
+    const entidad = await getEntidadActivaFromUser(req, res);
+    if (!entidad) return null;
 
-    const data = await listarAlertasEntidad(idEntidad, {
+    const data = await listarAlertasEntidad(entidad.id_entidad, {
       limit: req.query?.limit,
       offset: req.query?.offset,
     });
@@ -175,12 +183,10 @@ export const listarMisAlertasEntidad = async (req, res, next) => {
 
 export const listarMisAlertasNoLeidasEntidad = async (req, res, next) => {
   try {
-    const idEntidad = getEntidadIdFromUser(req);
-    if (!idEntidad) {
-      return errorResponse(res, 'Usuario entidad sin entidad asignada.', 403);
-    }
+    const entidad = await getEntidadActivaFromUser(req, res);
+    if (!entidad) return null;
 
-    const data = await listarAlertasNoLeidasEntidad(idEntidad, {
+    const data = await listarAlertasNoLeidasEntidad(entidad.id_entidad, {
       limit: req.query?.limit,
       offset: req.query?.offset,
     });
@@ -194,12 +200,10 @@ export const listarMisAlertasNoLeidasEntidad = async (req, res, next) => {
 
 export const contarMisAlertasNoLeidasEntidad = async (req, res, next) => {
   try {
-    const idEntidad = getEntidadIdFromUser(req);
-    if (!idEntidad) {
-      return errorResponse(res, 'Usuario entidad sin entidad asignada.', 403);
-    }
+    const entidad = await getEntidadActivaFromUser(req, res);
+    if (!entidad) return null;
 
-    const no_leidas = await contarAlertasNoLeidasEntidad(idEntidad);
+    const no_leidas = await contarAlertasNoLeidasEntidad(entidad.id_entidad);
 
     res.setHeader('Cache-Control', 'no-store');
     return successResponse(res, { no_leidas }, 'ok');
@@ -210,18 +214,16 @@ export const contarMisAlertasNoLeidasEntidad = async (req, res, next) => {
 
 export const marcarMiAlertaEntidadLeida = async (req, res, next) => {
   try {
-    const idEntidad = getEntidadIdFromUser(req);
+    const entidad = await getEntidadActivaFromUser(req, res);
     const idUsuario = req.user?.sub;
     const idAlerta = Number(req.params.id);
 
-    if (!idEntidad) {
-      return errorResponse(res, 'Usuario entidad sin entidad asignada.', 403);
-    }
+    if (!entidad) return null;
     if (!idAlerta) {
       return errorResponse(res, 'Id de alerta invalido.', 400);
     }
 
-    const ok = await marcarAlertaEntidadLeida(idAlerta, idEntidad, idUsuario);
+    const ok = await marcarAlertaEntidadLeida(idAlerta, entidad.id_entidad, idUsuario);
     if (!ok) {
       return errorResponse(res, 'Alerta de entidad no encontrada.', 404);
     }
@@ -238,14 +240,12 @@ export const marcarMiAlertaEntidadLeida = async (req, res, next) => {
 
 export const marcarTodasMisAlertasEntidadLeidas = async (req, res, next) => {
   try {
-    const idEntidad = getEntidadIdFromUser(req);
+    const entidad = await getEntidadActivaFromUser(req, res);
     const idUsuario = req.user?.sub;
 
-    if (!idEntidad) {
-      return errorResponse(res, 'Usuario entidad sin entidad asignada.', 403);
-    }
+    if (!entidad) return null;
 
-    const actualizadas = await marcarTodasAlertasEntidadLeidas(idEntidad, idUsuario);
+    const actualizadas = await marcarTodasAlertasEntidadLeidas(entidad.id_entidad, idUsuario);
 
     return successResponse(
       res,

--- a/src/controllers/reporte.controller.js
+++ b/src/controllers/reporte.controller.js
@@ -19,6 +19,8 @@ import { calcularScoreEvidencias } from '../services/evidencia-score.service.js'
 import { deleteFileByPublicId, uploadFileBuffer } from '../services/cloudinary.service.js';
 import { invalidatePrediccionCache } from '../services/prediccion.service.js';
 import { AsignacionEntidadesService } from '../services/asignacion-entidades.service.js';
+import { crearAlertaDesdeAsignacionReporte } from '../services/alerta-entidad.service.js';
+import { notificarReporteCriticoAsignado } from '../config/socket.js';
 import { errorResponse, successResponse } from '../utils/response.js';
 import { crearNotificacion } from './notificacion.controller.js';
 
@@ -61,6 +63,7 @@ const TRANSICIONES_ESTADO_REPORTE = {
   resuelto: [],
   rechazado: [],
 };
+const PRIORIDADES_ASIGNACION_PERMITIDAS = ['baja', 'media', 'alta', 'critica'];
 
 const canTransitionReporteEstado = (estadoActual, estadoNuevo) => {
   if (estadoActual === estadoNuevo) return true;
@@ -68,6 +71,16 @@ const canTransitionReporteEstado = (estadoActual, estadoNuevo) => {
 };
 
 const buildReporteLink = (reporte) => `/reports/${reporte.uuid ?? reporte.id_reporte}`;
+
+const getEntidadIdFromUser = (user) => Number(user?.id_entidad ?? user?.entidad_id);
+
+const getEntidadActivaIdFromUser = async (user) => {
+  const idEntidad = getEntidadIdFromUser(user);
+  if (!idEntidad) return null;
+
+  const entidad = await EntidadModel.findActiveAllowedByIdOrCodigo({ id_entidad: idEntidad });
+  return entidad?.id_entidad ?? null;
+};
 
 const canManageReporteEvidence = (reporte, user) => {
   if (!reporte || !user) {
@@ -482,11 +495,12 @@ export const getReportes = async (req, res, next) => {
     const { estado, tipo_contaminacion, nivel_severidad, municipio, limit = 20, offset = 0 } = req.query;
 
     if (req.user?.rol === 'entidad') {
-      if (!req.user.id_entidad) {
+      const idEntidad = await getEntidadActivaIdFromUser(req.user);
+      if (!idEntidad) {
         return errorResponse(res, 'Usuario entidad sin entidad asignada.', 403);
       }
 
-      const data = await ReporteEntidadModel.findByEntidad(req.user.id_entidad, {
+      const data = await ReporteEntidadModel.findByEntidad(idEntidad, {
         categoria: tipo_contaminacion,
         severidad: nivel_severidad,
         limit,
@@ -762,6 +776,15 @@ export const asignarEntidadReporte = async (req, res, next) => {
   try {
     const id = Number(req.params.id);
     const { id_entidad, codigo_entidad, comentario = null } = req.body ?? {};
+    const prioridad = normalizeEnumValue(req.body?.prioridad) || 'media';
+
+    if (!PRIORIDADES_ASIGNACION_PERMITIDAS.includes(prioridad)) {
+      return errorResponse(
+        res,
+        buildAllowedValuesMessage('La prioridad', PRIORIDADES_ASIGNACION_PERMITIDAS),
+        400
+      );
+    }
 
     const reporte = await ReporteModel.findById(id);
     if (!reporte) return errorResponse(res, 'Reporte no encontrado.', 404);
@@ -783,7 +806,7 @@ export const asignarEntidadReporte = async (req, res, next) => {
       id_reporte: id,
       id_entidad: entidad.id_entidad,
       tipo_asignacion: 'principal',
-      prioridad: 'media',
+      prioridad,
       estado_atencion: 'pendiente',
       comentario: typeof comentario === 'string' ? comentario.trim() || null : null,
     });
@@ -792,6 +815,24 @@ export const asignarEntidadReporte = async (req, res, next) => {
       id,
       entidad.id_entidad
     );
+
+    const assignmentForAlerts = {
+      ...asignacion,
+      id_reporte: id,
+      id_entidad: entidad.id_entidad,
+      tipo_asignacion: asignacion?.tipo_asignacion ?? 'principal',
+      prioridad: asignacion?.prioridad ?? prioridad,
+      entidad,
+    };
+
+    await crearAlertaDesdeAsignacionReporte({
+      reporte,
+      assignment: assignmentForAlerts,
+    });
+    notificarReporteCriticoAsignado({
+      reporte,
+      assignments: [assignmentForAlerts],
+    });
 
     if (reporte.id_usuario) {
       await crearNotificacion({
@@ -846,8 +887,15 @@ export const updateReporte = async (req, res, next) => {
     const { rol, sub } = req.user;
     const isOwner = reporte.id_usuario === sub;
     const isMod   = rol === 'moderador' || rol === 'admin';
-    const asignacionEntidad = rol === 'entidad' && req.user?.id_entidad
-      ? await ReporteEntidadModel.findOneByReporteAndEntidad(id, req.user.id_entidad)
+    const idEntidadActiva = rol === 'entidad'
+      ? await getEntidadActivaIdFromUser(req.user)
+      : null;
+    if (rol === 'entidad' && !idEntidadActiva) {
+      return errorResponse(res, 'Usuario entidad sin entidad asignada.', 403);
+    }
+
+    const asignacionEntidad = idEntidadActiva
+      ? await ReporteEntidadModel.findOneByReporteAndEntidad(id, idEntidadActiva)
       : null;
     const isEntidadAsignada = Boolean(asignacionEntidad);
 
@@ -1029,11 +1077,12 @@ export const getReporteById = async (req, res, next) => {
   try {
     const id = Number(req.params.id);
     if (req.user?.rol === 'entidad') {
-      if (!req.user.id_entidad) {
+      const idEntidad = await getEntidadActivaIdFromUser(req.user);
+      if (!idEntidad) {
         return errorResponse(res, 'Usuario entidad sin entidad asignada.', 403);
       }
 
-      const asignado = await ReporteEntidadModel.findOneByReporteAndEntidad(id, req.user.id_entidad);
+      const asignado = await ReporteEntidadModel.findOneByReporteAndEntidad(id, idEntidad);
       if (!asignado) {
         return errorResponse(res, 'No tienes permiso para ver este reporte.', 403);
       }

--- a/tests/unit/alertas-entidad.test.js
+++ b/tests/unit/alertas-entidad.test.js
@@ -9,6 +9,7 @@ import { fileURLToPath } from 'node:url';
 
 import entidadRouter from '../../routes/entidad.routes.js';
 import { AlertaEntidadModel } from '../../src/models/alerta-entidad.model.js';
+import { EntidadModel } from '../../src/models/entidad.model.js';
 import {
   crearAlertaDesdeAsignacionReporte,
   crearAlertasDesdeAsignacionesReporte,
@@ -66,6 +67,15 @@ const assignment = (overrides = {}) => ({
   entidad: { id_entidad: 1, codigo: 'bomberos', nombre: 'Bomberos' },
   ...overrides,
 });
+
+const mockEntidadActiva = (t, idEntidad = 1) => {
+  t.mock.method(EntidadModel, 'findActiveAllowedByIdOrCodigo', async ({ id_entidad }) => ({
+    id_entidad: id_entidad ?? idEntidad,
+    codigo: (id_entidad ?? idEntidad) === 1 ? 'bomberos' : 'corpoamazonia',
+    nombre: (id_entidad ?? idEntidad) === 1 ? 'Bomberos' : 'Corpoamazonia',
+    activo: 1,
+  }));
+};
 
 test('crea una alerta cuando se asigna un reporte critico a una entidad', async (t) => {
   let payload;
@@ -159,6 +169,7 @@ test('crea alerta para entidad principal y secundaria cuando ambas asignaciones 
 });
 
 test('usuario entidad solo lista alertas de su propia entidad', async (t) => {
+  mockEntidadActiva(t, 1);
   t.mock.method(AlertaEntidadModel, 'findByEntidad', async (idEntidad) => {
     assert.equal(idEntidad, 1);
     return { alertas: [{ id_alerta_entidad: 1, id_entidad: 1 }], meta: { total: 1 } };
@@ -176,6 +187,7 @@ test('usuario entidad solo lista alertas de su propia entidad', async (t) => {
 });
 
 test('usuario entidad solo lista alertas no leidas de su propia entidad', async (t) => {
+  mockEntidadActiva(t, 2);
   t.mock.method(AlertaEntidadModel, 'findByEntidad', async (idEntidad, filtros) => {
     assert.equal(idEntidad, 2);
     assert.equal(filtros.leida, false);
@@ -194,6 +206,7 @@ test('usuario entidad solo lista alertas no leidas de su propia entidad', async 
 });
 
 test('usuario entidad cuenta alertas no leidas solo de su entidad', async (t) => {
+  mockEntidadActiva(t, 1);
   t.mock.method(AlertaEntidadModel, 'countNoLeidasByEntidad', async (idEntidad) => {
     assert.equal(idEntidad, 1);
     return 3;
@@ -211,6 +224,7 @@ test('usuario entidad cuenta alertas no leidas solo de su entidad', async (t) =>
 });
 
 test('usuario entidad puede marcar como leida una alerta propia', async (t) => {
+  mockEntidadActiva(t, 1);
   t.mock.method(AlertaEntidadModel, 'markAsReadByEntidad', async (idAlerta, idEntidad, idUsuario) => {
     assert.equal(idAlerta, 15);
     assert.equal(idEntidad, 1);
@@ -230,6 +244,7 @@ test('usuario entidad puede marcar como leida una alerta propia', async (t) => {
 });
 
 test('usuario entidad no puede marcar como leida una alerta de otra entidad', async (t) => {
+  mockEntidadActiva(t, 1);
   t.mock.method(AlertaEntidadModel, 'markAsReadByEntidad', async (idAlerta, idEntidad) => {
     assert.equal(idAlerta, 16);
     assert.equal(idEntidad, 1);
@@ -248,6 +263,7 @@ test('usuario entidad no puede marcar como leida una alerta de otra entidad', as
 });
 
 test('usuario entidad puede marcar todas sus alertas como leidas', async (t) => {
+  mockEntidadActiva(t, 1);
   t.mock.method(AlertaEntidadModel, 'markAllAsReadByEntidad', async (idEntidad, idUsuario) => {
     assert.equal(idEntidad, 1);
     assert.equal(idUsuario, 9);
@@ -296,6 +312,87 @@ test('endpoints mis-alertas rechazan usuarios sin rol entidad', async () => {
       server.close((error) => (error ? reject(error) : resolve()));
     });
   }
+});
+
+test('alias PATCH /entidades/mis-alertas/:id marca alerta como leida', async (t) => {
+  process.env.JWT_SECRET = JWT_SECRET;
+  mockEntidadActiva(t, 1);
+  t.mock.method(AlertaEntidadModel, 'markAsReadByEntidad', async (idAlerta, idEntidad, idUsuario) => {
+    assert.equal(idAlerta, 15);
+    assert.equal(idEntidad, 1);
+    assert.equal(idUsuario, 9);
+    return true;
+  });
+
+  const app = express();
+  app.use(express.json());
+  app.use('/entidades', entidadRouter);
+
+  const server = await new Promise((resolve) => {
+    const instance = http.createServer(app);
+    instance.listen(0, () => resolve(instance));
+  });
+
+  try {
+    const token = jwt.sign(
+      { sub: 9, rol: 'entidad', id_entidad: 1, email: 'entidad@test.local' },
+      JWT_SECRET,
+      { expiresIn: '5m' }
+    );
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/entidades/mis-alertas/15`, {
+      method: 'PATCH',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.data.id_alerta_entidad, 15);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test('usuario entidad inactiva no puede listar mis alertas', async (t) => {
+  t.mock.method(EntidadModel, 'findActiveAllowedByIdOrCodigo', async ({ id_entidad }) => {
+    assert.equal(id_entidad, 1);
+    return null;
+  });
+  t.mock.method(AlertaEntidadModel, 'findByEntidad', async () => {
+    assert.fail('No debe consultar alertas si la entidad autenticada no esta activa.');
+  });
+
+  const res = createResponse();
+  await listarMisAlertasEntidad(
+    { user: { rol: 'entidad', id_entidad: 1 }, query: {} },
+    res,
+    assert.fail
+  );
+
+  assert.equal(res.statusCode, 403);
+  assert.equal(res.body.message, 'Entidad asociada no encontrada, inactiva o fuera de alcance.');
+});
+
+test('usuario entidad inactiva no puede marcar alerta como leida', async (t) => {
+  t.mock.method(EntidadModel, 'findActiveAllowedByIdOrCodigo', async ({ id_entidad }) => {
+    assert.equal(id_entidad, 1);
+    return null;
+  });
+  t.mock.method(AlertaEntidadModel, 'markAsReadByEntidad', async () => {
+    assert.fail('No debe actualizar alertas si la entidad autenticada no esta activa.');
+  });
+
+  const res = createResponse();
+  await marcarMiAlertaEntidadLeida(
+    { params: { id: '15' }, user: { sub: 9, rol: 'entidad', id_entidad: 1 } },
+    res,
+    assert.fail
+  );
+
+  assert.equal(res.statusCode, 403);
+  assert.equal(res.body.message, 'Entidad asociada no encontrada, inactiva o fuera de alcance.');
 });
 
 test('usuario entidad sin entidad asociada recibe error controlado', async (t) => {

--- a/tests/unit/backend-route-contract.test.js
+++ b/tests/unit/backend-route-contract.test.js
@@ -97,6 +97,7 @@ test('rutas consumidas por el cliente estan declaradas en backend', async () => 
     { router: 'entidadRouter', method: 'get', route: '/mis-alertas/no-leidas' },
     { router: 'entidadRouter', method: 'get', route: '/mis-alertas/no-leidas/count' },
     { router: 'entidadRouter', method: 'patch', route: '/mis-alertas/:id/leer' },
+    { router: 'entidadRouter', method: 'patch', route: '/mis-alertas/:id' },
     { router: 'entidadRouter', method: 'patch', route: '/mis-alertas/leer-todas' },
     { router: 'entidadRouter', method: 'get', route: '/mis-reportes' },
     { router: 'entidadRouter', method: 'get', route: '/mis-reportes/:id' },
@@ -129,6 +130,7 @@ test('rutas privadas y administrativas declaran middleware de autenticacion y ro
   assert.match(entidadRoutes, /entidadRouter\.get\([\s\S]*'\/mis-alertas\/no-leidas'[\s\S]*verifyToken[\s\S]*requireRoles\('entidad'\)/);
   assert.match(entidadRoutes, /entidadRouter\.get\([\s\S]*'\/mis-alertas\/no-leidas\/count'[\s\S]*verifyToken[\s\S]*requireRoles\('entidad'\)/);
   assert.match(entidadRoutes, /entidadRouter\.patch\([\s\S]*'\/mis-alertas\/:id\/leer'[\s\S]*verifyToken[\s\S]*requireRoles\('entidad'\)/);
+  assert.match(entidadRoutes, /entidadRouter\.patch\([\s\S]*'\/mis-alertas\/:id'[\s\S]*verifyToken[\s\S]*requireRoles\('entidad'\)/);
   assert.match(entidadRoutes, /entidadRouter\.patch\([\s\S]*'\/mis-alertas\/leer-todas'[\s\S]*verifyToken[\s\S]*requireRoles\('entidad'\)/);
   assert.match(entidadRoutes, /entidadRouter\.get\([\s\S]*'\/mis-reportes\/:id'[\s\S]*verifyToken[\s\S]*requireRoles\('entidad'\)/);
   assert.match(entidadRoutes, /entidadRouter\.patch\([\s\S]*'\/mis-reportes\/:id\/atencion'[\s\S]*verifyToken[\s\S]*requireRoles\('entidad'\)/);

--- a/tests/unit/entidad-reportes-seguridad.test.js
+++ b/tests/unit/entidad-reportes-seguridad.test.js
@@ -49,7 +49,17 @@ const createReportes = (codigoEntidad) => ([
   },
 ]);
 
+const mockEntidadActiva = (t, idEntidad = 1) => {
+  t.mock.method(EntidadModel, 'findActiveAllowedByIdOrCodigo', async ({ id_entidad }) => ({
+    id_entidad: id_entidad ?? idEntidad,
+    codigo: (id_entidad ?? idEntidad) === 1 ? 'bomberos' : 'corpoamazonia',
+    nombre: (id_entidad ?? idEntidad) === 1 ? 'Bomberos' : 'Corpoamazonia',
+    activo: 1,
+  }));
+};
+
 test('listarMisReportesEntidad usa la entidad autenticada para Bomberos', async (t) => {
+  mockEntidadActiva(t, 1);
   t.mock.method(ReporteEntidadModel, 'findByEntidad', async (idEntidad) => {
     assert.equal(idEntidad, 1);
     return {
@@ -77,6 +87,7 @@ test('listarMisReportesEntidad usa la entidad autenticada para Bomberos', async 
 });
 
 test('listarMisReportesEntidad usa entidad_id como alias autenticado para Corpoamazonia', async (t) => {
+  mockEntidadActiva(t, 2);
   t.mock.method(ReporteEntidadModel, 'findByEntidad', async (idEntidad) => {
     assert.equal(idEntidad, 2);
     return {
@@ -119,6 +130,30 @@ test('listarMisReportesEntidad responde error controlado si usuario entidad no t
 
   assert.equal(res.statusCode, 403);
   assert.equal(res.body.message, 'Usuario entidad sin entidad asignada.');
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('listarMisReportesEntidad rechaza usuario entidad con entidad inactiva o no permitida', async (t) => {
+  t.mock.method(EntidadModel, 'findActiveAllowedByIdOrCodigo', async ({ id_entidad }) => {
+    assert.equal(id_entidad, 1);
+    return null;
+  });
+  t.mock.method(ReporteEntidadModel, 'findByEntidad', async () => {
+    assert.fail('No debe consultar reportes si la entidad autenticada no esta activa.');
+  });
+
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  const { listarMisReportesEntidad } = await import('../../src/controllers/entidad.controller.js');
+  await listarMisReportesEntidad(
+    { user: { rol: 'entidad', id_entidad: 1 }, query: {} },
+    res,
+    next
+  );
+
+  assert.equal(res.statusCode, 403);
+  assert.equal(res.body.message, 'Entidad asociada no encontrada, inactiva o fuera de alcance.');
   assert.equal(next.mock.callCount(), 0);
 });
 

--- a/tests/unit/reporte-asignacion-manual.test.js
+++ b/tests/unit/reporte-asignacion-manual.test.js
@@ -1,9 +1,14 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { asignarEntidadReporte } from '../../src/controllers/reporte.controller.js';
+import { AlertaEntidadModel } from '../../src/models/alerta-entidad.model.js';
 import { EntidadModel } from '../../src/models/entidad.model.js';
 import { ReporteEntidadModel } from '../../src/models/reporte-entidad.model.js';
 import { ReporteModel } from '../../src/models/reporte.model.js';
+import {
+  setSocketServerForTests,
+  SOCKET_EVENTS,
+} from '../../src/config/socket.js';
 
 const createRes = () => {
   const res = {
@@ -22,34 +27,52 @@ const createRes = () => {
   return res;
 };
 
-test('asignarEntidadReporte asigna manualmente a una entidad activa y permitida', async (t) => {
-  const reporte = {
-    id_reporte: 10,
-    uuid: 'rep-10',
-    id_usuario: null,
-    titulo: 'Incendio en la vereda',
-  };
-  const entidad = {
-    id_entidad: 1,
-    codigo: 'bomberos',
-    nombre: 'Bomberos',
-    activo: 1,
-  };
-  const asignacion = {
-    id_reporte_entidad: 7,
-    id_reporte: 10,
-    id_entidad: 1,
-    estado_atencion: 'pendiente',
-  };
+const reporteBase = {
+  id_reporte: 10,
+  uuid: 'rep-10',
+  id_usuario: null,
+  titulo: 'Incendio en la vereda',
+};
+
+const entidadBomberos = {
+  id_entidad: 1,
+  codigo: 'bomberos',
+  nombre: 'Bomberos',
+  activo: 1,
+};
+
+const createAsignacion = (prioridad = 'media') => ({
+  id_reporte_entidad: 7,
+  id_reporte: 10,
+  id_entidad: 1,
+  tipo_asignacion: 'principal',
+  prioridad,
+  estado_atencion: 'pendiente',
+});
+
+const mockAsignacionManualBase = (t, { prioridad = 'media' } = {}) => {
   let assignmentPayload;
 
-  t.mock.method(ReporteModel, 'findById', async () => reporte);
-  t.mock.method(EntidadModel, 'findActiveAllowedByIdOrCodigo', async () => entidad);
+  t.mock.method(ReporteModel, 'findById', async () => reporteBase);
+  t.mock.method(EntidadModel, 'findActiveAllowedByIdOrCodigo', async () => entidadBomberos);
   t.mock.method(ReporteEntidadModel, 'createAssignment', async (payload) => {
     assignmentPayload = payload;
     return 7;
   });
-  t.mock.method(ReporteEntidadModel, 'findOneByReporteAndEntidad', async () => asignacion);
+  t.mock.method(ReporteEntidadModel, 'findOneByReporteAndEntidad', async () => (
+    createAsignacion(prioridad)
+  ));
+
+  return {
+    getAssignmentPayload: () => assignmentPayload,
+  };
+};
+
+test('asignarEntidadReporte asigna manualmente a una entidad activa y permitida', async (t) => {
+  const { getAssignmentPayload } = mockAsignacionManualBase(t);
+  t.mock.method(AlertaEntidadModel, 'create', async () => {
+    assert.fail('No debe crear alerta persistente para prioridad media.');
+  });
 
   const req = {
     params: { id: '10' },
@@ -66,7 +89,7 @@ test('asignarEntidadReporte asigna manualmente a una entidad activa y permitida'
   assert.equal(res.statusCode, 201);
   assert.equal(res.body.status, 'success');
   assert.equal(res.body.data.entidad.codigo, 'bomberos');
-  assert.deepEqual(assignmentPayload, {
+  assert.deepEqual(getAssignmentPayload(), {
     id_reporte: 10,
     id_entidad: 1,
     tipo_asignacion: 'principal',
@@ -74,6 +97,114 @@ test('asignarEntidadReporte asigna manualmente a una entidad activa y permitida'
     estado_atencion: 'pendiente',
     comentario: 'Revisar incendio',
   });
+});
+
+test('asignarEntidadReporte con prioridad critica genera alerta y evento socket', async (t) => {
+  const { getAssignmentPayload } = mockAsignacionManualBase(t, { prioridad: 'critica' });
+  let alertaPayload;
+  const emissions = [];
+  t.mock.method(AlertaEntidadModel, 'create', async (payload) => {
+    alertaPayload = payload;
+    return 20;
+  });
+  setSocketServerForTests({
+    to(room) {
+      return {
+        emit(event, payload) {
+          emissions.push({ room, event, payload });
+        },
+      };
+    },
+  });
+
+  const req = {
+    params: { id: '10' },
+    body: {
+      codigo_entidad: 'bomberos',
+      prioridad: 'critica',
+    },
+    user: { sub: 1, rol: 'admin' },
+  };
+  const res = createRes();
+
+  try {
+    await asignarEntidadReporte(req, res, assert.fail);
+  } finally {
+    setSocketServerForTests(null);
+  }
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(getAssignmentPayload().prioridad, 'critica');
+  assert.equal(alertaPayload.tipo_alerta, 'reporte_critico_asignado');
+  assert.equal(alertaPayload.id_reporte_entidad, 7);
+  assert.equal(emissions.length, 1);
+  assert.equal(emissions[0].room, 'entidad:1');
+  assert.equal(emissions[0].event, SOCKET_EVENTS.REPORTE_CRITICO_ASIGNADO);
+});
+
+test('asignarEntidadReporte con prioridad alta genera alerta persistente sin evento critico', async (t) => {
+  const { getAssignmentPayload } = mockAsignacionManualBase(t, { prioridad: 'alta' });
+  let alertaPayload;
+  const emissions = [];
+  t.mock.method(AlertaEntidadModel, 'create', async (payload) => {
+    alertaPayload = payload;
+    return 21;
+  });
+  setSocketServerForTests({
+    to(room) {
+      return {
+        emit(event, payload) {
+          emissions.push({ room, event, payload });
+        },
+      };
+    },
+  });
+
+  const req = {
+    params: { id: '10' },
+    body: {
+      codigo_entidad: 'bomberos',
+      prioridad: 'alta',
+    },
+    user: { sub: 1, rol: 'moderador' },
+  };
+  const res = createRes();
+
+  try {
+    await asignarEntidadReporte(req, res, assert.fail);
+  } finally {
+    setSocketServerForTests(null);
+  }
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(getAssignmentPayload().prioridad, 'alta');
+  assert.equal(alertaPayload.tipo_alerta, 'reporte_prioritario_asignado');
+  assert.deepEqual(emissions, []);
+});
+
+test('asignarEntidadReporte rechaza prioridad invalida', async (t) => {
+  t.mock.method(ReporteModel, 'findById', async () => {
+    assert.fail('No debe consultar reporte si la prioridad es invalida.');
+  });
+  t.mock.method(ReporteEntidadModel, 'createAssignment', async () => {
+    assert.fail('No debe crear asignacion con prioridad invalida.');
+  });
+
+  const req = {
+    params: { id: '10' },
+    body: {
+      codigo_entidad: 'bomberos',
+      prioridad: 'urgente',
+    },
+    user: { sub: 1, rol: 'admin' },
+  };
+  const res = createRes();
+
+  await asignarEntidadReporte(req, res, assert.fail);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.status, 'error');
+  assert.equal(res.body.message, 'La prioridad debe ser uno de: baja, media, alta, critica.');
 });
 
 test('asignarEntidadReporte rechaza entidades inactivas o fuera de alcance', async (t) => {

--- a/tests/unit/reporte-enum-validacion.test.js
+++ b/tests/unit/reporte-enum-validacion.test.js
@@ -1,7 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { updateReporte } from '../../src/controllers/reporte.controller.js';
+import { EntidadModel } from '../../src/models/entidad.model.js';
 import { NotificacionModel } from '../../src/models/notificacion.model.js';
+import { ReporteEntidadModel } from '../../src/models/reporte-entidad.model.js';
 import { ReporteModel } from '../../src/models/reporte.model.js';
 import { UsuarioModel } from '../../src/models/usuario.model.js';
 
@@ -179,5 +181,37 @@ test('updateReporte rechaza nivel_severidad invalido antes de actualizar', async
   assert.equal(res.statusCode, 400);
   assert.equal(res.body.message, 'El nivel de severidad debe ser uno de: bajo, medio, alto, critico.');
   assert.equal(ReporteModel.update.mock.callCount(), 0);
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('updateReporte rechaza usuario entidad con entidad inactiva', async (t) => {
+  t.mock.method(ReporteModel, 'findById', async () => ({
+    id_reporte: 15,
+    id_usuario: 7,
+    estado: 'pendiente',
+  }));
+  t.mock.method(EntidadModel, 'findActiveAllowedByIdOrCodigo', async ({ id_entidad }) => {
+    assert.equal(id_entidad, 1);
+    return null;
+  });
+  t.mock.method(ReporteEntidadModel, 'findOneByReporteAndEntidad', async () => {
+    assert.fail('No debe consultar asignacion si la entidad no esta activa.');
+  });
+  t.mock.method(ReporteModel, 'update', async () => {
+    assert.fail('No debe actualizar reportes si la entidad no esta activa.');
+  });
+
+  const req = {
+    params: { id: '15' },
+    user: { sub: 9, rol: 'entidad', id_entidad: 1 },
+    body: { estado: 'en_proceso' },
+  };
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await updateReporte(req, res, next);
+
+  assert.equal(res.statusCode, 403);
+  assert.equal(res.body.message, 'Usuario entidad sin entidad asignada.');
   assert.equal(next.mock.callCount(), 0);
 });


### PR DESCRIPTION
**Descripción**
Este PR completa el flujo backend de entidades en Green Alert, reforzando la validación de entidades activas en los endpoints propios, agregando el alias para marcar alertas como leídas y permitiendo definir prioridad en la asignación manual de reportes. La prioridad media se conserva por defecto para mantener compatibilidad, mientras que las prioridades alta y crítica generan alertas persistentes, y la prioridad crítica emite el evento Socket.IO correspondiente. También se agregaron y ajustaron pruebas unitarias para cubrir seguridad, entidades inactivas, alias de alertas, validación de prioridad, generación de alertas y emisión de eventos. Finalmente, se actualizó la documentación técnica de integración para frontend con el contrato final del backend, sin implementar frontend ni modificar GA-Test. La validación final dejó npm run test:unit en verde con 202 pruebas exitosas.

Close #271 

<img width="822" height="916" alt="image" src="https://github.com/user-attachments/assets/e3c29210-65e4-4357-b221-4fa1752ccd70" />
 