### PR TITLE
Issue 276 - Endurecer validación de evidencias y consistencia en reportes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,18 +59,18 @@ FRONTEND_URL=http://localhost:5173
 # Ver: GOOGLE_OAUTH_SETUP.md para obtener estas credenciales
 GOOGLE_CLIENT_ID=your_client_id_here.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your_client_secret_here
-GOOGLE_CALLBACK_URL=http://localhost:3000/auth/google/callback
+GOOGLE_CALLBACK_URL=http://localhost:3000/api/auth/google/callback
 
 # Facebook OAuth Configuration
 # Ver README.md para obtener estas credenciales
 FACEBOOK_APP_ID=your_facebook_app_id
 FACEBOOK_APP_SECRET=your_facebook_app_secret
-FACEBOOK_CALLBACK_URL=http://localhost:3000/auth/facebook/callback
+FACEBOOK_CALLBACK_URL=http://localhost:3000/api/auth/facebook/callback
 FACEBOOK_GRAPH_API_VERSION=v20.0
 FACEBOOK_CALLBACK_RESPONSE=json
 
 # API Configuration
-API_PREFIX=
+API_PREFIX=/api
 API_PUBLIC_URL=http://localhost:3000
 
 # Hugging Face API

--- a/docs/integracion-frontend-entidades.md
+++ b/docs/integracion-frontend-entidades.md
@@ -196,7 +196,7 @@ Campos relevantes:
 | Campo | Requerido | Valores | Nota |
 | --- | --- | --- | --- |
 | `id_entidad` | Si | ID de entidad activa y permitida | La entidad debe existir, estar activa y pertenecer al alcance actual. |
-| `tipo_asignacion` | No | `principal`, `secundaria` | Si no se envia, el backend conserva su comportamiento actual. |
+| `tipo_asignacion` | No | `principal`, `apoyo` | Si no se envia, el backend usa `principal` por defecto. |
 | `prioridad` | No | `baja`, `media`, `alta`, `critica` | Si no se envia, el backend usa `media` por defecto para mantener compatibilidad. |
 
 Comportamiento por prioridad:

--- a/middlewares/upload.middleware.js
+++ b/middlewares/upload.middleware.js
@@ -10,14 +10,85 @@ const ALLOWED_MIME = [
   'video/mp4', 'video/quicktime',
 ];
 
