### PR TITLE
Issue 274 - Alinear contrato de asignación de entidades responsables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,18 +59,18 @@ FRONTEND_URL=http://localhost:5173
 # Ver: GOOGLE_OAUTH_SETUP.md para obtener estas credenciales
 GOOGLE_CLIENT_ID=your_client_id_here.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your_client_secret_here
-GOOGLE_CALLBACK_URL=http://localhost:3000/auth/google/callback
+GOOGLE_CALLBACK_URL=http://localhost:3000/api/auth/google/callback
 
 # Facebook OAuth Configuration
 # Ver README.md para obtener estas credenciales
 FACEBOOK_APP_ID=your_facebook_app_id
 FACEBOOK_APP_SECRET=your_facebook_app_secret
-FACEBOOK_CALLBACK_URL=http://localhost:3000/auth/facebook/callback
+FACEBOOK_CALLBACK_URL=http://localhost:3000/api/auth/facebook/callback
 FACEBOOK_GRAPH_API_VERSION=v20.0
 FACEBOOK_CALLBACK_RESPONSE=json
 
 # API Configuration
-API_PREFIX=
+API_PREFIX=/api
 API_PUBLIC_URL=http://localhost:3000
 
 # Hugging Face API

--- a/docs/integracion-frontend-entidades.md
+++ b/docs/integracion-frontend-entidades.md
@@ -196,7 +196,7 @@ Campos relevantes:
 | Campo | Requerido | Valores | Nota |
 | --- | --- | --- | --- |
 | `id_entidad` | Si | ID de entidad activa y permitida | La entidad debe existir, estar activa y pertenecer al alcance actual. |
-| `tipo_asignacion` | No | `principal`, `secundaria` | Si no se envia, el backend conserva su comportamiento actual. |
+| `tipo_asignacion` | No | `principal`, `apoyo` | Si no se envia, el backend usa `principal` por defecto. |
 | `prioridad` | No | `baja`, `media`, `alta`, `critica` | Si no se envia, el backend usa `media` por defecto para mantener compatibilidad. |
 
 Comportamiento por prioridad:

--- a/src/controllers/reporte.controller.js
+++ b/src/controllers/reporte.controller.js
@@ -63,6 +63,7 @@ const TRANSICIONES_ESTADO_REPORTE = {
   resuelto: [],
   rechazado: [],
 };
