### PR TITLE
Issue 281 - Endurecer seguridad OAuth con validación de state

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,18 +59,18 @@ FRONTEND_URL=http://localhost:5173
 # Ver: GOOGLE_OAUTH_SETUP.md para obtener estas credenciales
 GOOGLE_CLIENT_ID=your_client_id_here.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your_client_secret_here
-GOOGLE_CALLBACK_URL=http://localhost:3000/auth/google/callback
+GOOGLE_CALLBACK_URL=http://localhost:3000/api/auth/google/callback
 
 # Facebook OAuth Configuration
 # Ver README.md para obtener estas credenciales
 FACEBOOK_APP_ID=your_facebook_app_id
 FACEBOOK_APP_SECRET=your_facebook_app_secret
-FACEBOOK_CALLBACK_URL=http://localhost:3000/auth/facebook/callback
+FACEBOOK_CALLBACK_URL=http://localhost:3000/api/auth/facebook/callback
 FACEBOOK_GRAPH_API_VERSION=v20.0
 FACEBOOK_CALLBACK_RESPONSE=json
 
 # API Configuration
-API_PREFIX=
+API_PREFIX=/api
 API_PUBLIC_URL=http://localhost:3000
 
 # Hugging Face API

--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ Backend/
   validate-google-credentials.js
   docs/
     README.md
+    openapi.yaml
+    integracion-frontend-entidades.md
+    PREDICCION_ZONAS_RIESGO.md
   middlewares/
     auth.middleware.js
     errorHandler.js
@@ -108,7 +111,10 @@ Backend/
     admin.routes.js
     auth.routes.js
     categoria-riesgo.routes.js
+    chatbot.routes.js
+    entidad.routes.js
     health.routes.js
+    notificacion.routes.js
     reporte.routes.js
   src/
     app.js
@@ -193,6 +199,10 @@ En desarrollo, el frontend puede seguir llamando `/api/*` porque Vite reescribe 
 
 Si necesitas publicar el backend directamente bajo `/api`, define `API_PREFIX=/api`. No se montan ambos prefijos al mismo tiempo.
 
+## OpenAPI
+
+La especificacion inicial esta disponible en [`docs/openapi.yaml`](docs/openapi.yaml). No se monta Swagger UI en runtime; el archivo queda listo para validarse con herramientas externas o integrarse en una etapa posterior.
+
 ## Rutas
 
 ### Salud
@@ -215,14 +225,17 @@ Si necesitas publicar el backend directamente bajo `/api`, define `API_PREFIX=/a
 | `POST` | `/auth/reset-password` | No | Restablece contrasena con token. |
 | `GET` | `/auth/perfil` | Si | Obtiene perfil del usuario autenticado. |
 | `PATCH` | `/auth/perfil` | Si | Actualiza perfil. |
+| `PATCH` | `/auth/avatar` | Si | Actualiza avatar con archivo `avatar`. |
 | `PATCH` | `/auth/cambiar-contrasena` | Si | Cambia contrasena y revoca refresh tokens. |
 | `PATCH` | `/auth/notificaciones` | Si | Actualiza preferencias de notificaciones. |
 | `POST` | `/auth/enviar-verificacion` | Si | Envia OTP de verificacion de email. |
 | `POST` | `/auth/verificar-email` | Si | Verifica OTP de email. |
 | `GET` | `/auth/google/url` | No | Genera URL de login con Google. |
+| `POST` | `/auth/google` | No | Login con access token de Google. |
 | `POST` | `/auth/google/login` | No | Login con `id_token` de Google. |
 | `GET` | `/auth/google/callback` | No | Callback OAuth de Google. |
 | `GET` | `/auth/facebook/url` | No | Genera URL de login con Facebook. |
+| `POST` | `/auth/facebook` | No | Login con Facebook. |
 | `GET` | `/auth/facebook/callback` | No | Callback OAuth de Facebook. |
 
 ### Reportes
@@ -233,23 +246,84 @@ Si necesitas publicar el backend directamente bajo `/api`, define `API_PREFIX=/a
 | `GET` | `/reportes/stats/categoria` | No | Estadisticas por categoria. |
 | `GET` | `/reportes/stats/timeline` | No | Serie temporal de reportes. |
 | `GET` | `/reportes/stats/heatmap` | No | Puntos para heatmap. |
+| `GET` | `/reportes/stats/ia` | Si, admin o moderador | Estadisticas de analisis IA. |
+| `GET` | `/reportes/zonas-riesgo` | Si, admin o moderador | Zonas de riesgo predictivas. |
+| `GET` | `/reportes/alertas-predictivas` | Autenticacion opcional | Alertas predictivas con filtros. |
+| `GET` | `/reportes/trending` | Autenticacion opcional | Reportes destacados por actividad. |
 | `GET` | `/reportes/export` | Si, admin o moderador | Exporta reportes. |
 | `GET` | `/reportes/mis-reportes` | Si | Lista reportes del usuario autenticado. |
+| `POST` | `/reportes/analizar-imagen` | Si | Clasifica una imagen en campo `imagen`. |
+| `POST` | `/reportes/sugerir-contenido` | Si | Sugiere titulo y descripcion desde evidencias. |
 | `GET` | `/reportes` | No | Lista reportes con filtros. |
 | `GET` | `/reportes/:id` | No | Obtiene un reporte por ID. |
-| `POST` | `/reportes` | Si | Crea reporte, con archivo opcional en campo `file`. |
+| `POST` | `/reportes` | Si | Crea reporte con evidencias opcionales en `file` o `files`. |
+| `POST` | `/reportes/:id/like` | Si | Alterna like del usuario autenticado. |
+| `POST` | `/reportes/:id/asignaciones` | Si, admin o moderador | Asigna manualmente una entidad responsable. |
+| `GET` | `/reportes/:id/evidencias` | Si | Lista evidencias de un reporte. |
+| `POST` | `/reportes/:id/evidencias` | Si | Agrega una evidencia al reporte. |
+| `DELETE` | `/reportes/:id/evidencias/:evidenciaId` | Si | Elimina logicamente una evidencia. |
 | `PATCH` | `/reportes/:id` | Si | Actualiza reporte. |
 | `DELETE` | `/reportes/:id` | Si | Elimina reporte logicamente. |
 
+Estados validos de reporte:
+
+- Entrada API: `pendiente`, `en proceso`, `en_proceso`, `resuelto`, `rechazado`.
+- Persistencia interna: `pendiente`, `en_proceso`, `resuelto`, `rechazado`.
+- `en proceso` se normaliza a `en_proceso`.
+
+Valores validos para asignacion manual:
+
+- `tipo_asignacion`: `principal`, `apoyo`.
+- `prioridad`: `baja`, `media`, `alta`, `critica`.
+
 ### Categorias de riesgo
+
+| Metodo | Ruta | Protegida | Descripcion |
+| --- | --- | --- | --- |
+| `GET` | `/categorias/estadisticas/resumen` | No | Resumen por categorias. |
+| `GET` | `/categorias/estadisticas/por-severidad` | No | Estadisticas por severidad. |
+| `GET` | `/categorias` | No | Lista categorias activas. |
+| `POST` | `/categorias` | Si, admin | Crea categoria. |
+| `PATCH` | `/categorias/:codigo` | Si, admin | Actualiza categoria. |
+| `PATCH` | `/categorias/:codigo/estado` | Si, admin | Activa o desactiva categoria. |
+| `GET` | `/categorias/:codigo/reportes` | No | Reportes de una categoria. |
+| `GET` | `/categorias/:codigo` | No | Detalle de categoria. |
+
+### Entidades y alertas de entidad
+
+| Metodo | Ruta | Protegida | Descripcion |
+| --- | --- | --- | --- |
+| `GET` | `/entidades` | Si, admin/moderador/entidad | Lista entidades institucionales. |
+| `GET` | `/entidades/:id/reportes` | Si, admin/moderador/entidad | Lista reportes asignados a una entidad. |
+| `GET` | `/entidades/mis-reportes` | Si, entidad | Lista reportes de la entidad autenticada. |
+| `GET` | `/entidades/mis-reportes/:id` | Si, entidad | Detalle de reporte asignado propio. |
+| `PATCH` | `/entidades/mis-reportes/:id/atencion` | Si, entidad | Actualiza estado de atencion. |
+| `GET` | `/entidades/mis-alertas` | Si, entidad | Lista alertas propias. |
+| `GET` | `/entidades/mis-alertas/no-leidas` | Si, entidad | Lista alertas propias no leidas. |
+| `GET` | `/entidades/mis-alertas/no-leidas/count` | Si, entidad | Cuenta alertas propias no leidas. |
+| `PATCH` | `/entidades/mis-alertas/leer-todas` | Si, entidad | Marca todas las alertas propias como leidas. |
+| `PATCH` | `/entidades/mis-alertas/:id/leer` | Si, entidad | Marca una alerta propia como leida. |
+| `PATCH` | `/entidades/mis-alertas/:id` | Si, entidad | Alias para marcar una alerta propia como leida. |
+
+### Notificaciones
+
+Todas las rutas de notificaciones requieren JWT.
 
 | Metodo | Ruta | Descripcion |
 | --- | --- | --- |
-| `GET` | `/categorias/estadisticas/resumen` | Resumen por categorias. |
-| `GET` | `/categorias/estadisticas/por-severidad` | Estadisticas por severidad. |
-| `GET` | `/categorias` | Lista categorias activas. |
-| `GET` | `/categorias/:codigo/reportes` | Reportes de una categoria. |
-| `GET` | `/categorias/:codigo` | Detalle de categoria. |
+| `GET` | `/notificaciones/contador` | Cuenta notificaciones no leidas. |
+| `POST` | `/notificaciones/fcm-token` | Registra token FCM del dispositivo. |
+| `PATCH` | `/notificaciones/marcar-todas` | Marca todas las notificaciones como leidas. |
+| `GET` | `/notificaciones` | Lista notificaciones del usuario autenticado. |
+| `PATCH` | `/notificaciones/:uuid/leida` | Marca una notificacion como leida. |
+| `DELETE` | `/notificaciones/:uuid` | Elimina una notificacion. |
+
+### Chatbot
+
+| Metodo | Ruta | Protegida | Descripcion |
+| --- | --- | --- | --- |
+| `POST` | `/chatbot/mensaje` | Autenticacion opcional | Envia mensaje al chatbot. |
+| `GET` | `/chatbot/faqs` | No | Lista preguntas frecuentes. |
 
 ### Administracion
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,114 +1,87 @@
-# 📚 Documentación - Backend GreenAlert
+# Documentacion publica del backend
 
-Índice centralizado de documentación técnica del Backend.
+Indice de documentacion tecnica y publica del Backend de Green Alert.
 
----
+## Documentos principales
 
-## 📁 Estructura
+| Archivo | Proposito |
+| --- | --- |
+| [`../README.md`](../README.md) | Guia principal del backend, comandos, variables, seguridad y rutas reales. |
+| [`openapi.yaml`](openapi.yaml) | Especificacion OpenAPI inicial de los modulos principales. |
+| [`integracion-frontend-entidades.md`](integracion-frontend-entidades.md) | Contrato de entidades, reportes asignados, asignacion manual y alertas persistentes. |
+| [`PREDICCION_ZONAS_RIESGO.md`](PREDICCION_ZONAS_RIESGO.md) | Reglas de zonas de riesgo y alertas predictivas. |
+| [`regression-parity-208.md`](regression-parity-208.md) | Nota de paridad/regresion historica conservada para referencia. |
 