+const MP4_COMPATIBLE_BRANDS = new Set([
+  'avc1', 'dash', 'iso2', 'iso5', 'iso6', 'isom', 'm4v ', 'mp41', 'mp42', 'msnv',
+]);
+
+const hasPrefix = (buffer, bytes) => (
+  Buffer.isBuffer(buffer) &&
+  buffer.length >= bytes.length &&
+  bytes.every((byte, index) => buffer[index] === byte)
+);
+
+const hasAsciiAt = (buffer, offset, value) => (
+  Buffer.isBuffer(buffer) &&
+  buffer.length >= offset + value.length &&
+  buffer.subarray(offset, offset + value.length).toString('ascii').toLowerCase() === value.toLowerCase()
+);
+
+const getIsoBaseMediaBrands = (buffer) => {
+  if (!Buffer.isBuffer(buffer) || buffer.length < 12 || !hasAsciiAt(buffer, 4, 'ftyp')) {
+    return [];
+  }
+
+  const boxSize = buffer.readUInt32BE(0);
+  if (boxSize < 12 || boxSize > buffer.length) {
+    return [];
+  }
+
+  const brands = [buffer.subarray(8, 12).toString('ascii').toLowerCase()];
+  for (let offset = 16; offset + 4 <= boxSize; offset += 4) {
+    brands.push(buffer.subarray(offset, offset + 4).toString('ascii').toLowerCase());
+  }
+
+  return brands;
+};
+
+const isJpeg = (buffer) => hasPrefix(buffer, [0xff, 0xd8, 0xff]);
+const isPng = (buffer) => hasPrefix(buffer, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const isWebp = (buffer) => hasAsciiAt(buffer, 0, 'RIFF') && hasAsciiAt(buffer, 8, 'WEBP');
+const isGif = (buffer) => hasAsciiAt(buffer, 0, 'GIF87a') || hasAsciiAt(buffer, 0, 'GIF89a');
+const isMp4 = (buffer) => getIsoBaseMediaBrands(buffer).some((brand) => MP4_COMPATIBLE_BRANDS.has(brand));
+const isQuicktime = (buffer) => getIsoBaseMediaBrands(buffer).includes('qt  ');
+
+const SIGNATURE_VALIDATORS = {
+  'image/jpeg': isJpeg,
+  'image/jpg': isJpeg,
+  'image/png': isPng,
+  'image/webp': isWebp,
+  'image/gif': isGif,
+  'video/mp4': isMp4,
+  'video/quicktime': isQuicktime,
+};
+
+const buildUploadError = (message) => {
+  const error = new Error(message);
+  error.statusCode = 400;
+  return error;
+};
+
+export const validateUploadedFilesContent = (files = []) => {
+  for (const file of files.filter(Boolean)) {
+    const validator = SIGNATURE_VALIDATORS[file.mimetype];
+    if (!validator) {
+      return 'Tipo de archivo no permitido. Solo imagenes y videos.';
+    }
+
+    if (!validator(file.buffer)) {
+      const filename = file.originalname || file.filename || 'archivo';
+      return `El contenido del archivo "${filename}" no coincide con el tipo declarado o esta corrupto.`;
+    }
+  }
+
+  return null;
+};
+
 export const fileFilter = (_req, file, cb) => {
   if (ALLOWED_MIME.includes(file.mimetype)) {
     return cb(null, true);
   }
 
-  const error = new Error('Tipo de archivo no permitido. Solo imagenes y videos.');
-  error.statusCode = 400;
-  return cb(error);
+  return cb(buildUploadError('Tipo de archivo no permitido. Solo imagenes y videos.'));
 };
 
 const baseUpload = multer({
@@ -49,6 +120,13 @@ const decorateUploadedFiles = (req) => {
   }
 };
 
+const getRequestUploadedFiles = (req) => ([
+  ...(req.file ? [req.file] : []),
+  ...(Array.isArray(req.files) ? req.files : []),
+  ...(Array.isArray(req.files?.file) ? req.files.file : []),
+  ...(Array.isArray(req.files?.files) ? req.files.files : []),
+]);
+
 const wrapUploadMiddleware = (middleware) => (req, res, next) => {
   middleware(req, res, (error) => {
     if (error) {
@@ -56,6 +134,11 @@ const wrapUploadMiddleware = (middleware) => (req, res, next) => {
     }
 
     decorateUploadedFiles(req);
+    const contentError = validateUploadedFilesContent(getRequestUploadedFiles(req));
+    if (contentError) {
+      return next(buildUploadError(contentError));
+    }
+
     return next();
   });
 };

--- a/src/controllers/reporte.controller.js
+++ b/src/controllers/reporte.controller.js
@@ -23,6 +23,7 @@ import { crearAlertaDesdeAsignacionReporte } from '../services/alerta-entidad.se
 import { notificarReporteCriticoAsignado } from '../config/socket.js';
 import { errorResponse, successResponse } from '../utils/response.js';
 import { crearNotificacion } from './notificacion.controller.js';
+import { validateUploadedFilesContent } from '../../middlewares/upload.middleware.js';
 
 const ANONYMOUS_VIEW_THROTTLE_MS = 5 * 60 * 1000;
 const anonymousViewThrottle = new Map();
@@ -147,7 +148,7 @@ const validateReporteEvidenceFiles = (files) => {
     return 'Solo puedes adjuntar un video por reporte.';
   }
 
-  return null;
+  return validateUploadedFilesContent(files);
 };
 
 export const sugerirContenidoReporte = async (req, res, next) => {
@@ -238,6 +239,19 @@ const cleanupCloudinaryUploads = async (uploads) => {
         resourceType: upload.resource_type || 'image',
       }))
   );