+const TIPOS_ASIGNACION_PERMITIDOS = ['principal', 'apoyo'];
 const PRIORIDADES_ASIGNACION_PERMITIDAS = ['baja', 'media', 'alta', 'critica'];
 
 const canTransitionReporteEstado = (estadoActual, estadoNuevo) => {
@@ -776,7 +777,16 @@ export const asignarEntidadReporte = async (req, res, next) => {
   try {
     const id = Number(req.params.id);
     const { id_entidad, codigo_entidad, comentario = null } = req.body ?? {};
+    const tipoAsignacion = normalizeEnumValue(req.body?.tipo_asignacion) || 'principal';
     const prioridad = normalizeEnumValue(req.body?.prioridad) || 'media';
+
+    if (!TIPOS_ASIGNACION_PERMITIDOS.includes(tipoAsignacion)) {
+      return errorResponse(
+        res,
+        buildAllowedValuesMessage('El tipo_asignacion', TIPOS_ASIGNACION_PERMITIDOS),
+        400
+      );
+    }
 
     if (!PRIORIDADES_ASIGNACION_PERMITIDAS.includes(prioridad)) {
       return errorResponse(
@@ -805,7 +815,7 @@ export const asignarEntidadReporte = async (req, res, next) => {
     await ReporteEntidadModel.createAssignment({
       id_reporte: id,
       id_entidad: entidad.id_entidad,
-      tipo_asignacion: 'principal',
+      tipo_asignacion: tipoAsignacion,
       prioridad,
       estado_atencion: 'pendiente',
       comentario: typeof comentario === 'string' ? comentario.trim() || null : null,
@@ -820,7 +830,7 @@ export const asignarEntidadReporte = async (req, res, next) => {
       ...asignacion,
       id_reporte: id,
       id_entidad: entidad.id_entidad,
-      tipo_asignacion: asignacion?.tipo_asignacion ?? 'principal',
+      tipo_asignacion: asignacion?.tipo_asignacion ?? tipoAsignacion,
       prioridad: asignacion?.prioridad ?? prioridad,
       entidad,
     };

--- a/tests/unit/alertas-entidad.test.js
+++ b/tests/unit/alertas-entidad.test.js
@@ -144,7 +144,7 @@ test('la tabla y el modelo evitan duplicados por asignacion y tipo de alerta', a
   assert.match(model, /LAST_INSERT_ID\(id_alerta_entidad\)/);
 });
 
-test('crea alerta para entidad principal y secundaria cuando ambas asignaciones aplican', async (t) => {
+test('crea alerta para entidad principal y de apoyo cuando ambas asignaciones aplican', async (t) => {
   const created = [];
   t.mock.method(AlertaEntidadModel, 'create', async (data) => {
     created.push(data);

--- a/tests/unit/reporte-asignacion-manual.test.js
+++ b/tests/unit/reporte-asignacion-manual.test.js
@@ -41,16 +41,19 @@ const entidadBomberos = {
   activo: 1,
 };
 
-const createAsignacion = (prioridad = 'media') => ({
+const createAsignacion = ({ prioridad = 'media', tipo_asignacion = 'principal' } = {}) => ({
   id_reporte_entidad: 7,
   id_reporte: 10,
   id_entidad: 1,
-  tipo_asignacion: 'principal',
+  tipo_asignacion,
   prioridad,
   estado_atencion: 'pendiente',
 });
 
-const mockAsignacionManualBase = (t, { prioridad = 'media' } = {}) => {
+const mockAsignacionManualBase = (t, {
+  prioridad = 'media',
+  tipo_asignacion = 'principal',
+} = {}) => {
   let assignmentPayload;
 
   t.mock.method(ReporteModel, 'findById', async () => reporteBase);
@@ -60,7 +63,7 @@ const mockAsignacionManualBase = (t, { prioridad = 'media' } = {}) => {
     return 7;
   });
   t.mock.method(ReporteEntidadModel, 'findOneByReporteAndEntidad', async () => (
-    createAsignacion(prioridad)
+    createAsignacion({ prioridad, tipo_asignacion })
   ));
 
   return {
@@ -97,6 +100,56 @@ test('asignarEntidadReporte asigna manualmente a una entidad activa y permitida'
     estado_atencion: 'pendiente',
     comentario: 'Revisar incendio',
   });
+});
+
+test('asignarEntidadReporte usa tipo_asignacion principal enviado en el body', async (t) => {
+  const { getAssignmentPayload } = mockAsignacionManualBase(t, {
+    tipo_asignacion: 'principal',
+  });
+  t.mock.method(AlertaEntidadModel, 'create', async () => {
+    assert.fail('No debe crear alerta persistente para prioridad media.');
+  });
+
+  const req = {
+    params: { id: '10' },
+    body: {
+      codigo_entidad: 'bomberos',
+      tipo_asignacion: 'principal',
+    },
+    user: { sub: 1, rol: 'admin' },
+  };
+  const res = createRes();
+
+  await asignarEntidadReporte(req, res, assert.fail);
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(getAssignmentPayload().tipo_asignacion, 'principal');
+  assert.equal(res.body.data.asignacion.tipo_asignacion, 'principal');
+});
+
+test('asignarEntidadReporte usa tipo_asignacion apoyo enviado en el body', async (t) => {
+  const { getAssignmentPayload } = mockAsignacionManualBase(t, {
+    tipo_asignacion: 'apoyo',
+  });
+  t.mock.method(AlertaEntidadModel, 'create', async () => {
+    assert.fail('No debe crear alerta persistente para prioridad media.');
+  });
+
+  const req = {
+    params: { id: '10' },
+    body: {
+      codigo_entidad: 'bomberos',
+      tipo_asignacion: 'apoyo',
+    },
+    user: { sub: 1, rol: 'admin' },
+  };
+  const res = createRes();
+
+  await asignarEntidadReporte(req, res, assert.fail);
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(getAssignmentPayload().tipo_asignacion, 'apoyo');
+  assert.equal(res.body.data.asignacion.tipo_asignacion, 'apoyo');
 });
 
 test('asignarEntidadReporte con prioridad critica genera alerta y evento socket', async (t) => {
@@ -205,6 +258,31 @@ test('asignarEntidadReporte rechaza prioridad invalida', async (t) => {
   assert.equal(res.statusCode, 400);
   assert.equal(res.body.status, 'error');
   assert.equal(res.body.message, 'La prioridad debe ser uno de: baja, media, alta, critica.');
+});
+
+test('asignarEntidadReporte rechaza tipo_asignacion invalido', async (t) => {
+  t.mock.method(ReporteModel, 'findById', async () => {
+    assert.fail('No debe consultar reporte si tipo_asignacion es invalido.');
+  });
+  t.mock.method(ReporteEntidadModel, 'createAssignment', async () => {
+    assert.fail('No debe crear asignacion con tipo_asignacion invalido.');
+  });
+
+  const req = {
+    params: { id: '10' },
+    body: {
+      codigo_entidad: 'bomberos',
+      tipo_asignacion: 'secundaria',
+    },
+    user: { sub: 1, rol: 'admin' },
+  };
+  const res = createRes();
+
+  await asignarEntidadReporte(req, res, assert.fail);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.status, 'error');
+  assert.equal(res.body.message, 'El tipo_asignacion debe ser uno de: principal, apoyo.');
 });
 
 test('asignarEntidadReporte rechaza entidades inactivas o fuera de alcance', async (t) => {

--- a/tests/unit/socket-notificaciones.test.js
+++ b/tests/unit/socket-notificaciones.test.js
@@ -121,7 +121,7 @@ test('emision critica a Bomberos notifica solo la sala de Bomberos', () => {
   assert.equal(emissions[0].event, SOCKET_EVENTS.REPORTE_CRITICO_ASIGNADO);
 });
 
-test('reporte critico con entidad principal y secundaria notifica ambas salas', () => {
+test('reporte critico con entidad principal y de apoyo notifica ambas salas', () => {
   const { io, emissions } = createMockIo();
   setSocketServerForTests(io);
 


### PR DESCRIPTION
**Descripción:**
Este PR corrige el flujo de asignación manual de reportes a entidades responsables en el backend de Green Alert, permitiendo que tipo_asignacion se lea correctamente desde el body, validando únicamente los valores principal y apoyo, usando principal como valor por defecto cuando no se envía y rechazando valores inválidos con respuesta 400. También actualiza la documentación de integración frontend para eliminar la referencia incorrecta a secundaria, ajusta las pruebas unitarias relacionadas con asignación manual, alertas y notificaciones, y confirma que la validación de sintaxis y las pruebas unitarias pasan correctamente, manteniendo el CI preparado para ejecutarse en verde.

Close #274 

<img width="820" height="832" alt="image" src="https://github.com/user-attachments/assets/7d522264-9710-4c75-8188-8eebd0f644a0" />