-```
-docs/
-├── tests/                       📍 DOCUMENTACIÓN ACTUAL
-│   ├── INDEX.md                 Índice global de tests
-│   ├── EMAIL_CONFIG.md          Tests de configuración (8 tests)
-│   ├── EMAIL_VERIFICATION.md    Verificación de email
-│   ├── EMAIL_WELCOME.md         Email de bienvenida
-│   ├── AUTH_REGISTER.md         Registro de usuarios
-│   ├── MANUAL_EMAIL_CONFIG.md   Pruebas manuales
-│   └── RESUMEN_FINAL.md         Estado actual
-│
-├── archived/                    📦 HISTÓRICO
-│   ├── README.md
-│   ├── CARPETA_TESTS.md
-│   ├── IMPLEMENTACION_CORREOS.md
-│   ├── IMPLEMENTACION_VERIFICACION_EMAIL.md
-│   └── TESTING_VERIFICACION_EMAIL.md
-│
-├── ENDPOINTS_PERFIL.md          Endpoints de perfil de usuario
-├── VERIFICACION_EMAIL.md        Verificación de email (original)
-├── TEST_VERIFICACION_EMAIL.md   Tests manuales (original)
-└── ENVIO_CORREOS.md             Envío de correos (original)
-```
+## OpenAPI
 
----
+La especificacion inicial cubre:
 
-## 🎯 Inicio Rápido
+- Autenticacion y OAuth.
+- Usuarios y perfil.
+- Reportes y evidencias.
+- Entidades responsables y alertas de entidad.
+- Notificaciones.
+- Categorias de riesgo.
+- Estadisticas, tendencias, zonas de riesgo y alertas predictivas.
+- Chatbot.
+- Administracion de usuarios.
 
-### Para Tests
-→ Ver: [tests/INDEX.md](tests/INDEX.md)
+No se monta Swagger UI desde el backend en esta etapa. El archivo queda listo para validacion externa o integracion futura.
 
-**Ejecutar tests:**
-```bash
-node tests/run-all.js config
-```
+## Contratos relevantes
 
-### Para Configuración de Email
-→ Ver: [tests/EMAIL_CONFIG.md](tests/EMAIL_CONFIG.md)
+### Estados de reporte
 
-### Para Endpoints API
-→ Ver: [ENDPOINTS_PERFIL.md](ENDPOINTS_PERFIL.md)
+Valores aceptados por la API:
 
-### Para Verificación de Email
-→ Ver: [tests/EMAIL_VERIFICATION.md](tests/EMAIL_VERIFICATION.md)
+- `pendiente`
+- `en proceso`
+- `en_proceso`
+- `resuelto`
+- `rechazado`
 
----
+El valor `en proceso` se normaliza internamente a `en_proceso`.
 
-## 📊 Contenido por Categoría
+### Asignacion de entidades responsables
 
-### Mejoras Backend
-- `DOCKER_SERVICIOS.md` - Dockerizacion individual de servicios backend sin Docker Compose.
+Valores validos de `tipo_asignacion`:
 
-### 🧪 Tests Automatizados
-- `tests/EMAIL_CONFIG.md` - 8 tests de configuración
-- `tests/EMAIL_VERIFICATION.md` - Tests de verificación
-- `tests/EMAIL_WELCOME.md` - Tests de bienvenida
-- `tests/AUTH_REGISTER.md` - Tests de registro
+- `principal`
+- `apoyo`
 
-### 📧 Sistema de Email
-- `tests/EMAIL_CONFIG.md` - Configuración centralizada
-- `tests/MANUAL_EMAIL_CONFIG.md` - Pruebas manuales paso a paso
-- `ENVIO_CORREOS.md` - Envío de correos
-- `VERIFICACION_EMAIL.md` - Verificación de email
+Valores validos de `prioridad`:
 
-### 👤 Usuarios y Autenticación
-- `ENDPOINTS_PERFIL.md` - Endpoints de perfil
-- `tests/AUTH_REGISTER.md` - Registro de usuarios
+- `baja`
+- `media`
+- `alta`
+- `critica`
 
-### 📦 Histórico
-- `archived/` - Documentación anterior (para referencia)
+### Evidencias
 
----
+El backend acepta evidencias en memoria con:
 
-## ✅ Estado Actual
+- Maximo 10 evidencias por reporte.
+- Maximo 1 video por reporte.
+- Limite de tamano configurable con `MAX_FILE_SIZE`.
+- Tipos MIME permitidos: `image/jpeg`, `image/jpg`, `image/png`, `image/webp`, `image/gif`, `video/mp4`, `video/quicktime`.
+- Validacion de firma real del archivo para evitar contenido falsificado.
+- Carga a Cloudinary, metadata, hash SHA-256 y soft delete.
 
-| Componente | Tests | Documentación | Status |
-|---|---|---|---|
-| Config Email | 8 ✅ | ✅ | ✅ |
-| Email Verification | 5 | ✅ | ✅ |
-| Email Welcome | 1 | ✅ | ✅ |
-| Auth Register | 3 | ✅ | ✅ |
-| **TOTAL** | **17** | **6 archivos** | ✅ |
+## Seguridad por rutas
 
----
+La documentacion publica debe conservar esta regla general:
 
-## 🚀 Próximos Pasos
+- Rutas publicas: salud, login/registro, estadisticas publicas, listado publico de reportes, categorias publicas y FAQs.
+- Rutas con autenticacion opcional: algunos listados de reportes, tendencias, alertas predictivas y chatbot.
+- Rutas privadas: perfil, creacion/edicion de reportes, evidencias, notificaciones.
+- Rutas restringidas por rol: administracion, estadisticas IA, zonas de riesgo, exportacion, asignacion manual y panel de entidad.
 
-1. **Tests adicionales:**
-   - Login tests
-   - Password reset tests
-   - Reportes tests
+## Mantenimiento
 
-2. **Documentación:**
-   - API OpenAPI/Swagger
-   - Database schema
-   - Architecture diagram
+Antes de cerrar cambios documentales:
 
-3. **CI/CD:**
-   - GitHub Actions workflow
-   - Automatic test execution
-
----
-
-**Última actualización:** Abril 17, 2026  
-**Responsable:** Equipo de Backend
-
+1. Revisar `routes/*.routes.js`.
+2. Confirmar middlewares de autenticacion y roles.
+3. Verificar que no se documenten rutas inexistentes.
+4. Ejecutar `npm test`.
+5. Ejecutar la validacion de sintaxis equivalente al workflow con `node --check`.

--- a/docs/integracion-frontend-entidades.md
+++ b/docs/integracion-frontend-entidades.md
@@ -196,7 +196,7 @@ Campos relevantes:
 | Campo | Requerido | Valores | Nota |
 | --- | --- | --- | --- |
 | `id_entidad` | Si | ID de entidad activa y permitida | La entidad debe existir, estar activa y pertenecer al alcance actual. |
-| `tipo_asignacion` | No | `principal`, `secundaria` | Si no se envia, el backend conserva su comportamiento actual. |
+| `tipo_asignacion` | No | `principal`, `apoyo` | Si no se envia, el backend usa `principal` por defecto. |
 | `prioridad` | No | `baja`, `media`, `alta`, `critica` | Si no se envia, el backend usa `media` por defecto para mantener compatibilidad. |
 
 Comportamiento por prioridad:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,1560 @@