+};
+
+const rollbackCreatedReporte = async (idReporte, cloudinaryUploads = []) => {
+  const results = await Promise.allSettled([
+    cleanupCloudinaryUploads(cloudinaryUploads),
+    idReporte ? ReporteModel.remove(idReporte) : Promise.resolve(),
+  ]);
+
+  results
+    .filter((result) => result.status === 'rejected')
+    .forEach((result) => {
+      console.error('[reportes] rollback parcial fallido:', result.reason?.message || result.reason);
+    });
 };
 
 const shouldDeleteFromCloudinary = (evidencia) => (
@@ -422,46 +436,49 @@ export const createReporte = async (req, res, next) => {
       scoreEvidencias.evidencias.map((item, index) => [index, item.hash_sha256])
     );
 
-    const idReporte = await ReporteModel.create({
-      id_usuario:       req.user.sub,
-      tipo_contaminacion: tipoContaminacion,
-      subcategoria:        subcategoria?.trim() || null,
-      nivel_severidad:    nivelSeveridad,
-      titulo:             titulo.trim(),
-      descripcion:        descripcion?.trim() || null,
-      direccion:          direccion.trim(),
-      municipio:          municipio?.trim() || null,
-      departamento:       departamento?.trim() || null,
-      latitud:            parsedLatitud.value,
-      longitud:           parsedLongitud.value,
-      confianza_evidencia: scoreEvidencias.score,
-    });
-
-    let reporte = await ReporteModel.findById(idReporte);
-
-    let iaAnalysis;
-    if (iaPayload.procesado) {
-      iaAnalysis = iaPayload.analysis;
-    } else {
-      iaAnalysis = analyzeReporte({
-        ...reporte,
-        tipo_contaminacion: tipoContaminacion,
-        nivel_severidad: nivelSeveridad,
-        titulo: titulo.trim(),
-        descripcion: descripcion?.trim() || null,
-        direccion: direccion.trim(),
-        municipio: municipio?.trim() || null,
-        departamento: departamento?.trim() || null,
-        latitud: parsedLatitud.value,
-        longitud: parsedLongitud.value,
-      });
-    }
-
-    await ReporteModel.updateIaAnalysis(idReporte, iaAnalysis);
-    reporte = await ReporteModel.findById(idReporte);
-
     const cloudinaryUploads = [];
+    let idReporte = null;
+    let reporte = null;
+
     try {
+      idReporte = await ReporteModel.create({
+        id_usuario:       req.user.sub,
+        tipo_contaminacion: tipoContaminacion,
+        subcategoria:        subcategoria?.trim() || null,
+        nivel_severidad:    nivelSeveridad,
+        titulo:             titulo.trim(),
+        descripcion:        descripcion?.trim() || null,
+        direccion:          direccion.trim(),
+        municipio:          municipio?.trim() || null,
+        departamento:       departamento?.trim() || null,
+        latitud:            parsedLatitud.value,
+        longitud:           parsedLongitud.value,
+        confianza_evidencia: scoreEvidencias.score,
+      });
+
+      reporte = await ReporteModel.findById(idReporte);
+
+      let iaAnalysis;
+      if (iaPayload.procesado) {
+        iaAnalysis = iaPayload.analysis;
+      } else {
+        iaAnalysis = analyzeReporte({
+          ...reporte,
+          tipo_contaminacion: tipoContaminacion,
+          nivel_severidad: nivelSeveridad,
+          titulo: titulo.trim(),
+          descripcion: descripcion?.trim() || null,
+          direccion: direccion.trim(),
+          municipio: municipio?.trim() || null,
+          departamento: departamento?.trim() || null,
+          latitud: parsedLatitud.value,
+          longitud: parsedLongitud.value,
+        });
+      }
+
+      await ReporteModel.updateIaAnalysis(idReporte, iaAnalysis);
+      reporte = await ReporteModel.findById(idReporte);
+
       for (const [index, file] of uploadedFiles.entries()) {
         const { uploadResult, evidencia } = await uploadEvidenceToCloudinary(file, {
           idReporte,
@@ -474,7 +491,7 @@ export const createReporte = async (req, res, next) => {
         await EvidenciaModel.create(evidencia);
       }
     } catch (error) {
-      await cleanupCloudinaryUploads(cloudinaryUploads);
+      await rollbackCreatedReporte(idReporte, cloudinaryUploads);
       throw error;
     }
 
@@ -1144,6 +1161,11 @@ export const addEvidenciaReporte = async (req, res, next) => {
 
     if (!req.file) {
       return errorResponse(res, 'Archivo de evidencia requerido.', 400);
+    }
+
+    const contentError = validateUploadedFilesContent([req.file]);
+    if (contentError) {
+      return errorResponse(res, contentError, 400);
     }
 
     const scoreEvidencia = await calcularScoreEvidencias([req.file], reporte.nivel_severidad);

--- a/src/controllers/reporte.controller.js
+++ b/src/controllers/reporte.controller.js
@@ -63,6 +63,7 @@ const TRANSICIONES_ESTADO_REPORTE = {
   resuelto: [],
   rechazado: [],
 };
+const TIPOS_ASIGNACION_PERMITIDOS = ['principal', 'apoyo'];
 const PRIORIDADES_ASIGNACION_PERMITIDAS = ['baja', 'media', 'alta', 'critica'];
 
 const canTransitionReporteEstado = (estadoActual, estadoNuevo) => {
@@ -776,7 +777,16 @@ export const asignarEntidadReporte = async (req, res, next) => {
   try {
     const id = Number(req.params.id);
     const { id_entidad, codigo_entidad, comentario = null } = req.body ?? {};
+    const tipoAsignacion = normalizeEnumValue(req.body?.tipo_asignacion) || 'principal';
     const prioridad = normalizeEnumValue(req.body?.prioridad) || 'media';
+
+    if (!TIPOS_ASIGNACION_PERMITIDOS.includes(tipoAsignacion)) {
+      return errorResponse(
+        res,
+        buildAllowedValuesMessage('El tipo_asignacion', TIPOS_ASIGNACION_PERMITIDOS),
+        400
+      );
+    }
 
     if (!PRIORIDADES_ASIGNACION_PERMITIDAS.includes(prioridad)) {
       return errorResponse(
@@ -805,7 +815,7 @@ export const asignarEntidadReporte = async (req, res, next) => {
     await ReporteEntidadModel.createAssignment({
       id_reporte: id,
       id_entidad: entidad.id_entidad,
-      tipo_asignacion: 'principal',
+      tipo_asignacion: tipoAsignacion,
       prioridad,
       estado_atencion: 'pendiente',
       comentario: typeof comentario === 'string' ? comentario.trim() || null : null,
@@ -820,7 +830,7 @@ export const asignarEntidadReporte = async (req, res, next) => {
       ...asignacion,
       id_reporte: id,
       id_entidad: entidad.id_entidad,
-      tipo_asignacion: asignacion?.tipo_asignacion ?? 'principal',
+      tipo_asignacion: asignacion?.tipo_asignacion ?? tipoAsignacion,
       prioridad: asignacion?.prioridad ?? prioridad,
       entidad,
     };

--- a/tests/unit/alertas-entidad.test.js
+++ b/tests/unit/alertas-entidad.test.js
@@ -144,7 +144,7 @@ test('la tabla y el modelo evitan duplicados por asignacion y tipo de alerta', a
   assert.match(model, /LAST_INSERT_ID\(id_alerta_entidad\)/);
 });
 
-test('crea alerta para entidad principal y secundaria cuando ambas asignaciones aplican', async (t) => {
+test('crea alerta para entidad principal y de apoyo cuando ambas asignaciones aplican', async (t) => {
   const created = [];
   t.mock.method(AlertaEntidadModel, 'create', async (data) => {
     created.push(data);

--- a/tests/unit/reporte-asignacion-manual.test.js
+++ b/tests/unit/reporte-asignacion-manual.test.js
@@ -41,16 +41,19 @@ const entidadBomberos = {
   activo: 1,
 };
 
-const createAsignacion = (prioridad = 'media') => ({
+const createAsignacion = ({ prioridad = 'media', tipo_asignacion = 'principal' } = {}) => ({
   id_reporte_entidad: 7,
   id_reporte: 10,
   id_entidad: 1,
-  tipo_asignacion: 'principal',
+  tipo_asignacion,
   prioridad,
   estado_atencion: 'pendiente',
 });
 
-const mockAsignacionManualBase = (t, { prioridad = 'media' } = {}) => {
+const mockAsignacionManualBase = (t, {
+  prioridad = 'media',
+  tipo_asignacion = 'principal',
+} = {}) => {
   let assignmentPayload;
 
   t.mock.method(ReporteModel, 'findById', async () => reporteBase);
@@ -60,7 +63,7 @@ const mockAsignacionManualBase = (t, { prioridad = 'media' } = {}) => {
     return 7;
   });
   t.mock.method(ReporteEntidadModel, 'findOneByReporteAndEntidad', async () => (
-    createAsignacion(prioridad)
+    createAsignacion({ prioridad, tipo_asignacion })
   ));
 
   return {
@@ -97,6 +100,56 @@ test('asignarEntidadReporte asigna manualmente a una entidad activa y permitida'
     estado_atencion: 'pendiente',
     comentario: 'Revisar incendio',
   });
+});
+
+test('asignarEntidadReporte usa tipo_asignacion principal enviado en el body', async (t) => {
+  const { getAssignmentPayload } = mockAsignacionManualBase(t, {
+    tipo_asignacion: 'principal',
+  });
+  t.mock.method(AlertaEntidadModel, 'create', async () => {
+    assert.fail('No debe crear alerta persistente para prioridad media.');
+  });
+
+  const req = {
+    params: { id: '10' },
+    body: {
+      codigo_entidad: 'bomberos',
+      tipo_asignacion: 'principal',
+    },
+    user: { sub: 1, rol: 'admin' },
+  };
+  const res = createRes();
+
+  await asignarEntidadReporte(req, res, assert.fail);
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(getAssignmentPayload().tipo_asignacion, 'principal');
+  assert.equal(res.body.data.asignacion.tipo_asignacion, 'principal');
+});
+
+test('asignarEntidadReporte usa tipo_asignacion apoyo enviado en el body', async (t) => {
+  const { getAssignmentPayload } = mockAsignacionManualBase(t, {
+    tipo_asignacion: 'apoyo',
+  });
+  t.mock.method(AlertaEntidadModel, 'create', async () => {
+    assert.fail('No debe crear alerta persistente para prioridad media.');
+  });
+
+  const req = {
+    params: { id: '10' },
+    body: {
+      codigo_entidad: 'bomberos',
+      tipo_asignacion: 'apoyo',
+    },
+    user: { sub: 1, rol: 'admin' },
+  };
+  const res = createRes();
+
+  await asignarEntidadReporte(req, res, assert.fail);
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(getAssignmentPayload().tipo_asignacion, 'apoyo');
+  assert.equal(res.body.data.asignacion.tipo_asignacion, 'apoyo');
 });
 
 test('asignarEntidadReporte con prioridad critica genera alerta y evento socket', async (t) => {
@@ -205,6 +258,31 @@ test('asignarEntidadReporte rechaza prioridad invalida', async (t) => {
   assert.equal(res.statusCode, 400);
   assert.equal(res.body.status, 'error');
   assert.equal(res.body.message, 'La prioridad debe ser uno de: baja, media, alta, critica.');
+});
+
+test('asignarEntidadReporte rechaza tipo_asignacion invalido', async (t) => {
+  t.mock.method(ReporteModel, 'findById', async () => {
+    assert.fail('No debe consultar reporte si tipo_asignacion es invalido.');
+  });
+  t.mock.method(ReporteEntidadModel, 'createAssignment', async () => {
+    assert.fail('No debe crear asignacion con tipo_asignacion invalido.');
+  });
+
+  const req = {
+    params: { id: '10' },
+    body: {
+      codigo_entidad: 'bomberos',
+      tipo_asignacion: 'secundaria',
+    },
+    user: { sub: 1, rol: 'admin' },
+  };
+  const res = createRes();
+
+  await asignarEntidadReporte(req, res, assert.fail);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.status, 'error');
+  assert.equal(res.body.message, 'El tipo_asignacion debe ser uno de: principal, apoyo.');
 });
 
 test('asignarEntidadReporte rechaza entidades inactivas o fuera de alcance', async (t) => {

--- a/tests/unit/reporte-evidencias-gestion.test.js
+++ b/tests/unit/reporte-evidencias-gestion.test.js
@@ -1,12 +1,12 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import {
   addEvidenciaReporte,
   deleteEvidenciaReporte,
   listEvidenciasReporte,
 } from '../../src/controllers/reporte.controller.js';
 import { EvidenciaModel } from '../../src/models/evidencia.model.js';
-const FAKE_IMAGE_SHA256 = 'a8eb701c6f567b08661c2604364dd595455b811d2759d2029b465935b561c86b';
 import { ReporteModel } from '../../src/models/reporte.model.js';
 import {
   resetCloudinaryClientForTest,
@@ -31,6 +31,13 @@ const reporte = {
   id_usuario: 7,
   estado: 'pendiente',
 };
+
+const VALID_PNG_BUFFER = Buffer.concat([
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+  Buffer.from('fake-image'),
+]);
+
+const FAKE_IMAGE_SHA256 = createHash('sha256').update(VALID_PNG_BUFFER).digest('hex');
 
 test.afterEach(() => {
   resetCloudinaryClientForTest();
@@ -95,7 +102,7 @@ test('addEvidenciaReporte agrega evidencia al reporte como moderador', async (t)
       filename: 'evidencia.png',
       originalname: 'foto.png',
       size: 1024,
-      buffer: Buffer.from('fake-image'),
+      buffer: VALID_PNG_BUFFER,
     },
   };
   const res = createResponse();
@@ -119,6 +126,37 @@ test('addEvidenciaReporte agrega evidencia al reporte como moderador', async (t)
   assert.equal(evidencia.cloudinary_resource_type, 'image');
   assert.equal(evidencia.cloudinary_metadata.bytes, 1024);
   assert.equal(evidencia.orden, 0);
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('addEvidenciaReporte rechaza archivo con contenido falso', async (t) => {
+  t.mock.method(ReporteModel, 'findById', async () => reporte);
+  t.mock.method(EvidenciaModel, 'create', async () => {
+    throw new Error('No debe guardar evidencia con contenido falso');
+  });
+
+  const req = {
+    params: { id: '15' },
+    user: { sub: 9, rol: 'moderador' },
+    file: {
+      mimetype: 'image/png',
+      filename: 'falso.png',
+      originalname: 'falso.png',
+      size: 1024,
+      buffer: Buffer.from('%PDF-1.7 contenido falso'),
+    },
+  };
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await addEvidenciaReporte(req, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(
+    res.body.message,
+    'El contenido del archivo "falso.png" no coincide con el tipo declarado o esta corrupto.'
+  );
+  assert.equal(EvidenciaModel.create.mock.callCount(), 0);
   assert.equal(next.mock.callCount(), 0);
 });
 

--- a/tests/unit/reporte-upload-evidencias.test.js
+++ b/tests/unit/reporte-upload-evidencias.test.js
@@ -1,13 +1,16 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import { fileFilter } from '../../middlewares/upload.middleware.js';
 import { createReporte } from '../../src/controllers/reporte.controller.js';
 import { CategoriaRiesgoModel } from '../../src/models/categoria-riesgo.model.js';
 import { EvidenciaModel } from '../../src/models/evidencia.model.js';
 import { ReporteModel } from '../../src/models/reporte.model.js';
 import { AsignacionEntidadesService } from '../../src/services/asignacion-entidades.service.js';
-
-const FAKE_FILE_1_SHA256 = 'c30851811a9b8c08b5c9b43c0d0ad77cc30f77188bfdc1bf97599c05e957d370';
+import {
+  resetCloudinaryClientForTest,
+  setCloudinaryClientForTest,
+} from '../../src/services/cloudinary.service.js';
 
 const createResponse = () => ({
   statusCode: null,
@@ -22,12 +25,60 @@ const createResponse = () => ({
   },
 });
 
+const sha256 = (buffer) => createHash('sha256').update(buffer).digest('hex');
+
+const createValidBuffer = (index, mimetype = 'image/png') => {
+  const payload = Buffer.from(`fake-file-${index}`);
+
+  if (mimetype === 'image/jpeg' || mimetype === 'image/jpg') {
+    return Buffer.concat([Buffer.from([0xff, 0xd8, 0xff, 0xe0]), payload]);
+  }
+
+  if (mimetype === 'image/webp') {
+    return Buffer.concat([
+      Buffer.from('RIFF', 'ascii'),
+      Buffer.from([0x10, 0x00, 0x00, 0x00]),
+      Buffer.from('WEBPVP8 ', 'ascii'),
+      payload,
+    ]);
+  }
+
+  if (mimetype === 'image/gif') {
+    return Buffer.concat([Buffer.from('GIF89a', 'ascii'), payload]);
+  }
+
+  if (mimetype === 'video/mp4') {
+    return Buffer.concat([
+      Buffer.from([0x00, 0x00, 0x00, 0x18]),
+      Buffer.from('ftypisom', 'ascii'),
+      Buffer.from([0x00, 0x00, 0x00, 0x00]),
+      Buffer.from('isomiso2mp41', 'ascii'),
+      payload,
+    ]);
+  }
+
+  if (mimetype === 'video/quicktime') {
+    return Buffer.concat([
+      Buffer.from([0x00, 0x00, 0x00, 0x14]),
+      Buffer.from('ftypqt  ', 'ascii'),
+      Buffer.from([0x00, 0x00, 0x00, 0x00]),
+      Buffer.from('qt  ', 'ascii'),
+      payload,
+    ]);
+  }
+
+  return Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    payload,
+  ]);
+};
+
 const createFile = (index, mimetype = 'image/png') => ({
   mimetype,
   filename: `evidencia-${index}.${mimetype.startsWith('video/') ? 'mp4' : 'png'}`,
   originalname: `original-${index}.${mimetype.startsWith('video/') ? 'mp4' : 'png'}`,
   size: 1024 + index,
-  buffer: Buffer.from(`fake-file-${index}`),
+  buffer: createValidBuffer(index, mimetype),
 });
 
 const createRequest = (files = [], bodyOverrides = {}) => ({
@@ -64,6 +115,10 @@ const mockSuccessfulCreate = (t) => {
   t.mock.method(AsignacionEntidadesService, 'asignarEntidadesAReporte', async () => []);
 };
 
+test.afterEach(() => {
+  resetCloudinaryClientForTest();
+});
+
 test('createReporte guarda multiples imagenes con metadata y orden', async (t) => {
   mockSuccessfulCreate(t);
 
@@ -83,7 +138,7 @@ test('createReporte guarda multiples imagenes con metadata y orden', async (t) =
   assert.equal(evidencia.nombre_original, 'original-1.png');
   assert.equal(evidencia.mime_type, 'image/png');
   assert.equal(evidencia.tamano_bytes, 1025);
-  assert.equal(evidencia.hash_sha256, FAKE_FILE_1_SHA256);
+  assert.equal(evidencia.hash_sha256, sha256(createFile(1).buffer));
   assert.equal(evidencia.storage_provider, 'cloudinary');
   assert.match(evidencia.cloudinary_public_id, /^green-alert\/test\//);
   assert.match(evidencia.cloudinary_asset_id, /^asset-/);
@@ -156,6 +211,37 @@ test('createReporte permite un video por reporte', async (t) => {
   assert.equal(EvidenciaModel.create.mock.calls[1].arguments[0].cloudinary_resource_type, 'video');
 });
 
+test('createReporte rechaza archivo con MIME valido pero contenido invalido', async (t) => {
+  t.mock.method(CategoriaRiesgoModel, 'esValido', async () => {
+    throw new Error('No debe validar categoria con contenido invalido');
+  });
+  t.mock.method(ReporteModel, 'create', async () => {
+    throw new Error('No debe insertar reporte con contenido invalido');
+  });
+  t.mock.method(EvidenciaModel, 'create', async () => {
+    throw new Error('No debe insertar evidencia con contenido invalido');
+  });
+
+  const req = createRequest([{
+    ...createFile(0),
+    originalname: 'falso.png',
+    buffer: Buffer.from('%PDF-1.7 contenido falso'),
+  }]);
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await createReporte(req, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(
+    res.body.message,
+    'El contenido del archivo "falso.png" no coincide con el tipo declarado o esta corrupto.'
+  );
+  assert.equal(ReporteModel.create.mock.callCount(), 0);
+  assert.equal(EvidenciaModel.create.mock.callCount(), 0);
+  assert.equal(next.mock.callCount(), 0);
+});
+
 test('createReporte rechaza dos videos antes de crear reporte', async (t) => {
   t.mock.method(CategoriaRiesgoModel, 'esValido', async () => {
     throw new Error('No debe validar categoria con dos videos');
@@ -199,4 +285,81 @@ test('fileFilter rechaza mime invalido como error 400', () => {
   assert.equal(callbackError.statusCode, 400);
   assert.equal(callbackError.message, 'Tipo de archivo no permitido. Solo imagenes y videos.');
   assert.equal(accepted, undefined);
+});
+
+test('createReporte revierte reporte si Cloudinary falla al subir evidencia', async (t) => {
+  mockSuccessfulCreate(t);
+  t.mock.method(ReporteModel, 'remove', async () => true);
+
+  setCloudinaryClientForTest({
+    uploader: {
+      upload_stream(_options, callback) {
+        return {
+          end() {
+            callback(new Error('cloudinary unavailable'));
+          },
+        };
+      },
+    },
+  });
+
+  const req = createRequest([createFile(0)]);
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await createReporte(req, res, next);
+
+  assert.equal(res.statusCode, null);
+  assert.equal(EvidenciaModel.create.mock.callCount(), 0);
+  assert.equal(ReporteModel.remove.mock.callCount(), 1);
+  assert.equal(ReporteModel.remove.mock.calls[0].arguments[0], 15);
+  assert.equal(next.mock.callCount(), 1);
+  assert.equal(next.mock.calls[0].arguments[0].message, 'cloudinary unavailable');
+});
+
+test('createReporte limpia Cloudinary y revierte reporte si falla guardado de evidencia', async (t) => {
+  mockSuccessfulCreate(t);
+  t.mock.method(ReporteModel, 'remove', async () => true);
+  t.mock.method(EvidenciaModel, 'create', async () => {
+    throw new Error('db evidence unavailable');
+  });
+
+  let destroyedPublicId = null;
+  let destroyOptions = null;
+  setCloudinaryClientForTest({
+    uploader: {
+      upload_stream(options, callback) {
+        return {
+          end() {
+            callback(null, {
+              asset_id: 'asset-mock',
+              public_id: 'green-alert/reportes/mock',
+              secure_url: 'https://mocked.cloudinary/image/upload/green-alert/reportes/mock',
+              resource_type: options.resource_type,
+              bytes: 1024,
+            });
+          },
+        };
+      },
+      destroy(publicId, options) {
+        destroyedPublicId = publicId;
+        destroyOptions = options;
+        return Promise.resolve({ result: 'ok' });
+      },
+    },
+  });
+
+  const req = createRequest([createFile(0)]);
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await createReporte(req, res, next);
+
+  assert.equal(res.statusCode, null);
+  assert.equal(ReporteModel.remove.mock.callCount(), 1);
+  assert.equal(ReporteModel.remove.mock.calls[0].arguments[0], 15);
+  assert.equal(destroyedPublicId, 'green-alert/reportes/mock');
+  assert.deepEqual(destroyOptions, { resource_type: 'image', invalidate: true });
+  assert.equal(next.mock.callCount(), 1);
+  assert.equal(next.mock.calls[0].arguments[0].message, 'db evidence unavailable');
 });

--- a/tests/unit/socket-notificaciones.test.js
+++ b/tests/unit/socket-notificaciones.test.js
@@ -121,7 +121,7 @@ test('emision critica a Bomberos notifica solo la sala de Bomberos', () => {
   assert.equal(emissions[0].event, SOCKET_EVENTS.REPORTE_CRITICO_ASIGNADO);
 });
 
-test('reporte critico con entidad principal y secundaria notifica ambas salas', () => {
+test('reporte critico con entidad principal y de apoyo notifica ambas salas', () => {
   const { io, emissions } = createMockIo();
   setSocketServerForTests(io);
 

--- a/tests/unit/upload-config.test.js
+++ b/tests/unit/upload-config.test.js
@@ -36,6 +36,23 @@ const listen = (app) => new Promise((resolve) => {
   const server = app.listen(0, () => resolve(server));
 });
 
+const PNG_BYTES = Buffer.concat([
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+  Buffer.from('fake-image'),
+]);
+
+const WEBP_BYTES = Buffer.concat([
+  Buffer.from('RIFF', 'ascii'),
+  Buffer.from([0x10, 0x00, 0x00, 0x00]),
+  Buffer.from('WEBPVP8 ', 'ascii'),
+  Buffer.from('fake-webp'),
+]);
+
+const JPEG_BYTES = Buffer.concat([
+  Buffer.from([0xff, 0xd8, 0xff, 0xe0]),
+  Buffer.from('fake-jpeg'),
+]);
+
 test('upload.single guarda archivo en memoria y conserva filename compatible', async () => {
   const app = express();
   app.post('/upload', upload.single('file'), (req, res) => {
@@ -51,7 +68,7 @@ test('upload.single guarda archivo en memoria y conserva filename compatible', a
   try {
     const port = server.address().port;
     const formData = new FormData();
-    formData.append('file', new Blob(['fake-image'], { type: 'image/png' }), 'evidencia.png');
+    formData.append('file', new Blob([PNG_BYTES], { type: 'image/png' }), 'evidencia.png');
 
     const response = await fetch(`http://127.0.0.1:${port}/upload`, {
       method: 'POST',
@@ -64,6 +81,37 @@ test('upload.single guarda archivo en memoria y conserva filename compatible', a
     assert.match(body.filename, /^[0-9a-f-]{36}\.png$/);
     assert.equal(body.originalname, 'evidencia.png');
     assert.equal(body.path, null);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test('upload.single rechaza MIME valido con contenido falso', async () => {
+  const app = express();
+  app.post('/upload', upload.single('file'), (_req, res) => {
+    res.json({ ok: true });
+  });
+  app.use((error, _req, res, _next) => {
+    res.status(error.statusCode || 500).json({ message: error.message });
+  });
+
+  const server = await listen(app);
+  try {
+    const port = server.address().port;
+    const formData = new FormData();
+    formData.append('file', new Blob(['%PDF-1.7 contenido falso'], { type: 'image/png' }), 'falso.png');
+
+    const response = await fetch(`http://127.0.0.1:${port}/upload`, {
+      method: 'POST',
+      body: formData,
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(
+      body.message,
+      'El contenido del archivo "falso.png" no coincide con el tipo declarado o esta corrupto.'
+    );
   } finally {
     await new Promise((resolve) => server.close(resolve));
   }
@@ -90,9 +138,9 @@ test('uploadMultiple mantiene campos file y files', async () => {
   try {
     const port = server.address().port;
     const formData = new FormData();
-    formData.append('file', new Blob(['main'], { type: 'image/png' }), 'principal.png');
-    formData.append('files', new Blob(['one'], { type: 'image/webp' }), 'uno.webp');
-    formData.append('files', new Blob(['two'], { type: 'image/jpeg' }), 'dos.jpg');
+    formData.append('file', new Blob([PNG_BYTES], { type: 'image/png' }), 'principal.png');
+    formData.append('files', new Blob([WEBP_BYTES], { type: 'image/webp' }), 'uno.webp');
+    formData.append('files', new Blob([JPEG_BYTES], { type: 'image/jpeg' }), 'dos.jpg');
 
     const response = await fetch(`http://127.0.0.1:${port}/upload-multiple`, {
       method: 'POST',


### PR DESCRIPTION
**Descripción:**
Este PR refuerza el flujo de evidencias en el backend de Green Alert mediante validación de firmas reales o magic bytes para archivos JPEG, PNG, WebP, GIF, MP4 y QuickTime, evitando que se acepten archivos falsificados aunque declaren un MIME válido. Además, mejora la consistencia en la creación de reportes al limpiar assets subidos a Cloudinary y aplicar rollback lógico cuando ocurre un fallo parcial durante la carga o el guardado de evidencias. También extiende esta protección al endpoint para agregar evidencias a reportes existentes, ajusta las pruebas unitarias relacionadas y confirma que npm test y la validación de sintaxis equivalente al workflow pasan correctamente, por lo que el CI del backend debería mantenerse en verde.

Close #276 

<img width="810" height="829" alt="image" src="https://github.com/user-attachments/assets/e41d7fe9-b18a-427e-b23e-fb71652764e2" />