+openapi: 3.0.3
+info:
+  title: Green Alert Backend API
+  version: 0.1.0
+  description: |
+    Especificacion OpenAPI inicial del backend de Green Alert.
+
+    Las rutas se montan con `API_PREFIX`. Por defecto `API_PREFIX` esta vacio,
+    por lo que las rutas reales son `/auth`, `/reportes`, `/categorias`, etc.
+    En desarrollo el frontend puede usar `/api` si Vite reescribe ese prefijo.
+servers:
+  - url: http://localhost:3000
+    description: Backend local sin API_PREFIX
+  - url: http://localhost:3000/api
+    description: Backend local cuando API_PREFIX=/api
+tags:
+  - name: Salud
+  - name: Autenticacion
+  - name: Usuarios
+  - name: Reportes
+  - name: Evidencias
+  - name: Entidades
+  - name: Alertas
+  - name: Notificaciones
+  - name: Categorias
+  - name: Analitica
+  - name: Chatbot
+  - name: Administracion
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  parameters:
+    IdParam:
+      in: path
+      name: id
+      required: true
+      schema:
+        type: integer
+        minimum: 1
+  schemas:
+    ApiSuccess:
+      type: object
+      properties:
+        status:
+          type: string
+          example: success
+        message:
+          type: string
+          example: Operacion realizada correctamente.
+        data:
+          nullable: true
+    ApiError:
+      type: object
+      properties:
+        status:
+          type: string
+          example: error
+        message:
+          type: string
+          example: Recurso no encontrado.
+    AuthTokens:
+      type: object
+      properties:
+        accessToken:
+          type: string
+          example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+        refreshToken:
+          type: string
+          example: 5ab9f4b2f8c64a0f...
+    Usuario:
+      type: object
+      properties:
+        id_usuario:
+          type: integer
+          example: 7
+        uuid:
+          type: string
+          example: 6ab3a0a3-7a5d-4d3b-a6e3-4f6b5c86aa20
+        nombre:
+          type: string
+          example: Juan
+        apellido:
+          type: string
+          example: Perez
+        email:
+          type: string
+          format: email
+          example: juan@example.com
+        rol:
+          type: string
+          enum: [ciudadano, moderador, admin, entidad]
+          example: ciudadano
+        telefono:
+          type: string
+          nullable: true
+          example: "+573001112233"
+        activo:
+          type: boolean
+          example: true
+    ReporteEstado:
+      type: string
+      description: |
+        La API acepta `en proceso` y lo normaliza internamente a `en_proceso`.
+        Los valores persistidos usan guion bajo.
+      enum: [pendiente, en_proceso, resuelto, rechazado]
+      example: pendiente
+    ReporteEstadoEntrada:
+      type: string
+      enum: [pendiente, "en proceso", en_proceso, resuelto, rechazado]
+      example: en proceso
+    NivelSeveridad:
+      type: string
+      enum: [bajo, medio, alto, critico]
+      example: alto
+    Reporte:
+      type: object
+      properties:
+        id_reporte:
+          type: integer
+          example: 15
+        uuid:
+          type: string
+          example: 2fbd8c03-d7c7-45c2-8a5d-f80e7e15ff0a
+        id_usuario:
+          type: integer
+          example: 7
+        tipo_contaminacion:
+          type: string
+          example: agua
+        subcategoria:
+          type: string
+          nullable: true
+          example: rio_contaminado
+        nivel_severidad:
+          $ref: "#/components/schemas/NivelSeveridad"
+        titulo:
+          type: string
+          example: Contaminacion en quebrada
+        descripcion:
+          type: string
+          nullable: true
+          example: Se observa agua oscura y mal olor.
+        direccion:
+          type: string
+          example: Calle 10
+        municipio:
+          type: string
+          nullable: true
+          example: Valledupar
+        departamento:
+          type: string
+          nullable: true
+          example: Cesar
+        latitud:
+          type: number
+          nullable: true
+          example: 10.45
+        longitud:
+          type: number
+          nullable: true
+          example: -73.25
+        estado:
+          $ref: "#/components/schemas/ReporteEstado"
+        confianza_evidencia:
+          type: number
+          nullable: true
+          example: 86
+        created_at:
+          type: string
+          format: date-time
+    Evidencia:
+      type: object
+      properties:
+        id_evidencia:
+          type: integer
+          example: 22
+        id_reporte:
+          type: integer
+          example: 15
+        tipo_archivo:
+          type: string
+          enum: [imagen, video]
+          example: imagen
+        url_archivo:
+          type: string
+          format: uri
+          example: https://res.cloudinary.com/demo/image/upload/green-alert/reportes/foto.png
+        nombre_original:
+          type: string
+          example: foto.png
+        mime_type:
+          type: string
+          enum: [image/jpeg, image/jpg, image/png, image/webp, image/gif, video/mp4, video/quicktime]
+          example: image/png
+        tamano_bytes:
+          type: integer
+          example: 102400
+        hash_sha256:
+          type: string
+          nullable: true
+    Categoria:
+      type: object
+      properties:
+        codigo:
+          type: string
+          example: agua
+        nombre:
+          type: string
+          example: Contaminacion del agua
+        descripcion:
+          type: string
+          example: Reportes relacionados con fuentes hidricas.
+        activo:
+          type: boolean
+          example: true
+    TipoAsignacion:
+      type: string
+      enum: [principal, apoyo]
+      example: principal
+    PrioridadAsignacion:
+      type: string
+      enum: [baja, media, alta, critica]
+      example: critica
+    EstadoAtencion:
+      type: string
+      enum: [pendiente, en_atencion, atendido, cerrado]
+      example: en_atencion
+    AsignacionEntidad:
+      type: object
+      properties:
+        id_reporte_entidad:
+          type: integer
+          example: 70
+        id_reporte:
+          type: integer
+          example: 15
+        id_entidad:
+          type: integer
+          example: 1
+        tipo_asignacion:
+          $ref: "#/components/schemas/TipoAsignacion"
+        prioridad:
+          $ref: "#/components/schemas/PrioridadAsignacion"
+        estado_atencion:
+          $ref: "#/components/schemas/EstadoAtencion"
+        comentario:
+          type: string
+          nullable: true
+          example: Equipo en desplazamiento.
+    Entidad:
+      type: object
+      properties:
+        id_entidad:
+          type: integer
+          example: 1
+        codigo:
+          type: string
+          example: bomberos
+        nombre:
+          type: string
+          example: Bomberos
+        activa:
+          type: boolean
+          example: true
+    AlertaEntidad:
+      type: object
+      properties:
+        id_alerta_entidad:
+          type: integer
+          example: 12
+        tipo_alerta:
+          type: string
+          example: reporte_critico_asignado
+        prioridad:
+          $ref: "#/components/schemas/PrioridadAsignacion"
+        titulo:
+          type: string
+          example: Reporte critico asignado
+        mensaje:
+          type: string
+          example: Se asigno un reporte critico a tu entidad.
+        leida:
+          type: boolean
+          example: false
+    Notificacion:
+      type: object
+      properties:
+        uuid:
+          type: string
+          example: b4fd9f48-6a61-48d0-bd56-68f8f15460fa
+        tipo:
+          type: string
+          example: reporte_asignado_entidad
+        titulo:
+          type: string
+          example: Reporte actualizado
+        mensaje:
+          type: string
+          example: Tu reporte cambio de estado.
+        leida:
+          type: boolean
+          example: false
+  responses:
+    BadRequest:
+      description: Solicitud invalida.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiError"
+          example:
+            status: error
+            message: El nivel de severidad debe ser uno de: bajo, medio, alto, critico.
+    Unauthorized:
+      description: Token ausente, invalido o credenciales incorrectas.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiError"
+          example:
+            status: error
+            message: Acceso denegado. Token no proporcionado.
+    Forbidden:
+      description: Usuario autenticado sin permisos suficientes.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiError"
+          example:
+            status: error
+            message: Acceso denegado. Rol no autorizado.
+    NotFound:
+      description: Recurso no encontrado.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiError"
+          example:
+            status: error
+            message: Reporte no encontrado.
+    Conflict:
+      description: Conflicto con datos existentes.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiError"
+          example:
+            status: error
+            message: Ya existe una cuenta registrada con ese correo.
+    ServerError:
+      description: Error interno del servidor.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiError"
+          example:
+            status: error
+            message: Error interno del servidor.
+paths:
+  /health:
+    get:
+      tags: [Salud]
+      summary: Verifica estado del servidor y base de datos.
+      responses:
+        "200":
+          description: Servicio disponible.
+        "500":
+          $ref: "#/components/responses/ServerError"
+  /auth/register:
+    post:
+      tags: [Autenticacion]
+      summary: Registra un usuario ciudadano.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [nombre, apellido, email, password]
+              properties:
+                nombre:
+                  type: string
+                  example: Juan
+                apellido:
+                  type: string
+                  example: Perez
+                email:
+                  type: string
+                  format: email
+                  example: juan@example.com
+                password:
+                  type: string
+                  format: password
+                  example: Password123
+                telefono:
+                  type: string
+                  example: "+573001112233"
+      responses:
+        "201":
+          description: Usuario creado y tokens emitidos.
+          content:
+            application/json:
+              example:
+                status: success
+                message: Cuenta creada correctamente. Verifica tu email con el codigo enviado.
+                data:
+                  user:
+                    id_usuario: 7
+                    email: juan@example.com
+                    rol: ciudadano
+                  accessToken: eyJ...
+                  refreshToken: 90f...
+                  pendingEmailVerification: true
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/ServerError"
+  /auth/login:
+    post:
+      tags: [Autenticacion]
+      summary: Inicia sesion con email y contrasena.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [email, password]
+              properties:
+                email:
+                  type: string
+                  format: email
+                  example: juan@example.com
+                password:
+                  type: string
+                  format: password
+                  example: Password123
+      responses:
+        "200":
+          description: Sesion iniciada.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/ServerError"
+  /auth/refresh:
+    post:
+      tags: [Autenticacion]
+      summary: Rota refresh token y emite nuevo access token.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [refreshToken]
+              properties:
+                refreshToken:
+                  type: string
+      responses:
+        "200":
+          description: Tokens renovados.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+  /auth/oauth/exchange:
+    post:
+      tags: [Autenticacion]
+      summary: Canjea codigo temporal OAuth por tokens del backend.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [code]
+              properties:
+                code:
+                  type: string
+      responses:
+        "200":
+          description: Tokens emitidos.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+  /auth/logout:
+    post:
+      tags: [Autenticacion]
+      summary: Cierra sesion individual o global.
+      description: Logout global requiere JWT cuando `allDevices` es true.
+      security:
+        - bearerAuth: []
+        - {}
+      responses:
+        "200":
+          description: Sesion cerrada.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+  /auth/perfil:
+    get:
+      tags: [Usuarios]
+      summary: Obtiene perfil del usuario autenticado.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Perfil obtenido.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+    patch:
+      tags: [Usuarios]
+      summary: Actualiza perfil del usuario autenticado.
+      security:
+        - bearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                nombre:
+                  type: string
+                apellido:
+                  type: string
+                telefono:
+                  type: string
+      responses:
+        "200":
+          description: Perfil actualizado.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+  /auth/avatar:
+    patch:
+      tags: [Usuarios]
+      summary: Actualiza avatar con archivo de imagen.
+      security:
+        - bearerAuth: []
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                avatar:
+                  type: string
+                  format: binary
+      responses:
+        "200":
+          description: Avatar actualizado.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+  /auth/cambiar-contrasena:
+    patch:
+      tags: [Usuarios]
+      summary: Cambia contrasena del usuario autenticado.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Contrasena actualizada.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+  /auth/notificaciones:
+    patch:
+      tags: [Usuarios]
+      summary: Actualiza preferencias de notificacion.
+      security:
+        - bearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            example:
+              email_alerts: true
+              push_notifications: false
+              report_updates: true
+              weekly_summary: false
+      responses:
+        "200":
+          description: Preferencias actualizadas.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+  /auth/verify-email:
+    get:
+      tags: [Autenticacion]
+      summary: Verifica email usando token de enlace.
+      parameters:
+        - in: query
+          name: token
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Email verificado.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+  /auth/enviar-verificacion:
+    post:
+      tags: [Autenticacion]
+      summary: Envia OTP de verificacion de email.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: OTP enviado.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+  /auth/verificar-email:
+    post:
+      tags: [Autenticacion]
+      summary: Verifica email usando OTP.
+      security:
+        - bearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            example:
+              otp: "123456"
+      responses:
+        "200":
+          description: Email verificado.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+  /auth/forgot-password:
+    post:
+      tags: [Autenticacion]
+      summary: Solicita recuperacion de contrasena.
+      responses:
+        "200":
+          description: Solicitud procesada.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+  /auth/reset-password:
+    post:
+      tags: [Autenticacion]
+      summary: Restablece contrasena con token.
+      responses:
+        "200":
+          description: Contrasena restablecida.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+  /auth/google/url:
+    get:
+      tags: [Autenticacion]
+      summary: Genera URL de autorizacion de Google.
+      responses:
+        "200":
+          description: URL generada.
+  /auth/google:
+    post:
+      tags: [Autenticacion]
+      summary: Login con access token de Google.
+      responses:
+        "200":
+          description: Login completado.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+  /auth/google/login:
+    post:
+      tags: [Autenticacion]
+      summary: Login con id_token de Google.
+      responses:
+        "200":
+          description: Login completado.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+  /auth/google/callback:
+    get:
+      tags: [Autenticacion]
+      summary: Callback OAuth de Google.
+      responses:
+        "302":
+          description: Redireccion al frontend con codigo temporal.
+  /auth/facebook/url:
+    get:
+      tags: [Autenticacion]
+      summary: Genera URL de autorizacion de Facebook.
+      responses:
+        "200":
+          description: URL generada.
+  /auth/facebook:
+    post:
+      tags: [Autenticacion]
+      summary: Login con Facebook.
+      responses:
+        "200":
+          description: Login completado.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+  /auth/facebook/callback:
+    get:
+      tags: [Autenticacion]
+      summary: Callback OAuth de Facebook.
+      responses:
+        "302":
+          description: Redireccion al frontend con codigo temporal.
+  /reportes:
+    get:
+      tags: [Reportes]
+      summary: Lista reportes con filtros.
+      security:
+        - bearerAuth: []
+        - {}
+      parameters:
+        - in: query
+          name: estado
+          schema:
+            $ref: "#/components/schemas/ReporteEstadoEntrada"
+        - in: query
+          name: tipo_contaminacion
+          schema:
+            type: string
+        - in: query
+          name: nivel_severidad
+          schema:
+            $ref: "#/components/schemas/NivelSeveridad"
+        - in: query
+          name: municipio
+          schema:
+            type: string
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            default: 20
+        - in: query
+          name: offset
+          schema:
+            type: integer
+            default: 0
+      responses:
+        "200":
+          description: Reportes obtenidos.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+    post:
+      tags: [Reportes]
+      summary: Crea un reporte ambiental con evidencias opcionales.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [tipo_contaminacion, nivel_severidad, titulo, direccion]
+              properties:
+                tipo_contaminacion:
+                  type: string
+                  example: agua
+                subcategoria:
+                  type: string
+                  example: rio_contaminado
+                nivel_severidad:
+                  $ref: "#/components/schemas/NivelSeveridad"
+                titulo:
+                  type: string
+                  example: Contaminacion en quebrada
+                descripcion:
+                  type: string
+                direccion:
+                  type: string
+                  example: Calle 10
+                municipio:
+                  type: string
+                departamento:
+                  type: string
+                latitud:
+                  type: number
+                longitud:
+                  type: number
+                file:
+                  type: string
+                  format: binary
+                files:
+                  type: array
+                  maxItems: 10
+                  items:
+                    type: string
+                    format: binary
+      responses:
+        "201":
+          description: Reporte creado.
+        "400":
+          description: Datos invalidos, tipo de archivo no permitido, mas de 10 evidencias o mas de un video.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              examples:
+                evidenciaFalsa:
+                  value:
+                    status: error
+                    message: El contenido del archivo "falso.png" no coincide con el tipo declarado o esta corrupto.
+                exceso:
+                  value:
+                    status: error
+                    message: Solo puedes adjuntar hasta 10 evidencias por reporte.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/ServerError"
+  /reportes/{id}:
+    get:
+      tags: [Reportes]
+      summary: Obtiene un reporte por ID.
+      security:
+        - bearerAuth: []
+        - {}
+      parameters:
+        - $ref: "#/components/parameters/IdParam"
+      responses:
+        "200":
+          description: Reporte obtenido.
+        "404":
+          $ref: "#/components/responses/NotFound"
+    patch:
+      tags: [Reportes]
+      summary: Actualiza un reporte.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/IdParam"
+      requestBody:
+        content:
+          application/json:
+            example:
+              estado: en proceso
+              comentario_moderacion: Validado por moderador.
+      responses:
+        "200":
+          description: Reporte actualizado.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    delete:
+      tags: [Reportes]
+      summary: Elimina logicamente un reporte.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/IdParam"
+      responses:
+        "200":
+          description: Reporte eliminado.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /reportes/mis-reportes:
+    get:
+      tags: [Reportes]
+      summary: Lista reportes del usuario autenticado.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Reportes propios obtenidos.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+  /reportes/{id}/like:
+    post:
+      tags: [Reportes]
+      summary: Alterna like del usuario autenticado sobre un reporte.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/IdParam"
+      responses:
+        "200":
+          description: Like registrado o retirado.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /reportes/{id}/asignaciones:
+    post:
+      tags: [Entidades]
+      summary: Asigna manualmente un reporte a una entidad responsable.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/IdParam"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id_entidad:
+                  type: integer
+                  example: 1
+                codigo_entidad:
+                  type: string
+                  example: bomberos
+                tipo_asignacion:
+                  $ref: "#/components/schemas/TipoAsignacion"
+                prioridad:
+                  $ref: "#/components/schemas/PrioridadAsignacion"
+                comentario:
+                  type: string
+                  example: Atender de forma prioritaria.
+            example:
+              id_entidad: 1
+              tipo_asignacion: apoyo
+              prioridad: critica
+      responses:
+        "201":
+          description: Reporte asignado a entidad.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /reportes/{id}/evidencias:
+    get:
+      tags: [Evidencias]
+      summary: Lista evidencias de un reporte.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/IdParam"
+      responses:
+        "200":
+          description: Evidencias obtenidas.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    post:
+      tags: [Evidencias]
+      summary: Agrega una evidencia a un reporte existente.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/IdParam"
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        "201":
+          description: Evidencia agregada.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /reportes/{id}/evidencias/{evidenciaId}:
+    delete:
+      tags: [Evidencias]
+      summary: Elimina logicamente una evidencia y su asset remoto.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/IdParam"
+        - in: path
+          name: evidenciaId
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Evidencia eliminada.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
+  /reportes/analizar-imagen:
+    post:
+      tags: [Reportes]
+      summary: Analiza una imagen para clasificacion asistida.
+      security:
+        - bearerAuth: []
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                imagen:
+                  type: string
+                  format: binary
+      responses:
+        "200":
+          description: Imagen analizada.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+  /reportes/sugerir-contenido:
+    post:
+      tags: [Reportes]
+      summary: Sugiere titulo y descripcion desde evidencias.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Contenido sugerido.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+  /reportes/stats:
+    get:
+      tags: [Analitica]
+      summary: Estadisticas generales de reportes.
+      responses:
+        "200":
+          description: Estadisticas obtenidas.
+  /reportes/stats/categoria:
+    get:
+      tags: [Analitica]
+      summary: Estadisticas de reportes por categoria.
+      responses:
+        "200":
+          description: Estadisticas obtenidas.
+  /reportes/stats/timeline:
+    get:
+      tags: [Analitica]
+      summary: Serie temporal de reportes.
+      responses:
+        "200":
+          description: Estadisticas obtenidas.
+  /reportes/stats/heatmap:
+    get:
+      tags: [Analitica]
+      summary: Puntos para mapa de calor.
+      responses:
+        "200":
+          description: Puntos obtenidos.
+  /reportes/stats/ia:
+    get:
+      tags: [Analitica]
+      summary: Estadisticas de analisis IA.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Estadisticas obtenidas.
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /reportes/trending:
+    get:
+      tags: [Analitica]
+      summary: Lista reportes destacados por actividad.
+      security:
+        - bearerAuth: []
+        - {}
+      responses:
+        "200":
+          description: Reportes obtenidos.
+  /reportes/export:
+    get:
+      tags: [Analitica]
+      summary: Exporta reportes para administracion.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Export generado.
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /reportes/zonas-riesgo:
+    get:
+      tags: [Analitica]
+      summary: Calcula zonas de riesgo.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: dias
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 365
+        - in: query
+          name: tipo
+          schema:
+            type: string
+        - in: query
+          name: min_score
+          schema:
+            type: number
+            minimum: 0
+            maximum: 100
+      responses:
+        "200":
+          description: Zonas obtenidas.
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /reportes/alertas-predictivas:
+    get:
+      tags: [Analitica]
+      summary: Lista alertas predictivas.
+      security:
+        - bearerAuth: []
+        - {}
+      parameters:
+        - in: query
+          name: nivel_min
+          schema:
+            type: string
+            enum: [bajo, medio, alto, critico]
+        - in: query
+          name: limite
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Alertas obtenidas.
+  /categorias:
+    get:
+      tags: [Categorias]
+      summary: Lista categorias activas.
+      responses:
+        "200":
+          description: Categorias obtenidas.
+    post:
+      tags: [Categorias]
+      summary: Crea una categoria de riesgo.
+      security:
+        - bearerAuth: []
+      responses:
+        "201":
+          description: Categoria creada.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          $ref: "#/components/responses/Conflict"
+  /categorias/{codigo}:
+    get:
+      tags: [Categorias]
+      summary: Obtiene detalle de una categoria.
+      parameters:
+        - in: path
+          name: codigo
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Categoria obtenida.
+        "404":
+          $ref: "#/components/responses/NotFound"
+    patch:
+      tags: [Categorias]
+      summary: Actualiza una categoria.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: codigo
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Categoria actualizada.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /categorias/{codigo}/estado:
+    patch:
+      tags: [Categorias]
+      summary: Activa o desactiva una categoria.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Estado actualizado.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /categorias/{codigo}/reportes:
+    get:
+      tags: [Categorias]
+      summary: Lista reportes de una categoria.
+      responses:
+        "200":
+          description: Reportes obtenidos.
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /categorias/estadisticas/resumen:
+    get:
+      tags: [Analitica]
+      summary: Resumen estadistico de categorias.
+      responses:
+        "200":
+          description: Resumen obtenido.
+  /categorias/estadisticas/por-severidad:
+    get:
+      tags: [Analitica]
+      summary: Estadisticas por severidad.
+      responses:
+        "200":
+          description: Estadisticas obtenidas.
+  /entidades:
+    get:
+      tags: [Entidades]
+      summary: Lista entidades institucionales.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Entidades obtenidas.
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /entidades/{id}/reportes:
+    get:
+      tags: [Entidades]
+      summary: Lista reportes asignados a una entidad.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/IdParam"
+      responses:
+        "200":
+          description: Reportes obtenidos.
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /entidades/mis-reportes:
+    get:
+      tags: [Entidades]
+      summary: Lista reportes de la entidad autenticada.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Reportes asignados obtenidos.
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /entidades/mis-reportes/{id}:
+    get:
+      tags: [Entidades]
+      summary: Obtiene un reporte asignado a la entidad autenticada.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/IdParam"
+      responses:
+        "200":
+          description: Reporte obtenido.
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /entidades/mis-reportes/{id}/atencion:
+    patch:
+      tags: [Entidades]
+      summary: Actualiza estado de atencion de la entidad autenticada.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/IdParam"
+      requestBody:
+        content:
+          application/json:
+            example:
+              estado_atencion: en_atencion
+              comentario: Equipo en desplazamiento.
+      responses:
+        "200":
+          description: Atencion actualizada.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /entidades/mis-alertas:
+    get:
+      tags: [Alertas]
+      summary: Lista alertas de la entidad autenticada.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Alertas obtenidas.
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /entidades/mis-alertas/no-leidas:
+    get:
+      tags: [Alertas]
+      summary: Lista alertas no leidas de la entidad autenticada.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Alertas no leidas obtenidas.
+  /entidades/mis-alertas/no-leidas/count:
+    get:
+      tags: [Alertas]
+      summary: Cuenta alertas no leidas de la entidad autenticada.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Contador obtenido.
+  /entidades/mis-alertas/leer-todas:
+    patch:
+      tags: [Alertas]
+      summary: Marca todas las alertas propias como leidas.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Alertas actualizadas.
+  /entidades/mis-alertas/{id}/leer:
+    patch:
+      tags: [Alertas]
+      summary: Marca una alerta propia como leida.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/IdParam"
+      responses:
+        "200":
+          description: Alerta marcada.
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /entidades/mis-alertas/{id}:
+    patch:
+      tags: [Alertas]
+      summary: Alias para marcar una alerta propia como leida.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/IdParam"
+      responses:
+        "200":
+          description: Alerta marcada.
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /notificaciones:
+    get:
+      tags: [Notificaciones]
+      summary: Lista notificaciones del usuario autenticado.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Notificaciones obtenidas.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+  /notificaciones/contador:
+    get:
+      tags: [Notificaciones]
+      summary: Cuenta notificaciones no leidas.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Contador obtenido.
+  /notificaciones/fcm-token:
+    post:
+      tags: [Notificaciones]
+      summary: Registra token FCM del dispositivo.
+      security:
+        - bearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            example:
+              token: fcm-device-token
+      responses:
+        "200":
+          description: Token registrado.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+  /notificaciones/marcar-todas:
+    patch:
+      tags: [Notificaciones]
+      summary: Marca todas las notificaciones como leidas.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Notificaciones actualizadas.
+  /notificaciones/{uuid}/leida:
+    patch:
+      tags: [Notificaciones]
+      summary: Marca una notificacion como leida.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: uuid
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Notificacion marcada.
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /notificaciones/{uuid}:
+    delete:
+      tags: [Notificaciones]
+      summary: Elimina una notificacion.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: uuid
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Notificacion eliminada.
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /admin/usuarios/stats:
+    get:
+      tags: [Administracion]
+      summary: Estadisticas administrativas de usuarios.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Estadisticas obtenidas.
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /admin/usuarios:
+    get:
+      tags: [Administracion]
+      summary: Lista usuarios para administracion.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Usuarios obtenidos.
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /admin/usuarios/{id}:
+    get:
+      tags: [Administracion]
+      summary: Obtiene usuario por ID.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/IdParam"
+      responses:
+        "200":
+          description: Usuario obtenido.
+        "404":
+          $ref: "#/components/responses/NotFound"
+    delete:
+      tags: [Administracion]
+      summary: Elimina logicamente un usuario.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/IdParam"
+      responses:
+        "200":
+          description: Usuario eliminado.
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /admin/usuarios/{id}/rol:
+    patch:
+      tags: [Administracion]
+      summary: Cambia rol de usuario.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/IdParam"
+      responses:
+        "200":
+          description: Rol actualizado.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+  /admin/usuarios/{id}/estado:
+    patch:
+      tags: [Administracion]
+      summary: Activa o desactiva usuario.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/IdParam"
+      responses:
+        "200":
+          description: Estado actualizado.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+  /chatbot/mensaje:
+    post:
+      tags: [Chatbot]
+      summary: Envia un mensaje al chatbot.
+      security:
+        - bearerAuth: []
+        - {}
+      requestBody:
+        content:
+          application/json:
+            example:
+              message: Como reporto contaminacion?
+              sessionId: web-123
+      responses:
+        "200":
+          description: Respuesta generada.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+  /chatbot/faqs:
+    get:
+      tags: [Chatbot]
+      summary: Lista preguntas frecuentes del chatbot.
+      responses:
+        "200":
+          description: FAQs obtenidas.

--- a/middlewares/upload.middleware.js
+++ b/middlewares/upload.middleware.js
@@ -10,14 +10,85 @@ const ALLOWED_MIME = [
   'video/mp4', 'video/quicktime',
 ];
 
+const MP4_COMPATIBLE_BRANDS = new Set([
+  'avc1', 'dash', 'iso2', 'iso5', 'iso6', 'isom', 'm4v ', 'mp41', 'mp42', 'msnv',
+]);
+
+const hasPrefix = (buffer, bytes) => (
+  Buffer.isBuffer(buffer) &&
+  buffer.length >= bytes.length &&
+  bytes.every((byte, index) => buffer[index] === byte)
+);
+
+const hasAsciiAt = (buffer, offset, value) => (
+  Buffer.isBuffer(buffer) &&
+  buffer.length >= offset + value.length &&
+  buffer.subarray(offset, offset + value.length).toString('ascii').toLowerCase() === value.toLowerCase()
+);
+
+const getIsoBaseMediaBrands = (buffer) => {
+  if (!Buffer.isBuffer(buffer) || buffer.length < 12 || !hasAsciiAt(buffer, 4, 'ftyp')) {
+    return [];
+  }
+
+  const boxSize = buffer.readUInt32BE(0);
+  if (boxSize < 12 || boxSize > buffer.length) {
+    return [];
+  }
+
+  const brands = [buffer.subarray(8, 12).toString('ascii').toLowerCase()];
+  for (let offset = 16; offset + 4 <= boxSize; offset += 4) {
+    brands.push(buffer.subarray(offset, offset + 4).toString('ascii').toLowerCase());
+  }
+
+  return brands;
+};
+
+const isJpeg = (buffer) => hasPrefix(buffer, [0xff, 0xd8, 0xff]);
+const isPng = (buffer) => hasPrefix(buffer, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const isWebp = (buffer) => hasAsciiAt(buffer, 0, 'RIFF') && hasAsciiAt(buffer, 8, 'WEBP');
+const isGif = (buffer) => hasAsciiAt(buffer, 0, 'GIF87a') || hasAsciiAt(buffer, 0, 'GIF89a');
+const isMp4 = (buffer) => getIsoBaseMediaBrands(buffer).some((brand) => MP4_COMPATIBLE_BRANDS.has(brand));
+const isQuicktime = (buffer) => getIsoBaseMediaBrands(buffer).includes('qt  ');
+
+const SIGNATURE_VALIDATORS = {
+  'image/jpeg': isJpeg,
+  'image/jpg': isJpeg,
+  'image/png': isPng,
+  'image/webp': isWebp,
+  'image/gif': isGif,
+  'video/mp4': isMp4,
+  'video/quicktime': isQuicktime,
+};
+
+const buildUploadError = (message) => {
+  const error = new Error(message);
+  error.statusCode = 400;
+  return error;
+};
+
+export const validateUploadedFilesContent = (files = []) => {
+  for (const file of files.filter(Boolean)) {
+    const validator = SIGNATURE_VALIDATORS[file.mimetype];
+    if (!validator) {
+      return 'Tipo de archivo no permitido. Solo imagenes y videos.';
+    }
+
+    if (!validator(file.buffer)) {
+      const filename = file.originalname || file.filename || 'archivo';
+      return `El contenido del archivo "${filename}" no coincide con el tipo declarado o esta corrupto.`;
+    }
+  }
+
+  return null;
+};
+
 export const fileFilter = (_req, file, cb) => {
   if (ALLOWED_MIME.includes(file.mimetype)) {
     return cb(null, true);
   }
 
-  const error = new Error('Tipo de archivo no permitido. Solo imagenes y videos.');
-  error.statusCode = 400;
-  return cb(error);
+  return cb(buildUploadError('Tipo de archivo no permitido. Solo imagenes y videos.'));
 };
 
 const baseUpload = multer({
@@ -49,6 +120,13 @@ const decorateUploadedFiles = (req) => {
   }
 };
 
+const getRequestUploadedFiles = (req) => ([
+  ...(req.file ? [req.file] : []),
+  ...(Array.isArray(req.files) ? req.files : []),
+  ...(Array.isArray(req.files?.file) ? req.files.file : []),
+  ...(Array.isArray(req.files?.files) ? req.files.files : []),
+]);
+
 const wrapUploadMiddleware = (middleware) => (req, res, next) => {
   middleware(req, res, (error) => {
     if (error) {
@@ -56,6 +134,11 @@ const wrapUploadMiddleware = (middleware) => (req, res, next) => {
     }
 
     decorateUploadedFiles(req);
+    const contentError = validateUploadedFilesContent(getRequestUploadedFiles(req));
+    if (contentError) {
+      return next(buildUploadError(contentError));
+    }
+
     return next();
   });
 };

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -22,6 +22,7 @@ import {
   consumeOAuthCallbackCode,
   createOAuthCallbackCode,
 } from '../services/oauth-callback-code.service.js';
+import { consumeOAuthState } from '../services/oauth-state.service.js';
 import { getApiPrefix } from '../config/api-prefix.config.js';
 import { getCloudinaryConfig } from '../config/cloudinary.config.js';
 import { deleteFileByPublicId, uploadFileBuffer } from '../services/cloudinary.service.js';
@@ -214,6 +215,31 @@ const errorResponseWithDevelopmentDetails = (
     message,
     details,
   });
+};
+
+const getOAuthStateErrorMessage = (reason) => {
+  if (reason === 'missing') {
+    return 'State OAuth requerido.';
+  }
+
+  if (reason === 'expired') {
+    return 'State OAuth expirado.';
+  }
+
+  return 'State OAuth invalido.';
+};
+
+export const validateOAuthCallbackState = (state, provider) => {
+  const validation = consumeOAuthState(state, provider);
+
+  if (validation.valid) {
+    return { valid: true };
+  }
+
+  return {
+    valid: false,
+    message: getOAuthStateErrorMessage(validation.reason),
+  };
 };
 
 const verifyPassword = (password, storedHash) => {
@@ -1242,7 +1268,12 @@ export const googleAccessTokenLogin = async (req, res, next) => {
 
 export const googleCallback = async (req, res, next) => {
   try {
-    const { code } = req.query ?? {};
+    const { code, state } = req.query ?? {};
+
+    const stateValidation = validateOAuthCallbackState(state, 'google');
+    if (!stateValidation.valid) {
+      return errorResponse(res, stateValidation.message, 400);
+    }
 
     if (!code || typeof code !== 'string') {
       return errorResponse(res, 'Código de autorización de Google requerido.', 400);
@@ -1463,7 +1494,12 @@ export const facebookLogin = async (req, res, next) => {
 
 export const facebookCallback = async (req, res, next) => {
   try {
-    const { code } = req.query ?? {};
+    const { code, state } = req.query ?? {};
+
+    const stateValidation = validateOAuthCallbackState(state, 'facebook');
+    if (!stateValidation.valid) {
+      return errorResponse(res, stateValidation.message, 400);
+    }
 
     if (!code || typeof code !== 'string') {
       return errorResponse(res, 'Codigo de autorizacion de Facebook requerido.', 400);

--- a/src/controllers/reporte.controller.js
+++ b/src/controllers/reporte.controller.js
@@ -23,6 +23,7 @@ import { crearAlertaDesdeAsignacionReporte } from '../services/alerta-entidad.se
 import { notificarReporteCriticoAsignado } from '../config/socket.js';
 import { errorResponse, successResponse } from '../utils/response.js';
 import { crearNotificacion } from './notificacion.controller.js';
+import { validateUploadedFilesContent } from '../../middlewares/upload.middleware.js';
 
 const ANONYMOUS_VIEW_THROTTLE_MS = 5 * 60 * 1000;
 const anonymousViewThrottle = new Map();
@@ -147,7 +148,7 @@ const validateReporteEvidenceFiles = (files) => {
     return 'Solo puedes adjuntar un video por reporte.';
   }
 
-  return null;
+  return validateUploadedFilesContent(files);
 };
 
 export const sugerirContenidoReporte = async (req, res, next) => {
@@ -238,6 +239,19 @@ const cleanupCloudinaryUploads = async (uploads) => {
         resourceType: upload.resource_type || 'image',
       }))
   );
+};
+
+const rollbackCreatedReporte = async (idReporte, cloudinaryUploads = []) => {
+  const results = await Promise.allSettled([
+    cleanupCloudinaryUploads(cloudinaryUploads),
+    idReporte ? ReporteModel.remove(idReporte) : Promise.resolve(),
+  ]);
+
+  results
+    .filter((result) => result.status === 'rejected')
+    .forEach((result) => {
+      console.error('[reportes] rollback parcial fallido:', result.reason?.message || result.reason);
+    });
 };
 
 const shouldDeleteFromCloudinary = (evidencia) => (
@@ -422,46 +436,49 @@ export const createReporte = async (req, res, next) => {
       scoreEvidencias.evidencias.map((item, index) => [index, item.hash_sha256])
     );
 
-    const idReporte = await ReporteModel.create({
-      id_usuario:       req.user.sub,
-      tipo_contaminacion: tipoContaminacion,
-      subcategoria:        subcategoria?.trim() || null,
-      nivel_severidad:    nivelSeveridad,
-      titulo:             titulo.trim(),
-      descripcion:        descripcion?.trim() || null,
-      direccion:          direccion.trim(),
-      municipio:          municipio?.trim() || null,
-      departamento:       departamento?.trim() || null,
-      latitud:            parsedLatitud.value,
-      longitud:           parsedLongitud.value,
-      confianza_evidencia: scoreEvidencias.score,
-    });
-
-    let reporte = await ReporteModel.findById(idReporte);
-
-    let iaAnalysis;
-    if (iaPayload.procesado) {
-      iaAnalysis = iaPayload.analysis;
-    } else {
-      iaAnalysis = analyzeReporte({
-        ...reporte,
-        tipo_contaminacion: tipoContaminacion,
-        nivel_severidad: nivelSeveridad,
-        titulo: titulo.trim(),
-        descripcion: descripcion?.trim() || null,
-        direccion: direccion.trim(),
-        municipio: municipio?.trim() || null,
-        departamento: departamento?.trim() || null,
-        latitud: parsedLatitud.value,
-        longitud: parsedLongitud.value,
-      });
-    }
-
-    await ReporteModel.updateIaAnalysis(idReporte, iaAnalysis);
-    reporte = await ReporteModel.findById(idReporte);
-
     const cloudinaryUploads = [];
+    let idReporte = null;
+    let reporte = null;
+
     try {
+      idReporte = await ReporteModel.create({
+        id_usuario:       req.user.sub,
+        tipo_contaminacion: tipoContaminacion,
+        subcategoria:        subcategoria?.trim() || null,
+        nivel_severidad:    nivelSeveridad,
+        titulo:             titulo.trim(),
+        descripcion:        descripcion?.trim() || null,
+        direccion:          direccion.trim(),
+        municipio:          municipio?.trim() || null,
+        departamento:       departamento?.trim() || null,
+        latitud:            parsedLatitud.value,
+        longitud:           parsedLongitud.value,
+        confianza_evidencia: scoreEvidencias.score,
+      });
+
+      reporte = await ReporteModel.findById(idReporte);
+
+      let iaAnalysis;
+      if (iaPayload.procesado) {
+        iaAnalysis = iaPayload.analysis;
+      } else {
+        iaAnalysis = analyzeReporte({
+          ...reporte,
+          tipo_contaminacion: tipoContaminacion,
+          nivel_severidad: nivelSeveridad,
+          titulo: titulo.trim(),
+          descripcion: descripcion?.trim() || null,
+          direccion: direccion.trim(),
+          municipio: municipio?.trim() || null,
+          departamento: departamento?.trim() || null,
+          latitud: parsedLatitud.value,
+          longitud: parsedLongitud.value,
+        });
+      }
+
+      await ReporteModel.updateIaAnalysis(idReporte, iaAnalysis);
+      reporte = await ReporteModel.findById(idReporte);
+
       for (const [index, file] of uploadedFiles.entries()) {
         const { uploadResult, evidencia } = await uploadEvidenceToCloudinary(file, {
           idReporte,
@@ -474,7 +491,7 @@ export const createReporte = async (req, res, next) => {
         await EvidenciaModel.create(evidencia);
       }
     } catch (error) {
-      await cleanupCloudinaryUploads(cloudinaryUploads);
+      await rollbackCreatedReporte(idReporte, cloudinaryUploads);
       throw error;
     }
 
@@ -1144,6 +1161,11 @@ export const addEvidenciaReporte = async (req, res, next) => {
 
     if (!req.file) {
       return errorResponse(res, 'Archivo de evidencia requerido.', 400);
+    }
+
+    const contentError = validateUploadedFilesContent([req.file]);
+    if (contentError) {
+      return errorResponse(res, contentError, 400);
     }
 
     const scoreEvidencia = await calcularScoreEvidencias([req.file], reporte.nivel_severidad);

--- a/src/controllers/reporte.controller.js
+++ b/src/controllers/reporte.controller.js
@@ -63,6 +63,7 @@ const TRANSICIONES_ESTADO_REPORTE = {
   resuelto: [],
   rechazado: [],
 };
+const TIPOS_ASIGNACION_PERMITIDOS = ['principal', 'apoyo'];
 const PRIORIDADES_ASIGNACION_PERMITIDAS = ['baja', 'media', 'alta', 'critica'];
 
 const canTransitionReporteEstado = (estadoActual, estadoNuevo) => {
@@ -776,7 +777,16 @@ export const asignarEntidadReporte = async (req, res, next) => {
   try {
     const id = Number(req.params.id);
     const { id_entidad, codigo_entidad, comentario = null } = req.body ?? {};
+    const tipoAsignacion = normalizeEnumValue(req.body?.tipo_asignacion) || 'principal';
     const prioridad = normalizeEnumValue(req.body?.prioridad) || 'media';
+
+    if (!TIPOS_ASIGNACION_PERMITIDOS.includes(tipoAsignacion)) {
+      return errorResponse(
+        res,
+        buildAllowedValuesMessage('El tipo_asignacion', TIPOS_ASIGNACION_PERMITIDOS),
+        400
+      );
+    }
 
     if (!PRIORIDADES_ASIGNACION_PERMITIDAS.includes(prioridad)) {
       return errorResponse(
@@ -805,7 +815,7 @@ export const asignarEntidadReporte = async (req, res, next) => {
     await ReporteEntidadModel.createAssignment({
       id_reporte: id,
       id_entidad: entidad.id_entidad,
-      tipo_asignacion: 'principal',
+      tipo_asignacion: tipoAsignacion,
       prioridad,
       estado_atencion: 'pendiente',
       comentario: typeof comentario === 'string' ? comentario.trim() || null : null,
@@ -820,7 +830,7 @@ export const asignarEntidadReporte = async (req, res, next) => {
       ...asignacion,
       id_reporte: id,
       id_entidad: entidad.id_entidad,
-      tipo_asignacion: asignacion?.tipo_asignacion ?? 'principal',
+      tipo_asignacion: asignacion?.tipo_asignacion ?? tipoAsignacion,
       prioridad: asignacion?.prioridad ?? prioridad,
       entidad,
     };

--- a/src/services/facebook-oauth.service.js
+++ b/src/services/facebook-oauth.service.js
@@ -1,4 +1,5 @@
 import { getFacebookConfig } from '../config/facebook.config.js';
+import { createOAuthState } from './oauth-state.service.js';
 
 const isDevelopment = () => process.env.NODE_ENV === 'development';
 
@@ -63,6 +64,7 @@ export const generateFacebookAuthUrl = () => {
       redirect_uri: config.callbackUrl,
       scope: 'email,public_profile',
       response_type: 'code',
+      state: createOAuthState('facebook'),
     });
 
     return {

--- a/src/services/google-oauth.service.js
+++ b/src/services/google-oauth.service.js
@@ -1,5 +1,6 @@
 import { OAuth2Client } from 'google-auth-library';
 import { getGoogleAuthUrlConfig, getGoogleConfig } from '../config/google.config.js';
+import { createOAuthState } from './oauth-state.service.js';
 
 let oauthClient = null;
 
@@ -110,6 +111,7 @@ export const generateAuthUrl = () => {
       access_type: 'offline',
       scope: scopes,
       prompt: 'consent',
+      state: createOAuthState('google'),
     });
 
     return {

--- a/src/services/oauth-state.service.js
+++ b/src/services/oauth-state.service.js
@@ -1,0 +1,58 @@
+import crypto from 'crypto';
+
+const DEFAULT_TTL_MS = 5 * 60 * 1000;
+const oauthStates = new Map();
+
+const getTtlMs = () => {
+  const value = Number(process.env.OAUTH_STATE_TTL_SECONDS);
+  return Number.isFinite(value) && value > 0 ? value * 1000 : DEFAULT_TTL_MS;
+};
+
+const deleteExpiredStates = () => {
+  const now = Date.now();
+
+  for (const [state, entry] of oauthStates.entries()) {
+    if (entry.expiresAt <= now) {
+      oauthStates.delete(state);
+    }
+  }
+};
+
+export const createOAuthState = (provider) => {
+  deleteExpiredStates();
+
+  const state = crypto.randomBytes(32).toString('base64url');
+  oauthStates.set(state, {
+    provider,
+    expiresAt: Date.now() + getTtlMs(),
+  });
+
+  return state;
+};
+
+export const consumeOAuthState = (state, provider) => {
+  if (typeof state !== 'string' || !state) {
+    return { valid: false, reason: 'missing' };
+  }
+
+  const entry = oauthStates.get(state);
+  oauthStates.delete(state);
+
+  if (!entry) {
+    return { valid: false, reason: 'invalid' };
+  }
+
+  if (entry.expiresAt <= Date.now()) {
+    return { valid: false, reason: 'expired' };
+  }
+
+  if (entry.provider !== provider) {
+    return { valid: false, reason: 'invalid' };
+  }
+
+  return { valid: true };
+};
+
+export const clearOAuthStates = () => {
+  oauthStates.clear();
+};

--- a/tests/unit/alertas-entidad.test.js
+++ b/tests/unit/alertas-entidad.test.js
@@ -144,7 +144,7 @@ test('la tabla y el modelo evitan duplicados por asignacion y tipo de alerta', a
   assert.match(model, /LAST_INSERT_ID\(id_alerta_entidad\)/);
 });
 
-test('crea alerta para entidad principal y secundaria cuando ambas asignaciones aplican', async (t) => {
+test('crea alerta para entidad principal y de apoyo cuando ambas asignaciones aplican', async (t) => {
   const created = [];
   t.mock.method(AlertaEntidadModel, 'create', async (data) => {
     created.push(data);

--- a/tests/unit/oauth-callback-state.test.js
+++ b/tests/unit/oauth-callback-state.test.js
@@ -1,0 +1,145 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  facebookCallback,
+  googleCallback,
+  validateOAuthCallbackState,
+} from '../../src/controllers/auth.controller.js';
+import {
+  clearOAuthStates,
+  createOAuthState,
+} from '../../src/services/oauth-state.service.js';
+
+const createResponse = () => ({
+  statusCode: null,
+  body: null,
+  headers: {},
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(body) {
+    this.body = body;
+    return this;
+  },
+  set(headers) {
+    this.headers = { ...this.headers, ...headers };
+    return this;
+  },
+  redirect(statusCode, url) {
+    this.statusCode = statusCode;
+    this.redirectUrl = url;
+    return this;
+  },
+});
+
+test.afterEach(() => {
+  clearOAuthStates();
+  delete process.env.OAUTH_STATE_TTL_SECONDS;
+});
+
+test('callback Google con state valido supera la validacion CSRF', async (t) => {
+  const state = createOAuthState('google');
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await googleCallback({ query: { state } }, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.message, 'Código de autorización de Google requerido.');
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('callback Google sin state se rechaza', async (t) => {
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await googleCallback({ query: { code: 'google-code' } }, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.message, 'State OAuth requerido.');
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('callback Google con state invalido se rechaza', async (t) => {
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await googleCallback({ query: { code: 'google-code', state: 'invalid-state' } }, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.message, 'State OAuth invalido.');
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('callback Google con state expirado se rechaza', async (t) => {
+  process.env.OAUTH_STATE_TTL_SECONDS = '0.001';
+  const state = createOAuthState('google');
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await googleCallback({ query: { code: 'google-code', state } }, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.message, 'State OAuth expirado.');
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('callback Facebook con state valido supera la validacion CSRF', async (t) => {
+  const state = createOAuthState('facebook');
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await facebookCallback({ query: { state } }, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.message, 'Codigo de autorizacion de Facebook requerido.');
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('callback Facebook sin state se rechaza', async (t) => {
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await facebookCallback({ query: { code: 'facebook-code' } }, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.message, 'State OAuth requerido.');
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('callback Facebook con state invalido se rechaza', async (t) => {
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await facebookCallback({ query: { code: 'facebook-code', state: 'invalid-state' } }, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.message, 'State OAuth invalido.');
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('callback Facebook con state expirado se rechaza', async (t) => {
+  process.env.OAUTH_STATE_TTL_SECONDS = '0.001';
+  const state = createOAuthState('facebook');
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await facebookCallback({ query: { code: 'facebook-code', state } }, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.message, 'State OAuth expirado.');
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('state ya consumido no puede reutilizarse en callbacks', () => {
+  const state = createOAuthState('google');
+
+  assert.deepEqual(validateOAuthCallbackState(state, 'google'), { valid: true });
+  assert.deepEqual(validateOAuthCallbackState(state, 'google'), {
+    valid: false,
+    message: 'State OAuth invalido.',
+  });
+});

--- a/tests/unit/oauth-state.test.js
+++ b/tests/unit/oauth-state.test.js
@@ -1,0 +1,76 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  clearOAuthStates,
+  consumeOAuthState,
+  createOAuthState,
+} from '../../src/services/oauth-state.service.js';
+import { generateAuthUrl } from '../../src/services/google-oauth.service.js';
+import { generateFacebookAuthUrl } from '../../src/services/facebook-oauth.service.js';
+
+test.beforeEach(() => {
+  process.env.GOOGLE_CLIENT_ID = 'google-client-id.apps.googleusercontent.com';
+  process.env.GOOGLE_CALLBACK_URL = 'http://localhost:3000/auth/google/callback';
+  process.env.FACEBOOK_APP_ID = 'facebook-app-id';
+  process.env.FACEBOOK_APP_SECRET = 'facebook-app-secret';
+  process.env.FACEBOOK_CALLBACK_URL = 'http://localhost:3000/auth/facebook/callback';
+  process.env.FACEBOOK_GRAPH_API_VERSION = 'v20.0';
+});
+
+test.afterEach(() => {
+  clearOAuthStates();
+  delete process.env.OAUTH_STATE_TTL_SECONDS;
+});
+
+test('state OAuth temporal se consume una sola vez', () => {
+  const state = createOAuthState('google');
+
+  assert.equal(typeof state, 'string');
+  assert.ok(state.length >= 32);
+  assert.deepEqual(consumeOAuthState(state, 'google'), { valid: true });
+  assert.deepEqual(consumeOAuthState(state, 'google'), { valid: false, reason: 'invalid' });
+});
+
+test('state OAuth expirado se rechaza con razon explicita', async () => {
+  process.env.OAUTH_STATE_TTL_SECONDS = '0.001';
+
+  const state = createOAuthState('google');
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  assert.deepEqual(consumeOAuthState(state, 'google'), { valid: false, reason: 'expired' });
+});
+
+test('state OAuth no se puede consumir con otro proveedor', () => {
+  const state = createOAuthState('google');
+
+  assert.deepEqual(consumeOAuthState(state, 'facebook'), { valid: false, reason: 'invalid' });
+  assert.deepEqual(consumeOAuthState(state, 'google'), { valid: false, reason: 'invalid' });
+});
+
+test('URL OAuth de Google incluye state consumible', () => {
+  const result = generateAuthUrl();
+
+  assert.equal(result.success, true);
+  const url = new URL(result.authUrl);
+  const state = url.searchParams.get('state');
+
+  assert.equal(url.searchParams.get('client_id'), process.env.GOOGLE_CLIENT_ID);
+  assert.equal(url.searchParams.get('redirect_uri'), process.env.GOOGLE_CALLBACK_URL);
+  assert.equal(typeof state, 'string');
+  assert.ok(state.length >= 32);
+  assert.deepEqual(consumeOAuthState(state, 'google'), { valid: true });
+});
+
+test('URL OAuth de Facebook incluye state consumible', () => {
+  const result = generateFacebookAuthUrl();
+
+  assert.equal(result.success, true);
+  const url = new URL(result.authUrl);
+  const state = url.searchParams.get('state');
+
+  assert.equal(url.searchParams.get('client_id'), process.env.FACEBOOK_APP_ID);
+  assert.equal(url.searchParams.get('redirect_uri'), process.env.FACEBOOK_CALLBACK_URL);
+  assert.equal(typeof state, 'string');
+  assert.ok(state.length >= 32);
+  assert.deepEqual(consumeOAuthState(state, 'facebook'), { valid: true });
+});

--- a/tests/unit/reporte-asignacion-manual.test.js
+++ b/tests/unit/reporte-asignacion-manual.test.js
@@ -41,16 +41,19 @@ const entidadBomberos = {
   activo: 1,
 };
 
-const createAsignacion = (prioridad = 'media') => ({
+const createAsignacion = ({ prioridad = 'media', tipo_asignacion = 'principal' } = {}) => ({
   id_reporte_entidad: 7,
   id_reporte: 10,
   id_entidad: 1,
-  tipo_asignacion: 'principal',
+  tipo_asignacion,
   prioridad,
   estado_atencion: 'pendiente',
 });
 
-const mockAsignacionManualBase = (t, { prioridad = 'media' } = {}) => {
+const mockAsignacionManualBase = (t, {
+  prioridad = 'media',
+  tipo_asignacion = 'principal',
+} = {}) => {
   let assignmentPayload;
 
   t.mock.method(ReporteModel, 'findById', async () => reporteBase);
@@ -60,7 +63,7 @@ const mockAsignacionManualBase = (t, { prioridad = 'media' } = {}) => {
     return 7;
   });
   t.mock.method(ReporteEntidadModel, 'findOneByReporteAndEntidad', async () => (
-    createAsignacion(prioridad)
+    createAsignacion({ prioridad, tipo_asignacion })
   ));
 
   return {
@@ -97,6 +100,56 @@ test('asignarEntidadReporte asigna manualmente a una entidad activa y permitida'
     estado_atencion: 'pendiente',
     comentario: 'Revisar incendio',
   });
+});
+
+test('asignarEntidadReporte usa tipo_asignacion principal enviado en el body', async (t) => {
+  const { getAssignmentPayload } = mockAsignacionManualBase(t, {
+    tipo_asignacion: 'principal',
+  });
+  t.mock.method(AlertaEntidadModel, 'create', async () => {
+    assert.fail('No debe crear alerta persistente para prioridad media.');
+  });
+
+  const req = {
+    params: { id: '10' },
+    body: {
+      codigo_entidad: 'bomberos',
+      tipo_asignacion: 'principal',
+    },
+    user: { sub: 1, rol: 'admin' },
+  };
+  const res = createRes();
+
+  await asignarEntidadReporte(req, res, assert.fail);
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(getAssignmentPayload().tipo_asignacion, 'principal');
+  assert.equal(res.body.data.asignacion.tipo_asignacion, 'principal');
+});
+
+test('asignarEntidadReporte usa tipo_asignacion apoyo enviado en el body', async (t) => {
+  const { getAssignmentPayload } = mockAsignacionManualBase(t, {
+    tipo_asignacion: 'apoyo',
+  });
+  t.mock.method(AlertaEntidadModel, 'create', async () => {
+    assert.fail('No debe crear alerta persistente para prioridad media.');
+  });
+
+  const req = {
+    params: { id: '10' },
+    body: {
+      codigo_entidad: 'bomberos',
+      tipo_asignacion: 'apoyo',
+    },
+    user: { sub: 1, rol: 'admin' },
+  };
+  const res = createRes();
+
+  await asignarEntidadReporte(req, res, assert.fail);
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(getAssignmentPayload().tipo_asignacion, 'apoyo');
+  assert.equal(res.body.data.asignacion.tipo_asignacion, 'apoyo');
 });
 
 test('asignarEntidadReporte con prioridad critica genera alerta y evento socket', async (t) => {
@@ -205,6 +258,31 @@ test('asignarEntidadReporte rechaza prioridad invalida', async (t) => {
   assert.equal(res.statusCode, 400);
   assert.equal(res.body.status, 'error');
   assert.equal(res.body.message, 'La prioridad debe ser uno de: baja, media, alta, critica.');
+});
+
+test('asignarEntidadReporte rechaza tipo_asignacion invalido', async (t) => {
+  t.mock.method(ReporteModel, 'findById', async () => {
+    assert.fail('No debe consultar reporte si tipo_asignacion es invalido.');
+  });
+  t.mock.method(ReporteEntidadModel, 'createAssignment', async () => {
+    assert.fail('No debe crear asignacion con tipo_asignacion invalido.');
+  });
+
+  const req = {
+    params: { id: '10' },
+    body: {
+      codigo_entidad: 'bomberos',
+      tipo_asignacion: 'secundaria',
+    },
+    user: { sub: 1, rol: 'admin' },
+  };
+  const res = createRes();
+
+  await asignarEntidadReporte(req, res, assert.fail);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.status, 'error');
+  assert.equal(res.body.message, 'El tipo_asignacion debe ser uno de: principal, apoyo.');
 });
 
 test('asignarEntidadReporte rechaza entidades inactivas o fuera de alcance', async (t) => {

--- a/tests/unit/reporte-evidencias-gestion.test.js
+++ b/tests/unit/reporte-evidencias-gestion.test.js
@@ -1,12 +1,12 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import {
   addEvidenciaReporte,
   deleteEvidenciaReporte,
   listEvidenciasReporte,
 } from '../../src/controllers/reporte.controller.js';
 import { EvidenciaModel } from '../../src/models/evidencia.model.js';
-const FAKE_IMAGE_SHA256 = 'a8eb701c6f567b08661c2604364dd595455b811d2759d2029b465935b561c86b';
 import { ReporteModel } from '../../src/models/reporte.model.js';
 import {
   resetCloudinaryClientForTest,
@@ -31,6 +31,13 @@ const reporte = {
   id_usuario: 7,
   estado: 'pendiente',
 };
+
+const VALID_PNG_BUFFER = Buffer.concat([
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+  Buffer.from('fake-image'),
+]);
+
+const FAKE_IMAGE_SHA256 = createHash('sha256').update(VALID_PNG_BUFFER).digest('hex');
 
 test.afterEach(() => {
   resetCloudinaryClientForTest();
@@ -95,7 +102,7 @@ test('addEvidenciaReporte agrega evidencia al reporte como moderador', async (t)
       filename: 'evidencia.png',
       originalname: 'foto.png',
       size: 1024,
-      buffer: Buffer.from('fake-image'),
+      buffer: VALID_PNG_BUFFER,
     },
   };
   const res = createResponse();
@@ -119,6 +126,37 @@ test('addEvidenciaReporte agrega evidencia al reporte como moderador', async (t)
   assert.equal(evidencia.cloudinary_resource_type, 'image');
   assert.equal(evidencia.cloudinary_metadata.bytes, 1024);
   assert.equal(evidencia.orden, 0);
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('addEvidenciaReporte rechaza archivo con contenido falso', async (t) => {
+  t.mock.method(ReporteModel, 'findById', async () => reporte);
+  t.mock.method(EvidenciaModel, 'create', async () => {
+    throw new Error('No debe guardar evidencia con contenido falso');
+  });
+
+  const req = {
+    params: { id: '15' },
+    user: { sub: 9, rol: 'moderador' },
+    file: {
+      mimetype: 'image/png',
+      filename: 'falso.png',
+      originalname: 'falso.png',
+      size: 1024,
+      buffer: Buffer.from('%PDF-1.7 contenido falso'),
+    },
+  };
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await addEvidenciaReporte(req, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(
+    res.body.message,
+    'El contenido del archivo "falso.png" no coincide con el tipo declarado o esta corrupto.'
+  );
+  assert.equal(EvidenciaModel.create.mock.callCount(), 0);
   assert.equal(next.mock.callCount(), 0);
 });
 

--- a/tests/unit/reporte-upload-evidencias.test.js
+++ b/tests/unit/reporte-upload-evidencias.test.js
@@ -1,13 +1,16 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import { fileFilter } from '../../middlewares/upload.middleware.js';
 import { createReporte } from '../../src/controllers/reporte.controller.js';
 import { CategoriaRiesgoModel } from '../../src/models/categoria-riesgo.model.js';
 import { EvidenciaModel } from '../../src/models/evidencia.model.js';
 import { ReporteModel } from '../../src/models/reporte.model.js';
 import { AsignacionEntidadesService } from '../../src/services/asignacion-entidades.service.js';
-
-const FAKE_FILE_1_SHA256 = 'c30851811a9b8c08b5c9b43c0d0ad77cc30f77188bfdc1bf97599c05e957d370';
+import {
+  resetCloudinaryClientForTest,
+  setCloudinaryClientForTest,
+} from '../../src/services/cloudinary.service.js';
 
 const createResponse = () => ({
   statusCode: null,
@@ -22,12 +25,60 @@ const createResponse = () => ({
   },
 });
 
+const sha256 = (buffer) => createHash('sha256').update(buffer).digest('hex');
+
+const createValidBuffer = (index, mimetype = 'image/png') => {
+  const payload = Buffer.from(`fake-file-${index}`);
+
+  if (mimetype === 'image/jpeg' || mimetype === 'image/jpg') {
+    return Buffer.concat([Buffer.from([0xff, 0xd8, 0xff, 0xe0]), payload]);
+  }
+
+  if (mimetype === 'image/webp') {
+    return Buffer.concat([
+      Buffer.from('RIFF', 'ascii'),
+      Buffer.from([0x10, 0x00, 0x00, 0x00]),
+      Buffer.from('WEBPVP8 ', 'ascii'),
+      payload,
+    ]);
+  }
+
+  if (mimetype === 'image/gif') {
+    return Buffer.concat([Buffer.from('GIF89a', 'ascii'), payload]);
+  }
+
+  if (mimetype === 'video/mp4') {
+    return Buffer.concat([
+      Buffer.from([0x00, 0x00, 0x00, 0x18]),
+      Buffer.from('ftypisom', 'ascii'),
+      Buffer.from([0x00, 0x00, 0x00, 0x00]),
+      Buffer.from('isomiso2mp41', 'ascii'),
+      payload,
+    ]);
+  }
+
+  if (mimetype === 'video/quicktime') {
+    return Buffer.concat([
+      Buffer.from([0x00, 0x00, 0x00, 0x14]),
+      Buffer.from('ftypqt  ', 'ascii'),
+      Buffer.from([0x00, 0x00, 0x00, 0x00]),
+      Buffer.from('qt  ', 'ascii'),
+      payload,
+    ]);
+  }
+
+  return Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    payload,
+  ]);
+};
+
 const createFile = (index, mimetype = 'image/png') => ({
   mimetype,
   filename: `evidencia-${index}.${mimetype.startsWith('video/') ? 'mp4' : 'png'}`,
   originalname: `original-${index}.${mimetype.startsWith('video/') ? 'mp4' : 'png'}`,
   size: 1024 + index,
-  buffer: Buffer.from(`fake-file-${index}`),
+  buffer: createValidBuffer(index, mimetype),
 });
 
 const createRequest = (files = [], bodyOverrides = {}) => ({
@@ -64,6 +115,10 @@ const mockSuccessfulCreate = (t) => {
   t.mock.method(AsignacionEntidadesService, 'asignarEntidadesAReporte', async () => []);
 };
 
+test.afterEach(() => {
+  resetCloudinaryClientForTest();
+});
+
 test('createReporte guarda multiples imagenes con metadata y orden', async (t) => {
   mockSuccessfulCreate(t);
 
@@ -83,7 +138,7 @@ test('createReporte guarda multiples imagenes con metadata y orden', async (t) =
   assert.equal(evidencia.nombre_original, 'original-1.png');
   assert.equal(evidencia.mime_type, 'image/png');
   assert.equal(evidencia.tamano_bytes, 1025);
-  assert.equal(evidencia.hash_sha256, FAKE_FILE_1_SHA256);
+  assert.equal(evidencia.hash_sha256, sha256(createFile(1).buffer));
   assert.equal(evidencia.storage_provider, 'cloudinary');
   assert.match(evidencia.cloudinary_public_id, /^green-alert\/test\//);
   assert.match(evidencia.cloudinary_asset_id, /^asset-/);
@@ -156,6 +211,37 @@ test('createReporte permite un video por reporte', async (t) => {
   assert.equal(EvidenciaModel.create.mock.calls[1].arguments[0].cloudinary_resource_type, 'video');
 });
 
+test('createReporte rechaza archivo con MIME valido pero contenido invalido', async (t) => {
+  t.mock.method(CategoriaRiesgoModel, 'esValido', async () => {
+    throw new Error('No debe validar categoria con contenido invalido');
+  });
+  t.mock.method(ReporteModel, 'create', async () => {
+    throw new Error('No debe insertar reporte con contenido invalido');
+  });
+  t.mock.method(EvidenciaModel, 'create', async () => {
+    throw new Error('No debe insertar evidencia con contenido invalido');
+  });
+
+  const req = createRequest([{
+    ...createFile(0),
+    originalname: 'falso.png',
+    buffer: Buffer.from('%PDF-1.7 contenido falso'),
+  }]);
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await createReporte(req, res, next);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(
+    res.body.message,
+    'El contenido del archivo "falso.png" no coincide con el tipo declarado o esta corrupto.'
+  );
+  assert.equal(ReporteModel.create.mock.callCount(), 0);
+  assert.equal(EvidenciaModel.create.mock.callCount(), 0);
+  assert.equal(next.mock.callCount(), 0);
+});
+
 test('createReporte rechaza dos videos antes de crear reporte', async (t) => {
   t.mock.method(CategoriaRiesgoModel, 'esValido', async () => {
     throw new Error('No debe validar categoria con dos videos');
@@ -199,4 +285,81 @@ test('fileFilter rechaza mime invalido como error 400', () => {
   assert.equal(callbackError.statusCode, 400);
   assert.equal(callbackError.message, 'Tipo de archivo no permitido. Solo imagenes y videos.');
   assert.equal(accepted, undefined);
+});
+
+test('createReporte revierte reporte si Cloudinary falla al subir evidencia', async (t) => {
+  mockSuccessfulCreate(t);
+  t.mock.method(ReporteModel, 'remove', async () => true);
+
+  setCloudinaryClientForTest({
+    uploader: {
+      upload_stream(_options, callback) {
+        return {
+          end() {
+            callback(new Error('cloudinary unavailable'));
+          },
+        };
+      },
+    },
+  });
+
+  const req = createRequest([createFile(0)]);
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await createReporte(req, res, next);
+
+  assert.equal(res.statusCode, null);
+  assert.equal(EvidenciaModel.create.mock.callCount(), 0);
+  assert.equal(ReporteModel.remove.mock.callCount(), 1);
+  assert.equal(ReporteModel.remove.mock.calls[0].arguments[0], 15);
+  assert.equal(next.mock.callCount(), 1);
+  assert.equal(next.mock.calls[0].arguments[0].message, 'cloudinary unavailable');
+});
+
+test('createReporte limpia Cloudinary y revierte reporte si falla guardado de evidencia', async (t) => {
+  mockSuccessfulCreate(t);
+  t.mock.method(ReporteModel, 'remove', async () => true);
+  t.mock.method(EvidenciaModel, 'create', async () => {
+    throw new Error('db evidence unavailable');
+  });
+
+  let destroyedPublicId = null;
+  let destroyOptions = null;
+  setCloudinaryClientForTest({
+    uploader: {
+      upload_stream(options, callback) {
+        return {
+          end() {
+            callback(null, {
+              asset_id: 'asset-mock',
+              public_id: 'green-alert/reportes/mock',
+              secure_url: 'https://mocked.cloudinary/image/upload/green-alert/reportes/mock',
+              resource_type: options.resource_type,
+              bytes: 1024,
+            });
+          },
+        };
+      },
+      destroy(publicId, options) {
+        destroyedPublicId = publicId;
+        destroyOptions = options;
+        return Promise.resolve({ result: 'ok' });
+      },
+    },
+  });
+
+  const req = createRequest([createFile(0)]);
+  const res = createResponse();
+  const next = t.mock.fn();
+
+  await createReporte(req, res, next);
+
+  assert.equal(res.statusCode, null);
+  assert.equal(ReporteModel.remove.mock.callCount(), 1);
+  assert.equal(ReporteModel.remove.mock.calls[0].arguments[0], 15);
+  assert.equal(destroyedPublicId, 'green-alert/reportes/mock');
+  assert.deepEqual(destroyOptions, { resource_type: 'image', invalidate: true });
+  assert.equal(next.mock.callCount(), 1);
+  assert.equal(next.mock.calls[0].arguments[0].message, 'db evidence unavailable');
 });

--- a/tests/unit/socket-notificaciones.test.js
+++ b/tests/unit/socket-notificaciones.test.js
@@ -121,7 +121,7 @@ test('emision critica a Bomberos notifica solo la sala de Bomberos', () => {
   assert.equal(emissions[0].event, SOCKET_EVENTS.REPORTE_CRITICO_ASIGNADO);
 });
 
-test('reporte critico con entidad principal y secundaria notifica ambas salas', () => {
+test('reporte critico con entidad principal y de apoyo notifica ambas salas', () => {
   const { io, emissions } = createMockIo();
   setSocketServerForTests(io);
 

--- a/tests/unit/upload-config.test.js
+++ b/tests/unit/upload-config.test.js
@@ -36,6 +36,23 @@ const listen = (app) => new Promise((resolve) => {
   const server = app.listen(0, () => resolve(server));
 });
 
+const PNG_BYTES = Buffer.concat([
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+  Buffer.from('fake-image'),
+]);
+
+const WEBP_BYTES = Buffer.concat([
+  Buffer.from('RIFF', 'ascii'),
+  Buffer.from([0x10, 0x00, 0x00, 0x00]),
+  Buffer.from('WEBPVP8 ', 'ascii'),
+  Buffer.from('fake-webp'),
+]);
+
+const JPEG_BYTES = Buffer.concat([
+  Buffer.from([0xff, 0xd8, 0xff, 0xe0]),
+  Buffer.from('fake-jpeg'),
+]);
+
 test('upload.single guarda archivo en memoria y conserva filename compatible', async () => {
   const app = express();
   app.post('/upload', upload.single('file'), (req, res) => {
@@ -51,7 +68,7 @@ test('upload.single guarda archivo en memoria y conserva filename compatible', a
   try {
     const port = server.address().port;
     const formData = new FormData();
-    formData.append('file', new Blob(['fake-image'], { type: 'image/png' }), 'evidencia.png');
+    formData.append('file', new Blob([PNG_BYTES], { type: 'image/png' }), 'evidencia.png');
 
     const response = await fetch(`http://127.0.0.1:${port}/upload`, {
       method: 'POST',
@@ -64,6 +81,37 @@ test('upload.single guarda archivo en memoria y conserva filename compatible', a
     assert.match(body.filename, /^[0-9a-f-]{36}\.png$/);
     assert.equal(body.originalname, 'evidencia.png');
     assert.equal(body.path, null);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test('upload.single rechaza MIME valido con contenido falso', async () => {
+  const app = express();
+  app.post('/upload', upload.single('file'), (_req, res) => {
+    res.json({ ok: true });
+  });
+  app.use((error, _req, res, _next) => {
+    res.status(error.statusCode || 500).json({ message: error.message });
+  });
+
+  const server = await listen(app);
+  try {
+    const port = server.address().port;
+    const formData = new FormData();
+    formData.append('file', new Blob(['%PDF-1.7 contenido falso'], { type: 'image/png' }), 'falso.png');
+
+    const response = await fetch(`http://127.0.0.1:${port}/upload`, {
+      method: 'POST',
+      body: formData,
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(
+      body.message,
+      'El contenido del archivo "falso.png" no coincide con el tipo declarado o esta corrupto.'
+    );
   } finally {
     await new Promise((resolve) => server.close(resolve));
   }
@@ -90,9 +138,9 @@ test('uploadMultiple mantiene campos file y files', async () => {
   try {
     const port = server.address().port;
     const formData = new FormData();
-    formData.append('file', new Blob(['main'], { type: 'image/png' }), 'principal.png');
-    formData.append('files', new Blob(['one'], { type: 'image/webp' }), 'uno.webp');
-    formData.append('files', new Blob(['two'], { type: 'image/jpeg' }), 'dos.jpg');
+    formData.append('file', new Blob([PNG_BYTES], { type: 'image/png' }), 'principal.png');
+    formData.append('files', new Blob([WEBP_BYTES], { type: 'image/webp' }), 'uno.webp');
+    formData.append('files', new Blob([JPEG_BYTES], { type: 'image/jpeg' }), 'dos.jpg');
 
     const response = await fetch(`http://127.0.0.1:${port}/upload-multiple`, {
       method: 'POST',


### PR DESCRIPTION
**Descripción:** 
Este PR refuerza la seguridad de los flujos OAuth de Google y Facebook en el backend de Green Alert mediante la generación segura de state con crypto.randomBytes(32), almacenamiento temporal en memoria con expiración y consumo de un solo uso, inclusión de state en las URLs OAuth y validación estricta en los callbacks antes de intercambiar el code. También agrega pruebas unitarias para URLs OAuth, callbacks con state válido, ausente, inválido, expirado, reutilizado y asociado a proveedor incorrecto, confirmando que npm test, la validación de sintaxis equivalente al workflow y git diff --check pasan correctamente, por lo que el CI debería mantenerse en verde.

Close #280 
Close #281 

<img width="807" height="913" alt="image" src="https://github.com/user-attachments/assets/5444d1aa-49c9-4ee4-ae8d-3ef84eb07b42" />
